### PR TITLE
Server now uses SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,8 @@ fireworks_logfile.txt
 
 # Geometric
 energy.txt
+
+# SSl certs
+*.pem
+*.crt
+*.key

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -1,31 +1,36 @@
 """Provides an interface the QCDB Server instance"""
 
-import cryptography.fernet
 import json
 import requests
 import yaml
-import base64
 
 from . import molecule
 from . import orm
 
+
 class FractalClient(object):
     def __init__(self, address, username=None, password=None, verify=True):
-        """Constructs a FractalClient
+        """Initializes a FractalClient instance from an address and verification information.
 
         Parameters
         ----------
         address : str
-            The address of the FractalServer to connect to.
-        username : str, optional
-            The username to authenticate the connection with.
-        password : str, optional
-            The password to authenticate the connection with.
+            The IP and port of the FractalServer instance ("192.168.1.1:8888")
+        username : None, optional
+            The username to authenticate with.
+        password : None, optional
+            The password to authenticate with.
         verify : bool, optional
-            Verifies the SSL connection with a third party. 
+            Verifies the SSL connection with a third party server. This may be False if a
+            FractalServer was not provided a SSL certificate and defaults back to self-signed
+            SSL keys.
         """
         if "http" not in address:
-            address = "http://" + address
+            address = "https://" + address
+
+        # If we are `http`, ignore all SSL directives
+        if not address.startswith("https"):
+            self._verify = True
 
         if not address.endswith("/"):
             address += "/"
@@ -55,7 +60,6 @@ class FractalClient(object):
         ret += "username='{}')".format(self.username)
         return ret
 
-        # self.info = self.get_information()
     def _request(self, method, service, payload):
 
         addr = self.address + service

--- a/qcfractal/interface/molecule.py
+++ b/qcfractal/interface/molecule.py
@@ -372,11 +372,10 @@ class Molecule:
                     atomMass = float(atomm.group('mass'))
                 tmpMass.append(atomMass)
 
+                charge = float(zVal)
                 if ghostAtom:
                     zVal = 0
                     charge = 0.0
-                else:
-                    charge = float(zVal)
 
                 # handle cartesians
                 if len(entries) == 4:

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -2,7 +2,6 @@
 The FractalServer class
 """
 
-import base64
 import logging
 import ssl
 

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -3,8 +3,8 @@ The FractalServer class
 """
 
 import base64
-import cryptography.fernet
 import logging
+import ssl
 
 import tornado.ioloop
 import tornado.web
@@ -15,6 +15,54 @@ from . import web_handlers
 
 myFormatter = logging.Formatter('[%(asctime)s] %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
 
+def _build_ssl():
+    from cryptography import x509
+    from cryptography.x509.oid import NameOID
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    import sys
+    import socket
+    import datetime
+    import ipaddress
+    import random
+
+    hostname = socket.gethostname()
+    public_ip = ipaddress.ip_address(socket.gethostbyname(hostname))
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=1024, backend=default_backend())
+
+    alt_name_list = [x509.DNSName(hostname), x509.IPAddress(ipaddress.ip_address(public_ip))]
+    alt_names = x509.SubjectAlternativeName(alt_name_list)
+
+    # Basic data
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+    basic_contraints = x509.BasicConstraints(ca=True, path_length=0)
+    now = datetime.datetime.utcnow()
+
+    # Build cert
+    cert = (x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(int(random.random() * sys.maxsize))
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=10*365))
+        .add_extension(basic_contraints, False)
+        .add_extension(alt_names, False)
+        .sign(key, hashes.SHA256(), default_backend())) # yapf: disable
+
+    # Build and return keys
+    cert_pem = cert.public_bytes(encoding=serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ) # yapf: disable
+
+    return (cert_pem, key_pem)
 
 class FractalServer(object):
     def __init__(
@@ -23,8 +71,9 @@ class FractalServer(object):
             # Server info options
             port=8888,
             io_loop=None,
+
             security=None,
-            shared_secret=None,
+            ssl_options=None,
 
             # Database options
             db_ip="127.0.0.1",
@@ -42,7 +91,10 @@ class FractalServer(object):
 
         # Save local options
         self.port = port
-        self._address = "http://localhost:" + str(self.port) + "/"
+        if ssl_options is False:
+            self._address = "http://localhost:" + str(self.port) + "/"
+        else:
+            self._address = "https://localhost:" + str(self.port) + "/"
 
         # Setup logging.
         self.logger = logging.getLogger("FractalServer")
@@ -65,18 +117,51 @@ class FractalServer(object):
             self.logger.info("No logfile given, setting output to stdout")
 
         # Build security layers
-        fernet = None
         if security is None:
             db_bypass_security = True
         elif security == "local":
-            if shared_secret is None:
-                raise KeyError("Security is set to local, but no shared_secret was added.")
-
-            shared_secret = base64.urlsafe_b64encode((shared_secret + " " * (32 - len(shared_secret))).encode("UTF-8"))
-            fernet = cryptography.fernet.Fernet(shared_secret)
             db_bypass_security = False
         else:
             raise KeyError("Security option '{}' not recognized.".format(security))
+
+        # Handle SSL
+        ssl_ctx = None
+        if ssl_options is None:
+            self.logger.warning("No SSL files passed in, generating self-signed SSL certificate.")
+            self.logger.warning("Clients must use `verify=False` when connects.")
+
+            cert, key = _build_ssl()
+
+            # Add quick names
+            cert_name = db_project_name + "_ssl.crt"
+            key_name = db_project_name + "_ssl.key"
+
+            ssl_options = {"crt": cert_name, "key": key_name}
+
+            with open(cert_name, "wb") as handle:
+                handle.write(cert)
+
+            with open(key_name, "wb") as handle:
+                handle.write(key)
+
+            ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            ssl_ctx.load_cert_chain(ssl_options["crt"], ssl_options["key"])
+
+            # Destroy keyfiles upon close
+            import atexit
+            import os
+            atexit.register(os.remove, cert_name)
+            atexit.register(os.remove, key_name)
+        elif ssl_options is False:
+            ssl_ctx = None
+        elif isinstance(ssl_options, dict):
+            if ("crt" not in ssl_options) or ("key" not in ssl_options):
+                raise KeyError("'crt' (SSL Certificate) and 'key' (SSL Key) fields are required for `ssl_options`.")
+
+            ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            ssl_ctx.load_cert_chain(ssl_options["crt"], ssl_options["key"])
+        else:
+            raise KeyError("ssl_options not understood")
 
         # Setup the database connection
         self.db = db_sockets.db_socket_factory(
@@ -98,7 +183,6 @@ class FractalServer(object):
         self.objects = {
             "db_socket": self.db,
             "logger": self.logger,
-            "fernet": fernet
         }
 
         endpoints = [
@@ -131,7 +215,9 @@ class FractalServer(object):
         }
         self.app = tornado.web.Application(endpoints, **app_settings)
 
-        self.app.listen(self.port)
+        self.http_server = tornado.httpserver.HTTPServer(self.app, ssl_options=ssl_ctx)
+
+        self.http_server.listen(self.port)
 
         # Add in periodic callbacks
 

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -127,7 +127,7 @@ def test_server(request):
     with pristine_loop() as loop:
 
         # Build server, manually handle IOLoop (no start/stop needed)
-        server = FractalServer(port=find_open_port(), db_project_name=db_name, io_loop=loop)
+        server = FractalServer(port=find_open_port(), db_project_name=db_name, io_loop=loop, ssl_options=False)
 
         # Clean and re-init the databse
         server.db.client.drop_database(server.db._project_name)
@@ -158,7 +158,11 @@ def dask_server_fixture(request):
 
             # Build server, manually handle IOLoop (no start/stop needed)
             server = FractalServer(
-                port=find_open_port(), db_project_name=db_name, io_loop=cluster.loop, queue_socket=client)
+                port=find_open_port(),
+                db_project_name=db_name,
+                io_loop=cluster.loop,
+                queue_socket=client,
+                ssl_options=False)
 
             # Clean and re-init the databse
             server.db.client.drop_database(server.db._project_name)
@@ -187,7 +191,8 @@ def fireworks_server_fixture(request):
     with pristine_loop() as loop:
 
         # Build server, manually handle IOLoop (no start/stop needed)
-        server = FractalServer(port=find_open_port(), db_project_name=db_name, io_loop=loop, queue_socket=lpad)
+        server = FractalServer(
+            port=find_open_port(), db_project_name=db_name, io_loop=loop, queue_socket=lpad, ssl_options=False)
 
         # Clean and re-init the databse
         server.db.client.drop_database(server.db._project_name)

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -3,8 +3,6 @@ Web handlers for the FractalServer
 """
 import json
 import tornado.web
-from base64 import b64decode
-import cryptography
 
 
 class APIHandler(tornado.web.RequestHandler):
@@ -23,7 +21,6 @@ class APIHandler(tornado.web.RequestHandler):
 
         #print(self.request.headers["Content-Type"])
         self.json = json.loads(self.request.body.decode("UTF-8"))
-
 
     def authenticate(self, permission):
         """Authenticates request with a given permission setting
@@ -218,47 +215,46 @@ class ServiceHandler(APIHandler):
 
     #     self.write(ret)
 
+    # def _check_auth(objects, header):
+    #     auth = False
+    #     try:
+    #         objects["mongod_socket"].client.database_names()
+    #         username = "default"
+    #         auth = True
+    #     except pymongo.errors.OperationFailure:
 
-# def _check_auth(objects, header):
-#     auth = False
-#     try:
-#         objects["mongod_socket"].client.database_names()
-#         username = "default"
-#         auth = True
-#     except pymongo.errors.OperationFailure:
+    #         # The authenticate method should match a username and password
+    #         # to a username and password hash in the database users table.
+    #         db = self.objects["mongod_socket"][header["project"]]
+    #         try:
+    #             auth = db.authenticate(header["username"], header["password"])
+    #         except pymongo.errors.OperationFailure:
+    #             auth = False
 
-#         # The authenticate method should match a username and password
-#         # to a username and password hash in the database users table.
-#         db = self.objects["mongod_socket"][header["project"]]
-#         try:
-#             auth = db.authenticate(header["username"], header["password"])
-#         except pymongo.errors.OperationFailure:
-#             auth = False
+    #     if auth is not True:
+    #         raise KeyError("Could not authenticate user.")
 
-#     if auth is not True:
-#         raise KeyError("Could not authenticate user.")
+    # class Information(tornado.web.RequestHandler):
+    #     """
+    #     Obtains generic information about the Application Objects
+    #     """
 
-# class Information(tornado.web.RequestHandler):
-#     """
-#     Obtains generic information about the Application Objects
-#     """
+    #     def initialize(self, **objects):
+    #         self.objects = objects
 
-#     def initialize(self, **objects):
-#         self.objects = objects
+    #         if "logger" in list(self.objects):
+    #             self.logger = self.objects["logger"]
+    #         else:
+    #             self.logger = logging.getLogger('Information')
+    #         self.logger.info("INFO: %s" % self.request.method)
 
-#         if "logger" in list(self.objects):
-#             self.logger = self.objects["logger"]
-#         else:
-#             self.logger = logging.getLogger('Information')
-#         self.logger.info("INFO: {}".format(self.request.method))
+    #     def get(self):
+    #         _check_auth(self.objects, self.request.headers)
 
-#     def get(self):
-#         _check_auth(self.objects, self.request.headers)
+    #         queue = self.objects["queue_socket"]
+    #         mongod = self.objects["mongod_socket"]
 
-#         queue = self.objects["queue_socket"]
-#         mongod = self.objects["mongod_socket"]
-
-#         ret = {}
-#         ret["mongo_data"] = (mongod.url, mongod.port)
-#         ret["dask_data"] = str(queue.host) + ":" + str(queue.port)
-#         self.write(json.dumps(ret))
+    #         ret = {}
+    #         ret["mongo_data"] = (mongod.url, mongod.port)
+    #         ret["dask_data"] = str(queue.host) + ":" + str(queue.port)
+    #         self.write(json.dumps(ret))

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -35,12 +35,8 @@ class APIHandler(tornado.web.RequestHandler):
 
         """
         if "Authorization" in self.request.headers:
-            bytes_token = self.request.headers["Authorization"].encode("UTF-8")
-            try:
-                data = json.loads(self.objects["fernet"].decrypt(bytes_token))
-            except cryptography.fernet.InvalidToken:
-                raise tornado.web.HTTPError(status_code=401, reason="Invalid shared secret.")
 
+            data = json.loads(self.request.headers["Authorization"])
             username = data["username"]
             password = data["password"]
         else:


### PR DESCRIPTION
## Description
The server now automatically generates self-signed SSL certs if no SSL certs are passed in. The Client coerces `requests` to accept self-signed SSL if `verify=False` and warnings are hidden. If `verify=True` and self-signed SSL certs are used, the user will get a bad verification error. 

## Status
- [x] Ready to go