### PR TITLE
Molecular formula molecule index

### DIFF
--- a/qcfractal/db_sockets/db_utils.py
+++ b/qcfractal/db_sockets/db_utils.py
@@ -15,6 +15,8 @@ def translate_molecule_index(index):
         return "molecule_hash"
     elif index in ["_id", "molecule_hash"]:
         return index
+    elif index == "molecular_formula":
+        return index
     else:
         raise KeyError("Molecule Index '{}' not understood".format(index))
 

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -151,7 +151,7 @@ class FractalClient(object):
             mol_list = [mol_list]
 
         index = index.lower()
-        if index not in ["id", "index"]:
+        if index not in ["id", "index", "molecular_formula"]:
             raise KeyError("Search index must either be 'id' or hash, found: {}".format(index))
 
         payload = {"meta": {"index": index}, "data": mol_list}

--- a/qcfractal/interface/molecule.py
+++ b/qcfractal/interface/molecule.py
@@ -60,6 +60,7 @@ class Molecule:
         self.fragment_multiplicities = []
         self.provenance = {}
         self.connectivity = []
+        self.identifiers = {}
 
         # List any flags
         self._custom_masses = False

--- a/qcfractal/interface/molecule.py
+++ b/qcfractal/interface/molecule.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import re
+import collections
 
 import numpy as np
 
@@ -725,3 +726,42 @@ class Molecule:
 
         m.update(concat.encode("utf-8"))
         return m.hexdigest()
+
+    def get_molecular_formula(self):
+        """
+        Returns the molecular formula for a molecule. Atom symbols are sorted from
+        A-Z.
+
+        Examples
+        --------
+
+        >>> methane = portal.Molecule('''
+          H      0.5288      0.1610      0.9359
+          C      0.0000      0.0000      0.0000
+          H      0.2051      0.8240     -0.6786
+          H      0.3345     -0.9314     -0.4496
+          H     -1.0685     -0.0537      0.1921
+        ''')
+
+        >>> methane.get_molecular_formula()
+        CH4
+
+        >>> hcl = portal.Molecule('''
+          H      0.0000      0.0000      0.0000
+          Cl     0.0000      0.0000      1.2000
+        ''')
+
+        >>> hcl.get_molecular_formula()
+        ClH
+
+        """
+        count = collections.Counter(x.title() for x in self.symbols)
+
+        ret = []
+        for k in sorted(count.keys()):
+            c = count[k]
+            ret.append(k)
+            if c > 1:
+                ret.append(str(c))
+
+        return "".join(ret)

--- a/qcfractal/interface/schema/molecule_schema.py
+++ b/qcfractal/interface/schema/molecule_schema.py
@@ -31,6 +31,28 @@ molecule_schema = {
             "description": "The name of the molecule.",
             "type": "string"
         },
+        "identifiers": {
+            "description": "Canonical chemical identifiers.",
+            "type": "object",
+            "properties": {
+                "molecular_formula": {
+                    "description": "A string giving the symbol and symbol count for the molecule.",
+                    "type": "string"
+                },
+                "smiles": {
+                    "description": "Simplified Molecular Input Line Entry System line notation.",
+                    "type": "string"
+                },
+                "inchi": {
+                    "description": "IUPAC International Chemical Identifier line notation.",
+                    "type": "string"
+                },
+                "inchikey": {
+                    "description": "A SHA1 hash of the inichi description.",
+                    "type": "string"
+                },
+            }
+        },
         "comment": {
             "description": "Any additional comment one would attach to the molecule.",
             "type": "string"

--- a/qcfractal/interface/schema/molecule_schema.py
+++ b/qcfractal/interface/schema/molecule_schema.py
@@ -35,6 +35,10 @@ molecule_schema = {
             "description": "Canonical chemical identifiers.",
             "type": "object",
             "properties": {
+                "molecule_hash": {
+                    "description": "A unique hash for molecules specific to QCFractal.",
+                    "type": "string"
+                },
                 "molecular_formula": {
                     "description": "A string giving the symbol and symbol count for the molecule.",
                     "type": "string"
@@ -48,7 +52,7 @@ molecule_schema = {
                     "type": "string"
                 },
                 "inchikey": {
-                    "description": "A SHA1 hash of the inichi description.",
+                    "description": "A SHA1 hash of the inchi description.",
                     "type": "string"
                 },
             }

--- a/qcfractal/interface/schema/schema_getters.py
+++ b/qcfractal/interface/schema/schema_getters.py
@@ -28,8 +28,8 @@ _schemas["options"] = options_schema
 _collection_indices = {
     "database": ("category", "name"),
     "options": ("program", "name"),
-    "result": ("program", "molecule_id", "driver", "method", "basis", "options"),
-    "molecule": ("molecule_hash", ),
+    "result": ("molecule_id", "program", "driver", "method", "basis", "options"),
+    "molecule": ("molecule_hash", "molecular_formula"),
     "procedure": ("procedure", "program"),
     "service": ("service", ),
     "queue": ("status", "hash_index", "tag"),

--- a/qcfractal/interface/tests/test_molecule.py
+++ b/qcfractal/interface/tests/test_molecule.py
@@ -16,6 +16,7 @@ def test_molecule_constructors():
     water_from_np = portal.Molecule(npwater, name="water dimer", dtype="numpy", frags=[3])
 
     assert water_psi.compare(water_psi, water_from_np)
+    assert water_psi.get_molecular_formula() == "H4O2"
 
     # Check the JSON construct/deconstruct
     water_from_json = portal.Molecule(water_psi.to_json(), dtype="json")
@@ -27,11 +28,12 @@ def test_molecule_constructors():
     npneon = np.hstack((ele, neon_from_psi.geometry))
     neon_from_np = portal.Molecule(npneon, name="neon tetramer", dtype="numpy", frags=[1, 2, 3], units="bohr")
 
-    assert water_psi.compare(neon_from_psi, neon_from_np)
+    assert neon_from_psi.compare(neon_from_psi, neon_from_np)
 
     # Check the JSON construct/deconstruct
     neon_from_json = portal.Molecule(neon_from_psi.to_json(), dtype="json")
-    assert water_psi.compare(neon_from_psi, neon_from_json)
+    assert neon_from_psi.compare(neon_from_psi, neon_from_json)
+    assert neon_from_json.get_molecular_formula() == "Ne4"
 
     assert water_psi.compare(portal.Molecule(water_psi.to_string()))
 
@@ -44,6 +46,7 @@ def test_molecule_file_constructors():
 
     assert mol_psi.compare(mol_json)
     assert mol_psi.compare(mol_np)
+    assert mol_psi.get_molecular_formula() == "He2"
 
 
 def test_water_minima_data():
@@ -158,6 +161,7 @@ def test_molecule_repeated_hashing():
     })
 
     h1 = mol.get_hash()
+    assert mol.get_molecular_formula() == "H2O2"
 
     mol2 = portal.Molecule(mol.to_json(), orient=False)
     assert h1 == mol2.get_hash()

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -36,7 +36,7 @@ class TorsionDriveService:
         # Remove identity info from template
         molecule_template = copy.deepcopy(molecule)
         del molecule_template["id"]
-        del molecule_template["molecule_hash"]
+        del molecule_template["identifiers"]
 
         # Iniate torsiondrive meta
         meta["torsiondrive_state"] = td_api.create_initial_state(

--- a/qcfractal/tests/test_portal.py
+++ b/qcfractal/tests/test_portal.py
@@ -20,7 +20,10 @@ def test_molecule_portal(test_server):
 
     # Test get
     get_mol = client.get_molecules(ret["water"], index="id")
+    assert water.compare(get_mol[0])
 
+    # Test molecular_formula get
+    get_mol = client.get_molecules(["H4O2"], index="molecular_formula")
     assert water.compare(get_mol[0])
 
 

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -57,7 +57,7 @@ class MoleculeHandler(APIHandler):
 
         Request:
             "meta" - Overall options to the Molecule pull request
-                - "index" - What kind of index used to find the data ("id", "molecule_hash")
+                - "index" - What kind of index used to find the data ("id", "molecule_hash", "molecular_formula")
             "data" - A dictionary of {key : index} requests
 
         Returns:


### PR DESCRIPTION
## Description
Adds molecular formula as a possible molecule index to query. Also canonicalizes molecule identifiers so that additional idents such as SMILES or InChI are easier to add in the future.

Identity indices are duplicated in the flat document namespace then projected out for speed.

## Status
- [x] Ready to go