### PR TITLE
Add initial Example test

### DIFF
--- a/examples/fireworks_server/README.md
+++ b/examples/fireworks_server/README.md
@@ -5,7 +5,7 @@
 This example assumes you have a install configure to the setup in the
 [fireworks.yaml or openff.yaml conda env](../../devtools/conda-envs).
 
-You effectivley need MongoDB and Fireworks installed
+You effectively need MongoDB and Fireworks installed
 
 You will also need to configure your MongoDB to write to location 
 you have write access to. The example sets one but you can change 
@@ -40,7 +40,7 @@ python server.py
 Add a new Database of several intermolecular reactions. 
 
 This step and following ones should be run in the same window and/or 
-as foreground processes sparate from the MongoDB and Fireworks servers.
+as foreground processes separate from the MongoDB and Fireworks servers.
 
 ```bash
 python build_database.py
@@ -60,7 +60,7 @@ rlaunch -l fw_lpad.yaml rapidfire
 
 ### Step 5
 Query data
-```
+```bash
 python query_database.py
 ``` 
 

--- a/examples/fireworks_server/run_fireworks_example.sh
+++ b/examples/fireworks_server/run_fireworks_example.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Check if MongoDB is running, filter grep itself
+STOPMONGOD=false
+if [[ $(ps -ax | grep mongo | grep -v grep) == "" ]]
+then
+    # Runs mongod on the default location, sends output to /dev/null and runs in background
+    mongod --dbpath /data/db > /dev/null &
+    sleep 5  # Give it a bit to boot up
+    STOPMONGOD=true
+fi
+
+# Spin up a fireworks server in background
+python server.py &
+sleep 5  # Give it a bit to boot up
+
+# Build, compute, and query database
+python build_database.py
+python compute_database.py
+rlaunch -l fw_lpad.yaml rapidfire
+python query_database.py
+
+# Cleanup background processes we started
+kill %%
+if $STOPMONGOD;
+then
+    sleep 3  # Give some time to kill the fireworks server
+    kill %%
+fi

--- a/examples/fireworks_server/test_firework_example.py
+++ b/examples/fireworks_server/test_firework_example.py
@@ -1,0 +1,30 @@
+"""
+Test the examples
+"""
+
+import re
+import pytest
+import subprocess as sp
+from qcfractal import testing
+
+
+@testing.using_fireworks
+@testing.using_unix
+@pytest.mark.slow
+def test_fireworks_example():
+    """Make sure the Fireworks example works as intended"""
+    output = sp.check_output(["bash", "run_fireworks_example.sh"], shell=False)
+    output_lines = output.decode().split('\n')  # Split up the output
+    expected = {
+        'Water Dimer': -1.392710,
+        'Water Dimer Stretch': 0.037144,
+        'Helium Dimer': -0.003148
+    }
+    for index, line in enumerate(output_lines):
+        try:
+            split = re.split(r"([-.0-9]+$)", line)  # Split the line around what we expect
+            expected_value = expected[split[0].strip()]  # use first column as key
+            assert expected_value == float(split[1])  # Check that output is expected value
+        except (KeyError, IndexError):
+            # Skip over lines which are not in the right format
+            pass

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -2,6 +2,7 @@
 Contains testing infrastructure for QCFractal
 """
 
+import os
 import logging
 import pkgutil
 import socket
@@ -54,6 +55,8 @@ using_psi4 = pytest.mark.skipif(has_module('psi4') is False, reason=_import_mess
 using_rdkit = pytest.mark.skipif(has_module('rdkit') is False, reason=_import_message.format('rdkit'))
 using_geometric = pytest.mark.skipif(has_module('geometric') is False, reason=_import_message.format('geometric'))
 using_torsiondrive = pytest.mark.skipif(has_module('torsiondrive') is False, reason=_import_message.format('torsiondrive'))
+using_unix = pytest.mark.skipif(os.name.lower() != 'posix', reason='Not on Unix operating system, '
+                                                                   'assuming Bash is not present')
 
 ### Server testing mechanics
 


### PR DESCRIPTION
## Description
This adds the bash script to run the Fireworks example, and then adds
a pytest file to execute and validate. Its a bit crude, but I am open
to suggestions on fixes.

## Questions
Known issues:
- [ ] I'm not sure we want to run the examples on Travis all the time, they
  can be a bit slow, and I imagine as the examples get more complex,
  they will. I have not added the travis hooks to do this yet for that
  reason
- [ ] The py.test script relies on subprocess output and very output
  sensitive regex matching to assert values are returned correctly
- [ ] Cleaning up the background process jobs is fragile, but it was either
  that or never clean them up and/or flood the STDOUT with MongoDB and
  Fireworks spam.

I'm open to suggestions for these issues, but I can confirm it works
locally.
## Status
- [ ] Ready to go