### PR TITLE
CI: Updates conda-envs to mostly from default channels

### DIFF
--- a/devtools/conda-envs/dask.yaml
+++ b/devtools/conda-envs/dask.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
-  - conda-forge
-  - psi4/label/dev
+  - psi4
 dependencies:
     # Dask testing environment
   - psi4=1.2
@@ -18,9 +17,9 @@ dependencies:
 
     # Testing
   - pytest
-  - codecov
   - pytest-cov
 
     # Pip depends
   - pip:
     - git+git://github.com/MolSSI/QCEngine#egg=qcengine
+    - codecov

--- a/devtools/conda-envs/fireworks.yaml
+++ b/devtools/conda-envs/fireworks.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
-  - conda-forge
-  - psi4/label/dev
+  - psi4
 dependencies:
     # Fireworks
   - psi4=1.2
@@ -16,10 +15,10 @@ dependencies:
 
     # Testing
   - pytest
-  - codecov
   - pytest-cov
 
     # Pip depends
   - pip:
     - git+git://github.com/MolSSI/QCEngine#egg=qcengine
     - fireworks
+    - codecov

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
-  - conda-forge
-  - psi4/label/dev
+  - psi4
 dependencies:
     # Computers
   - psi4=1.2
@@ -20,12 +19,12 @@ dependencies:
 
     # Testing
   - pytest
-  - codecov
   - pytest-cov
 
     # Pip depends
   - pip:
     - git+git://github.com/MolSSI/QCEngine#egg=qcengine
+    - codecov
 
       # Fireworks
     - fireworks

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -26,7 +26,6 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
     
-conda config --add channels conda-forge
 conda config --set always_yes yes --set changeps1 no
 conda update --q conda
 


### PR DESCRIPTION
## Description
As described, env builds should pull from either default or Psi channels. Fixes #23.

## Status
- [x] Ready to go