### PR TITLE
Covert String formatting from % to .format

### DIFF
--- a/qcfractal/cli/dqm_server.py
+++ b/qcfractal/cli/dqm_server.py
@@ -22,7 +22,7 @@ A command line interface to the qcfractal.
 #
 # queues = ["fireworks", "dask"]
 # if options.queue not in queues:
-#     raise KeyError("Queue of type %s not understood" % options.queue)
+#     raise KeyError("Queue of type {} not understood".format(options.queue))
 #
 # if options.queue == "dask":
 #     import distributed
@@ -48,7 +48,7 @@ A command line interface to the qcfractal.
 
 #         self.logger.addHandler(handler)
 
-#         self.logger.info("Logfile set to %s\n" % options.logfile)
+#         self.logger.info("Logfile set to {}\n".format(options.logfile))
 
 #         mongo_username = None
 #         mongo_password = None
@@ -116,7 +116,7 @@ A command line interface to the qcfractal.
 #         #loop.run_sync(lambda: post(data))
 
 #         self.loop = loop
-#         self.logger.info("QCDB Client successfully initialized at https://localhost:%d.\n" % options.port)
+#         self.logger.info("QCDB Client successfully initialized at https://localhost:{0:d}.\n".format(options.port))
 
 #     def start(self):
 

--- a/qcfractal/db_sockets/mongo_socket.py
+++ b/qcfractal/db_sockets/mongo_socket.py
@@ -107,12 +107,12 @@ class MongoSocket:
         new_collections = self.init_database()
         for k, v in new_collections.items():
             if v:
-                self.logger.info("New collection '%s' for database!" % k)
+                self.logger.info("New collection '{}' for database!".format(k))
 
 ### Mongo meta functions
 
     def __repr__(self):
-        return "<MongoSocket: address='%s:%d:%s'>" % (self._url, self._port, self._project_name)
+        return "<MongoSocket: address='{0:s}:{1:d}:{2:s}'>".format(str(self._url), self._port, str(self._project_name))
 
     def init_database(self):
         """
@@ -177,7 +177,7 @@ class MongoSocket:
                 if error["code"] == 11000:
                     meta["duplicates"].append(ukey)
                 else:
-                    meta["errors"].append({"id": str(x["op"]["_id"]), "code": x["code"], "key": ukey})
+                    meta["errors"].append({"id": str(error["op"]["_id"]), "code": error["code"], "key": ukey})
 
                 error_skips.append(error["index"])
 
@@ -767,7 +767,7 @@ class MongoSocket:
 
     def queue_get_by_id(self, ids, n=100):
 
-        return list(self._project["queue"].find({"_id": status}, limit=n))
+        return list(self._project["queue"].find({"_id": ids}, limit=n))
 
     def queue_mark_complete(self, ids):
         query = {"_id": {"$in": [ObjectId(x) for x in ids]}}

--- a/qcfractal/interface/constants.py
+++ b/qcfractal/interface/constants.py
@@ -85,4 +85,4 @@ def get_scale(name):
     elif name == "cm":
         return physconst["hartree2wavenumbers"]
     else:
-        raise KeyError("get_scale: Scale '%s' not recognized" % str(name))
+        raise KeyError("get_scale: Scale '{}' not recognized".format(str(name)))

--- a/qcfractal/interface/data/data_getters.py
+++ b/qcfractal/interface/data/data_getters.py
@@ -19,7 +19,7 @@ _data_folders = {x: os.path.join(_data_dir, x) for x in _folders}
 
 def _get_folder_path(folder):
     if folder not in _data_folders:
-        raise KeyError("Folder '%s' not recognized" % folder)
+        raise KeyError("Folder '{}' not recognized".format(folder))
 
     return _data_folders[folder]
 
@@ -47,7 +47,7 @@ def get_file(folder, *args):
     folder = _get_folder_path(folder)
     filename = os.path.join(folder, *args)
     if not os.path.isfile(filename):
-        raise OSError("Path '%s' not found." % filename)
+        raise OSError("Path '{}' not found.".format(filename))
 
     with open(filename, "r") as infile:
         ret = infile.read()

--- a/qcfractal/interface/database.py
+++ b/qcfractal/interface/database.py
@@ -95,7 +95,7 @@ class Database(object):
                 self.client = portal
 
             else:
-                raise TypeError("Database: client argument of unrecognized type '%s'" % type(portal))
+                raise TypeError("Database: client argument of unrecognized type '{}'".format(type(portal)))
 
             tmp_data = self.client.get_databases([self.data["db_index"]])
             if len(tmp_data) == 0:
@@ -397,10 +397,10 @@ class Database(object):
                 found.append(num)
 
         if len(found) == 0:
-            raise KeyError("Database:get_rxn: Reaction name '%s' not found." % name)
+            raise KeyError("Database:get_rxn: Reaction name '{}' not found.".format(name))
 
         if len(found) > 1:
-            raise KeyError("Database:get_rxn: Multiple reactions of name '%s' found. Database failure." % name)
+            raise KeyError("Database:get_rxn: Multiple reactions of name '{}' found. Database failure.".format(name))
 
         return self.data["reactions"][found[0]]
 
@@ -599,8 +599,8 @@ class Database(object):
         # Set name
         if name in self.get_index():
             raise KeyError(
-                "Database: Name '%s' already exists. Please either delete this entry or call the update function." %
-                name)
+                "Database: Name '{}' already exists. "
+                "Please either delete this entry or call the update function.".format(name))
 
         # Set stoich
         if isinstance(stoichiometry, dict):
@@ -616,17 +616,17 @@ class Database(object):
             rxn["stoichiometry"] = {}
             rxn["stoichiometry"]["default"] = self.parse_stoichiometry(stoichiometry)
         else:
-            raise TypeError("Database:add_rxn: Type of stoichiometry input was not recognized '%s'",
+            raise TypeError("Database:add_rxn: Type of stoichiometry input was not recognized:",
                             type(stoichiometry))
 
         # Set attributes
         if not isinstance(attributes, dict):
-            raise TypeError("Database:add_rxn: attributes must be a dictionary, not '%s'", type(attributes))
+            raise TypeError("Database:add_rxn: attributes must be a dictionary, not '{}'".format(type(attributes)))
 
         rxn["attributes"] = attributes
 
         if not isinstance(other_fields, dict):
-            raise TypeError("Database:add_rxn: other_fields must be a dictionary, not '%s'", type(attributes))
+            raise TypeError("Database:add_rxn: other_fields must be a dictionary, not '{}'".format(type(attributes)))
 
         for k, v in other_fields.items():
             rxn[k] = v
@@ -683,8 +683,9 @@ class Database(object):
         ret : dict
             A JSON representation of the Database
         """
-        if filename:
-            json.dumps(filename, self.data)
+        if filename is not None:
+            with open(filename, 'w') as open_file:
+                json.dump(self.data, open_file)
 
         else:
             return copy.deepcopy(self.data)

--- a/qcfractal/interface/hash_helpers.py
+++ b/qcfractal/interface/hash_helpers.py
@@ -21,6 +21,6 @@ def float_prep(array, around):
         if array == -0.0:
             array = 0.0
     else:
-        raise TypeError("Type '%s' not recognized" % type(array))
+        raise TypeError("Type '{}' not recognized".format(type(array).__name__))
 
     return array

--- a/qcfractal/interface/molecule.py
+++ b/qcfractal/interface/molecule.py
@@ -69,7 +69,7 @@ class Molecule:
             elif dtype == "json":
                 self._molecule_from_json(mol_str)
             else:
-                raise KeyError("Molecule: dtype of %s not recognized.")
+                raise KeyError("Molecule: dtype of {} not recognized.".format(dtype))
 
             self.geometry = hash_helpers.float_prep(self.geometry, GEOMETRY_NOISE)
             if kwargs.pop("orient", True):
@@ -78,7 +78,7 @@ class Molecule:
 
             # Cleanup un-initialized variables
             if len(self.real) == 0:
-                self.real = [True for x in range(self._geometry.shape[0])]
+                self.real = [True for _ in range(self._geometry.shape[0])]
 
             if not self.fragments:
                 natoms = self._geometry.shape[0]
@@ -93,7 +93,7 @@ class Molecule:
             pass
 
         if len(kwargs):
-            raise KeyError("Not all kwargs were correctly parsed, remaining: %s" % ", ".join(kwargs.keys()))
+            raise KeyError("Not all kwargs were correctly parsed, remaining: {}".format(", ".join(kwargs.keys())))
 
 ### Any needed setters and getters
 
@@ -140,7 +140,7 @@ class Molecule:
             elif ext in [".json"]:
                 dtype = "json"
             else:
-                raise KeyError("No dtype provided and ext '%s' not understood." % ext)
+                raise KeyError("No dtype provided and ext '{}' not understood.".format(ext))
 
         if dtype == "psi4":
             with open(filename, "r") as infile:
@@ -151,7 +151,7 @@ class Molecule:
             with open(filename, "r") as infile:
                 data = json.load(infile)
         else:
-            raise KeyError("Dtype not understood '%s'." % dtype)
+            raise KeyError("Dtype not understood '{}'.".format(dtype))
 
         return cls(data, dtype=dtype, orient=orient)
 
@@ -179,14 +179,14 @@ class Molecule:
         arr = np.array(arr, dtype=np.double)
 
         if (len(arr.shape) != 2) or (arr.shape[1] != 4):
-            raise AttributeError("Molecule: Molecule should be shape (N, 4) not {}." % arr.shape)
+            raise AttributeError("Molecule: Molecule should be shape (N, 4) not {}.".format(arr.shape))
 
         if units == "bohr":
             const = 1
         elif units == "angstrom":
             const = 1 / constants.physconst["bohr2angstroms"]
         else:
-            raise KeyError("Unit '%s' not understood" % units)
+            raise KeyError("Unit '{}' not understood".format(units))
 
         self.geometry = arr[:, 1:].copy() * const
         self.real = [True for x in arr[:, 0]]
@@ -275,7 +275,8 @@ class Molecule:
                 glines.append(line)
             else:
                 raise TypeError(
-                    'Molecule:create_molecule_from_string: Unidentifiable line in geometry specification: %s' % line)
+                    'Molecule:create_molecule_from_string: '
+                    'Unidentifiable line in geometry specification: {}'.format(line))
 
         # catch last default fragment cgmp
         try:
@@ -315,10 +316,10 @@ class Molecule:
                 ghostAtom = False if (atomm.group('gh1') is None and atomm.group('gh2') is None) else True
 
                 # Check that the atom symbol is valid
-                if not atomSym in constants.el2z:
+                if atomSym not in constants.el2z:
                     raise TypeError(
-                        'Molecule:create_molecule_from_string: Illegal atom symbol in geometry specification: %s' %
-                        atomSym)
+                        'Molecule:create_molecule_from_string: '
+                        'Illegal atom symbol in geometry specification: {}'.format(atomSym))
 
                 symbols.append(atomSym)
                 zVal = constants.el2z[atomSym]
@@ -341,22 +342,25 @@ class Molecule:
                     if realNumber.match(entries[1]):
                         xval = float(entries[1])
                     else:
-                        raise TypeError("Molecule::create_molecule_from_string: Unidentifiable entry %s.", entries[1])
+                        raise TypeError("Molecule::create_molecule_from_string: "
+                                        "Unidentifiable entry: {}.".format(entries[1]))
 
                     if realNumber.match(entries[2]):
                         yval = float(entries[2])
                     else:
-                        raise TypeError("Molecule::create_molecule_from_string: Unidentifiable entry %s.", entries[2])
+                        raise TypeError("Molecule::create_molecule_from_string: "
+                                        "Unidentifiable entry {}.".format(entries[2]))
 
                     if realNumber.match(entries[3]):
                         zval = float(entries[3])
                     else:
-                        raise TypeError("Molecule::create_molecule_from_string: Unidentifiable entry %s.", entries[3])
+                        raise TypeError("Molecule::create_molecule_from_string: "
+                                        "Unidentifiable entry {}.".format(entries[3]))
 
                     geometry.append([xval, yval, zval])
                 else:
-                    raise TypeError('Molecule::create_molecule_from_string: Illegal geometry specification line : %s. \
-                        You should provide either Z-Matrix or Cartesian input' % line)
+                    raise TypeError('Molecule::create_molecule_from_string: Illegal geometry specification line : {}.'
+                                    'You should provide either Z-Matrix or Cartesian input'.format(line))
 
                 iatom += 1
 
@@ -416,15 +420,15 @@ class Molecule:
         """
         text = ""
 
-        text += """    Geometry (in %s), charge = %.1f, multiplicity = %d:\n\n""" % \
-            ('Angstrom', self.charge, self.multiplicity)
+        text += """    Geometry (in {0:s}), charge = {1:.1f}, multiplicity = {2:d}:\n\n""".format(
+            'Angstrom', self.charge, self.multiplicity)
         text += """       Center              X                  Y                   Z       \n"""
         text += """    ------------   -----------------  -----------------  -----------------\n"""
 
         for i in range(len(self.geometry)):
-            text += """    %8s%4s """ % (self.symbols[i], "" if self.real[i] else "(Gh)")
+            text += """    {0:8s}{1:4s} """.format(self.symbols[i], "" if self.real[i] else "(Gh)")
             for j in range(3):
-                text += """  %17.12f""" % (self.geometry[i][j] * constants.physconst["bohr2angstroms"])
+                text += """  {0:17.12f}""".format(self.geometry[i][j] * constants.physconst["bohr2angstroms"])
             text += "\n"
         text += "\n"
 
@@ -525,7 +529,7 @@ class Molecule:
 
         if len(set(real) & set(ghost)):
             raise TypeError(
-                "Molecule:get_fragment: real and ghost sets are overlaping! (%s, %s)." % (str(real), str(ghost)))
+                "Molecule:get_fragment: real and ghost sets are overlapping! ({0}, {1}).".format(str(real), str(ghost)))
 
         geom_blocks = []
         symbols = []
@@ -588,7 +592,7 @@ class Molecule:
         if dtype == "psi4":
             return self._to_psi4_string()
         else:
-            raise KeyError("Molecule:to_string: dtype of '%s' not recognized." % dtype)
+            raise KeyError("Molecule:to_string: dtype of '{}' not recognized.".format(dtype))
 
     def _to_psi4_string(self):
         """Regenerates a input file molecule specification string from the
@@ -598,22 +602,22 @@ class Molecule:
         """
         text = "\n"
 
-        # append atoms and coordentries and fragment separators with charge and multiplicity
+        # append atoms and coordinates and fragment separators with charge and multiplicity
         for num, frag in enumerate(self.fragments):
             divider = "    --"
             if num == 0:
                 divider = ""
 
             if any(self.real[at] for at in frag):
-                text += "%s    \n    %d %d\n" % (divider, self.fragment_charges[num],
-                                                 self.fragment_multiplicities[num])
+                text += "{0:s}    \n    {1:d} {1:d}\n".format(divider, int(self.fragment_charges[num]),
+                                                              self.fragment_multiplicities[num])
 
             for at in frag:
                 if self.real[at]:
-                    text += "    %-8s" % self.symbols[at]
+                    text += "    {0:<8s}".format(str(self.symbols[at]))
                 else:
-                    text += "    %-8s" % ("Gh(" + self.symbols[at] + ")")
-                text += "    % 14.10f % 14.10f % 14.10f\n" % tuple(self.geometry[at])
+                    text += "    {0:<8s}".format("Gh(" + self.symbols[at] + ")")
+                text += "    {0: 14.10f} {1: 14.10f} {2: 14.10f}\n".format(*tuple(self.geometry[at]))
         text += "\n"
 
         # append units and any other non-default molecule keywords

--- a/qcfractal/interface/molecule.py
+++ b/qcfractal/interface/molecule.py
@@ -609,7 +609,7 @@ class Molecule:
                 divider = ""
 
             if any(self.real[at] for at in frag):
-                text += "{0:s}    \n    {1:d} {1:d}\n".format(divider, int(self.fragment_charges[num]),
+                text += "{0:s}    \n    {1:d} {2:d}\n".format(divider, int(self.fragment_charges[num]),
                                                               self.fragment_multiplicities[num])
 
             for at in frag:

--- a/qcfractal/interface/schema/definitions_schema.py
+++ b/qcfractal/interface/schema/definitions_schema.py
@@ -31,6 +31,6 @@ _definitions = {
 
 def get_definition(definition):
     if definition not in _definitions:
-        raise KeyError("Definition '%s' not present.")
+        raise KeyError("Definition '{}' not present.".format(definition))
 
     return copy.deepcopy(_definitions[definition])

--- a/qcfractal/interface/schema/schema_getters.py
+++ b/qcfractal/interface/schema/schema_getters.py
@@ -38,13 +38,13 @@ _collection_indices = {
 
 def get_hash_fields(name):
     if name not in _schemas:
-        raise KeyError("Schema name %s not found." % name)
+        raise KeyError("Schema name {} not found.".format(name))
     return copy.deepcopy(_schemas[name]["hash_fields"])
 
 
 def get_indices(name):
     if name not in _collection_indices:
-        raise KeyError("Indices for %s not found." % name)
+        raise KeyError("Indices for {} not found.".format(name))
     return _collection_indices[name]
 
 
@@ -56,19 +56,19 @@ def format_result_indices(data, program=None):
 
 def get_schema(name):
     if name not in _schemas:
-        raise KeyError("Schema name %s not found." % name)
+        raise KeyError("Schema name {} not found.".format(name))
     return copy.deepcopy(_schemas)
 
 
 def get_schema_keys(name):
     if name not in _schemas:
-        raise KeyError("Schema name %s not found." % name)
+        raise KeyError("Schema name {} not found.".format(name))
     return _schemas[name]["properties"].keys()
 
 
 def validate(data, schema_name, return_errors=False):
     if schema_name not in _schemas:
-        raise KeyError("Schema name %s not found." % name)
+        raise KeyError("Schema name {} not found.".format(schema_name))
 
     error_gen = jsonschema.Draft4Validator(_schemas[schema_name]).iter_errors(data)
     errors = [x for x in error_gen]
@@ -76,7 +76,7 @@ def validate(data, schema_name, return_errors=False):
         if return_errors:
             return errors
         else:
-            error_msg = "Error validating schema '%s'!\n" % schema_name
+            error_msg = "Error validating schema '{}'!\n".format(schema_name)
             error_msg += "Data: \n" + json.dumps(data, indent=2)
             error_msg += "\n\nJSON Schema errors as follow:\n"
             error_msg += "\r".join(x.message for x in errors)

--- a/qcfractal/interface/statistics.py
+++ b/qcfractal/interface/statistics.py
@@ -85,4 +85,4 @@ def wrap_statistics(description, df, value, bench):
         return ret
 
     else:
-        raise TypeError('Type %s is not understood for statistical quanities' % str(type(value)))
+        raise TypeError('Type {} is not understood for statistical quantities'.format(str(type(value))))

--- a/qcfractal/queue_handlers/queue_handlers.py
+++ b/qcfractal/queue_handlers/queue_handlers.py
@@ -186,7 +186,7 @@ class QueueNanny:
         """
 
         for x in range(max_iter):
-            self.logger.info("\nAwait services {0:d} : {1:s}\n".format(x + 1, self.services))
+            self.logger.info("\nAwait services {0:d} : {1:s}\n".format(x + 1, str(self.services)))
             self.update_services()
             self.await_results()
             if len(self.services) == 0:

--- a/qcfractal/queue_handlers/queue_handlers.py
+++ b/qcfractal/queue_handlers/queue_handlers.py
@@ -115,7 +115,8 @@ class QueueNanny:
                     else:
                         error = "No error supplied"
 
-                    raise self.logger.info("Computation key did not complete successfully!:\n%s\n" % (str(key), error))
+                    raise self.logger.info("Computation key did not complete successfully:\n\t{}\n"
+                                           "Because: {}".format(str(key), error))
                 # res = self.db_socket.del_page_by_data(tmp_data)
 
                 self.logger.info("update: {}".format(key))
@@ -124,7 +125,7 @@ class QueueNanny:
                 msg = "".join(traceback.format_tb(e.__traceback__))
                 msg += str(type(e).__name__) + ":" + str(e)
                 self.errors[key] = msg
-                self.logger.info("update: ERROR\n%s" % msg)
+                self.logger.info("update: ERROR\n{}".format(msg))
 
         # Run output parsers
         hooks = []
@@ -185,7 +186,7 @@ class QueueNanny:
         """
 
         for x in range(max_iter):
-            self.logger.info("\nAwait services %d : %s\n" % (x + 1, self.services))
+            self.logger.info("\nAwait services {0:d} : {1:s}\n".format(x + 1, self.services))
             self.update_services()
             self.await_results()
             if len(self.services) == 0:

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -58,7 +58,7 @@ class FractalServer(object):
             self.logger.addHandler(handler)
             app_logger.addHandler(handler)
 
-            self.logger.info("Logfile set to %s\n" % logfile_name)
+            self.logger.info("Logfile set to {}\n".format(logfile_name))
         else:
             app_logger.addHandler(logging.StreamHandler())
             self.logger.addHandler(logging.StreamHandler())
@@ -135,7 +135,7 @@ class FractalServer(object):
 
         # Add in periodic callbacks
 
-        self.logger.info("DQM Server successfully initialized at https://localhost:%d.\n" % self.port)
+        self.logger.info("DQM Server successfully initialized at https://localhost:{0:d}.\n".format(self.port))
         self.periodic = {}
 
     def start(self):

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -223,11 +223,11 @@ def db_socket_fixture(request):
         db.client.drop_database(db._project_name)
         db.init_database()
     else:
-        raise KeyError("DB type %s not understood" % request.param)
+        raise KeyError("DB type {} not understood".format(request.param))
 
     yield db
 
     if request.param == "mongo":
         db.client.drop_database(db_name)
     else:
-        raise KeyError("DB type %s not understood" % request.param)
+        raise KeyError("DB type {} not understood".format(request.param))

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -254,7 +254,7 @@ class ServiceHandler(APIHandler):
 #             self.logger = self.objects["logger"]
 #         else:
 #             self.logger = logging.getLogger('Information')
-#         self.logger.info("INFO: %s" % self.request.method)
+#         self.logger.info("INFO: {}".format(self.request.method))
 
 #     def get(self):
 #         _check_auth(self.objects, self.request.headers)


### PR DESCRIPTION
## Description
This unifies the Python string format methods to the `.format` method
which is what we want going forward. The `"%..." % obj` style should no
longer be present in any of our files. Versioneer files remain untouched.

Fixed a few missing formats
Fixed a misused `json.dump` command
Fixed a few unresolved references which were only reachable in case of failures

## Status
- [x] Ready to go