### PR TITLE
Merges service result with procedures

### DIFF
--- a/qcfractal/db_sockets/mongo_socket.py
+++ b/qcfractal/db_sockets/mongo_socket.py
@@ -718,6 +718,12 @@ class MongoSocket:
             modified_count += result.modified_count
         return (match_count, modified_count)
 
+    def del_services(self, values, index="id"):
+
+        index = _translate_id_index(index)
+
+        return self._del_by_index("service_queue", values, index=index)
+
 ### Mongo queue handling functions
 
     def queue_submit(self, data, tag=None):

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -270,7 +270,7 @@ class FractalClient(object):
         else:
             return r.json()["data"]
 
-    def get_procedure(self, procedure_id, **kwargs):
+    def get_procedures(self, procedure_id, **kwargs):
 
         payload = {"meta": {}, "data": [procedure_id]}
         r = self._request("get", "procedure", payload)

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -270,10 +270,10 @@ class FractalClient(object):
         else:
             return r.json()["data"]
 
-    def get_service(self, service_id, **kwargs):
+    def get_procedure(self, procedure_id, **kwargs):
 
-        payload = {"meta": {}, "data": [service_id]}
-        r = self._request("get", "service", payload)
+        payload = {"meta": {}, "data": [procedure_id]}
+        r = self._request("get", "procedure", payload)
 
         if kwargs.get("return_objects", True):
             ret = []
@@ -320,7 +320,7 @@ class FractalClient(object):
             "data": molecule_id
         }
 
-        r = self._request("post", "scheduler", payload)
+        r = self._request("post", "task_scheduler", payload)
 
         if return_full:
             return r.json()

--- a/qcfractal/interface/orm/__init__.py
+++ b/qcfractal/interface/orm/__init__.py
@@ -4,3 +4,4 @@ Object relational mappers
 
 from .build_orm import build_orm
 from .torsiondrive_orm import TorsionDriveORM
+from .optimization_orm import OptimizationORM

--- a/qcfractal/interface/orm/build_orm.py
+++ b/qcfractal/interface/orm/build_orm.py
@@ -37,10 +37,10 @@ def build_orm(data, service=None):
     TorsionDrive(id='5b7f1fd57b87872d2c5d0a6c', state='RUNNING', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
     """
 
-    if ("service" not in data) and (service is None):
+    if ("procedure" not in data) and (service is None):
         raise KeyError("There is not a service tag and service is none. Unable to determine service type")
 
-    if data["service"].lower() == "torsiondrive":
+    if data["procedure"].lower() == "torsiondrive":
         return TorsionDriveORM.from_json(data)
     else:
         raise KeyError("Service names {} not recognized.".format(data["service"]))

--- a/qcfractal/interface/orm/build_orm.py
+++ b/qcfractal/interface/orm/build_orm.py
@@ -3,30 +3,31 @@ Constructs ORMs from raw JSON
 """
 
 from .torsiondrive_orm import TorsionDriveORM
+from .optimization_orm import OptimizationORM
 
 
-def build_orm(data, service=None):
+def build_orm(data, procedure=None):
     """
     Constructs a Service ORM from incoming JSON data.
 
     Parameters
     ----------
     data : dict
-        A JSON representation of the service.
-    service : None, optional
-        The name of the service. If blank the service name is pulled from the `data["service"]` field.
+        A JSON representation of the procedure.
+    procedure : None, optional
+        The name of the procedure. If blank the procedure name is pulled from the `data["procedure"]` field.
 
     Returns
     -------
     ret : a ORM-like object
-        Returns an interface object of the appropriate service.
+        Returns an interface object of the appropriate procedure.
 
     Examples
     --------
 
     # A partial example of torsiondrive metadata
     >>> data = {
-        "service": "torsiondrive",
+        "procedure": "torsiondrive",
         "initial_molecule": "5b7f1fd57b87872d2c5d0a6c",
         "state": "RUNNING",
         "id": "5b7f1fd57b87872d2c5d0a6d",
@@ -37,10 +38,14 @@ def build_orm(data, service=None):
     TorsionDrive(id='5b7f1fd57b87872d2c5d0a6c', state='RUNNING', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
     """
 
-    if ("procedure" not in data) and (service is None):
-        raise KeyError("There is not a service tag and service is none. Unable to determine service type")
+    if ("procedure" not in data) and (procedure is None):
+        raise KeyError("There is not a procedure tag and procedure is none. Unable to determine procedure type")
 
+    # import json
+    # print(json.dumps(data, indent=2))
     if data["procedure"].lower() == "torsiondrive":
         return TorsionDriveORM.from_json(data)
+    elif data["procedure"].lower() == "optimization":
+        return OptimizationORM.from_json(data)
     else:
-        raise KeyError("Service names {} not recognized.".format(data["service"]))
+        raise KeyError("Service names {} not recognized.".format(data["procedure"]))

--- a/qcfractal/interface/orm/optimization_orm.py
+++ b/qcfractal/interface/orm/optimization_orm.py
@@ -1,0 +1,120 @@
+"""
+A ORM for Optimization results
+"""
+
+import json
+import copy
+
+class OptimizationORM:
+    """
+    A interface to the raw JSON data of a Optimization result.
+    """
+
+    # Maps {internal_status : FractalServer status}
+    __json_mapper = {
+        "_id": "id",
+        "_success": "success",
+
+        # Options
+        "_program": "program",
+        "_qc_options": "qc_meta",
+
+        "_initial_molecule_id": "initial_molecule",
+        "_final_molecule_id": "final_molecule",
+        "_trajectory": "trajectory",
+        "_energies": "energies",
+    }
+
+    def __init__(self, initial_molecule, **kwargs):
+        """Initializes a OptimizationORM object, from local data.
+
+        This object may be able to submit jobs to the server in the future.
+
+        *Prototype object, may change in the future.
+
+        Parameters
+        ----------
+        initial_molecule : TYPE
+            Description
+        kwargs:
+            See OptimizationORM.from_json
+
+        """
+        self._initial_molecule = initial_molecule
+
+        # Set kwargs
+        for k in self.__json_mapper.keys():
+            setattr(self, k, kwargs.get(k[1:], None))
+
+    @classmethod
+    def from_json(cls, data):
+        """
+        Creates a OptimizationORM object from FractalServer data.
+
+        Parameters
+        ----------
+        data : dict
+            A JSON blob from FractalServer:
+                - "id": The service id of the blob
+                - "success": If the optimization result was successful or not.
+                - "program": The program used for the optimization run.
+                - "qc_meta": The quantum chemistry options identified..
+                - "initial_molecule_id": The id of the initial (submitted) molecule.
+                - "final_molecule_id": The id of the optimizated molecule.
+                - "trajectory": QC results for each step in the geometry optimization.
+                - "energies": The final energies for each step in the geometry optimization.
+
+        Returns
+        -------
+        optimization_obj : OptimizationORM
+            A OptimizationORM object from the specified JSON.
+
+        """
+        kwargs = {}
+        for k, v in OptimizationORM.__json_mapper.items():
+            if v in data:
+                kwargs[k[1:]] = data[v]
+
+        if ("final_energies" in kwargs) and (kwargs["final_energies"] is not None):
+            kwargs["final_energies"] = {tuple(json.loads(k)): v for k, v in kwargs["final_energies"].items()}
+
+        return cls(None, **kwargs)
+
+    def __str__(self):
+        """
+        Simplified optimization string representation.
+
+        Returns
+        -------
+        ret : str
+            A representation of the current Optimization status.
+
+        Examples
+        --------
+
+        >>> repr(optimization_obj)
+        Optimization(id='5b7f1fd57b87872d2c5d0a6d', status='FINISHED', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
+        """
+
+        ret = "Optimization("
+        ret += "id='{}', ".format(self._id)
+        ret += "success='{}', ".format(self._success)
+        ret += "initial_molecule_id='{}', ".format(self._initial_molecule_id)
+
+        name = None
+        if self._initial_molecule:
+            name = self._initial_molecule.name()
+
+        ret += "initial_molecule_name='{}')".format(name)
+
+        return ret
+
+    def final_energy(self):
+        """The final energy of the geometry optimization.
+
+        Returns
+        -------
+        float
+            The optimization molecular energy.
+        """
+        return self._energies[-1]

--- a/qcfractal/interface/orm/torsiondrive_orm.py
+++ b/qcfractal/interface/orm/torsiondrive_orm.py
@@ -13,7 +13,7 @@ class TorsionDriveORM:
     # Maps {internal_status : FractalServer status}
     __json_mapper = {
         "_id": "id",
-        "_status": "status",
+        "_success": "success",
 
         # Options
         "_optimization_history": "optimization_history",
@@ -57,7 +57,7 @@ class TorsionDriveORM:
         data : dict
             A JSON blob from FractalServer:
                 - "id": The service id of the blob
-                - "status": The current status of the job ("WAITING", "RUNNING", "FINISHED")
+                - "success": If the procedure was successful or not.
                 - "initial_molecule": The id of the submitted molecule
                 - "torsiondrive_meta": The option submitted to the TorsionDrive method
                 - "geometric_meta": The options submitted to the Geometric method called by TorsionDrive
@@ -93,12 +93,12 @@ class TorsionDriveORM:
         --------
 
         >>> repr(torsiondrive_obj)
-        TorsionDrive(id='5b7f1fd57b87872d2c5d0a6d', status='FINISHED', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
+        TorsionDrive(id='5b7f1fd57b87872d2c5d0a6d', success=True, molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
         """
 
         ret = "TorsionDrive("
         ret += "id='{}', ".format(self._id)
-        ret += "status='{}', ".format(self._status)
+        ret += "success='{}', ".format(self._success)
         ret += "molecule_id='{}', ".format(self._initial_molecule_id)
 
         name = None
@@ -132,8 +132,8 @@ class TorsionDriveORM:
         {(-90,): -148.7641654446243, (180,): -148.76501336993732, (0,): -148.75056290106735, (90,): -148.7641654446148}
         """
 
-        if self._status != "FINISHED":
-            raise KeyError("{} has not completed. Unable to show final energies.".format(self))
+        if not self._success:
+            raise KeyError("{} has not completed or failed. Unable to show final energies.".format(self))
 
         if key is None:
             return self._final_energies.copy()

--- a/qcfractal/interface/orm/torsiondrive_orm.py
+++ b/qcfractal/interface/orm/torsiondrive_orm.py
@@ -10,10 +10,10 @@ class TorsionDriveORM:
     A interface to the raw JSON data of a TorsionDrive torsion scan run.
     """
 
-    # Maps {internal_state : FractalServer state}
+    # Maps {internal_status : FractalServer status}
     __json_mapper = {
         "_id": "id",
-        "_state": "state",
+        "_status": "status",
 
         # Options
         "_optimization_history": "optimization_history",
@@ -57,7 +57,7 @@ class TorsionDriveORM:
         data : dict
             A JSON blob from FractalServer:
                 - "id": The service id of the blob
-                - "state": The current state of the job ("WAITING", "RUNNING", "FINISHED")
+                - "status": The current status of the job ("WAITING", "RUNNING", "FINISHED")
                 - "initial_molecule": The id of the submitted molecule
                 - "torsiondrive_meta": The option submitted to the TorsionDrive method
                 - "geometric_meta": The options submitted to the Geometric method called by TorsionDrive
@@ -87,18 +87,18 @@ class TorsionDriveORM:
         Returns
         -------
         ret : str
-            A representation of the current TorsionDrive state.
+            A representation of the current TorsionDrive status.
 
         Examples
         --------
 
         >>> repr(torsiondrive_obj)
-        TorsionDrive(id='5b7f1fd57b87872d2c5d0a6d', state='FINISHED', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
+        TorsionDrive(id='5b7f1fd57b87872d2c5d0a6d', status='FINISHED', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
         """
 
         ret = "TorsionDrive("
         ret += "id='{}', ".format(self._id)
-        ret += "state='{}', ".format(self._state)
+        ret += "status='{}', ".format(self._status)
         ret += "molecule_id='{}', ".format(self._initial_molecule_id)
 
         name = None
@@ -132,7 +132,7 @@ class TorsionDriveORM:
         {(-90,): -148.7641654446243, (180,): -148.76501336993732, (0,): -148.75056290106735, (90,): -148.7641654446148}
         """
 
-        if self._state != "FINISHED":
+        if self._status != "FINISHED":
             raise KeyError("{} has not completed. Unable to show final energies.".format(self))
 
         if key is None:

--- a/qcfractal/interface/schema/schema_getters.py
+++ b/qcfractal/interface/schema/schema_getters.py
@@ -31,8 +31,8 @@ _collection_indices = {
     "result": ("molecule_id", "program", "driver", "method", "basis", "options"),
     "molecule": ("molecule_hash", "molecular_formula"),
     "procedure": ("procedure", "program"),
-    "service": ("service", ),
-    "queue": ("status", "hash_index", "tag"),
+    "service_queue": ("status", "hash_index", "status", "tag"),
+    "task_queue": ("status", "hash_index", "tag"),
 }
 
 

--- a/qcfractal/procedures/__init__.py
+++ b/qcfractal/procedures/__init__.py
@@ -1,1 +1,6 @@
+"""
+Import file for procedures
+"""
+
 from .procedures import add_new_procedure, get_procedure_input_parser, get_procedure_output_parser
+from . import procedures_util

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -177,10 +177,10 @@ def procedure_optimization_input_parser(db, data):
 
         # Unique nesting of args
         keys = {
-            "procedure_type": "optimization",
+            "type": "optimization",
+            "program": data["meta"]["program"],
+            "keywords": packet["keywords"],
             "single_key": k,
-            "optimization_program": data["meta"]["program"],
-            "optimization_kwargs": packet["keywords"]
         }
 
         task = {

--- a/qcfractal/queue_handlers/queue_handlers.py
+++ b/qcfractal/queue_handlers/queue_handlers.py
@@ -148,6 +148,7 @@ class QueueNanny:
         """Runs through all active services and examines their current status.
         """
 
+        new_procedures = []
         for data in self.db_socket.get_services(list(self.services), by_id=True)["data"]:
             obj = services.build(data["service"], self.db_socket, self, data)
 
@@ -155,10 +156,13 @@ class QueueNanny:
             self.db_socket.update_services([(data["id"], obj.get_json())])
             # print(obj.get_json())
 
-            if finished:
+            if finished is not False:
                 self.services -= {
                     data["id"],
                 }
+                new_procedures.append(finished)
+
+        self.db_socket.add_procedures(new_procedures)
 
     def await_results(self):
         """A synchronus method for testing or small launches

--- a/qcfractal/queue_handlers/queue_handlers.py
+++ b/qcfractal/queue_handlers/queue_handlers.py
@@ -149,6 +149,7 @@ class QueueNanny:
         """
 
         new_procedures = []
+        complete_ids = []
         for data in self.db_socket.get_services(list(self.services), by_id=True)["data"]:
             obj = services.build(data["service"], self.db_socket, self, data)
 
@@ -157,12 +158,18 @@ class QueueNanny:
             # print(obj.get_json())
 
             if finished is not False:
+                # Decrement service lookup
                 self.services -= {
                     data["id"],
                 }
+
+                # Add results to procedures, remove complete_ids
                 new_procedures.append(finished)
+                complete_ids.append(data["id"])
+
 
         self.db_socket.add_procedures(new_procedures)
+        self.db_socket.del_services(complete_ids)
 
     def await_results(self):
         """A synchronus method for testing or small launches

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -189,7 +189,7 @@ class FractalServer(object):
             (r"/option", web_handlers.OptionHandler, self.objects),
             (r"/database", web_handlers.DatabaseHandler, self.objects),
             (r"/result", web_handlers.ResultHandler, self.objects),
-            (r"/service", web_handlers.ServiceHandler, self.objects),
+            (r"/procedure", web_handlers.ProcedureHandler, self.objects),
         ]
 
         # Queue handlers
@@ -203,7 +203,7 @@ class FractalServer(object):
             self.objects["queue_nanny"] = queue_nanny
 
             # Add the endpoint
-            endpoints.append((r"/scheduler", queue_scheduler, self.objects))
+            endpoints.append((r"/task_scheduler", queue_scheduler, self.objects))
             endpoints.append((r"/service_scheduler", service_scheduler, self.objects))
 
         # Build the app

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -77,6 +77,7 @@ class TorsionDriveService:
             "single_keys": schema.format_result_indices(single_keys)
         }
 
+        meta["success"] = False
         meta["procedure"] = "torsiondrive"
         meta["program"] = "torsiondrive"
         meta["hash_index"] = procedures.procedures_util.hash_procedure_keys(keys),
@@ -221,7 +222,7 @@ class TorsionDriveService:
         # Add finalize state
         # Parse remaining procedures
         # Create a map of "jobs" so that procedures does not have to followed
-        self.data["status"] = "FINISHED"
+        self.data["success"] = True
 
         self.data["final_energies"] = {}
         self.data["minimum_positions"] = {}
@@ -245,6 +246,7 @@ class TorsionDriveService:
         del self.data["molecule_template"]
         del self.data["queue_keys"]
         del self.data["torsiondrive_state"]
+        del self.data["status"]
 
         return self.data
 

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -47,7 +47,7 @@ class TorsionDriveService:
         meta["torsiondrive_history"] = {}
 
         # Save initial molecule and add hash
-        meta["state"] = "READY"
+        meta["status"] = "READY"
         meta["required_jobs"] = False
         meta["remaining_jobs"] = False
         meta["molecule_template"] = molecule_template
@@ -59,6 +59,10 @@ class TorsionDriveService:
             dihedral_template.append(tmp)
         meta["torsiondrive_meta"]["dihedral_template"] = dihedral_template
 
+        # Temporary hash index
+        meta["hash_index"] = str(uuid.uuid4())
+        meta["tag"] = None
+
         return cls(db_socket, queue_socket, meta)
 
     def get_json(self):
@@ -66,7 +70,7 @@ class TorsionDriveService:
 
     def iterate(self):
 
-        self.data["state"] = "RUNNING"
+        self.data["status"] = "RUNNING"
         # print("\nTorsionDrive State:")
         # print(json.dumps(self.data["torsiondrive_state"], indent=2))
         # print("Iterate")
@@ -197,7 +201,7 @@ class TorsionDriveService:
         # Add finalize state
         # Parse remaining procedures
         # Create a map of "jobs" so that procedures does not have to followed
-        self.data["state"] = "FINISHED"
+        self.data["status"] = "FINISHED"
 
         self.data["final_energies"] = {}
         self.data["minimum_positions"] = {}

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -45,7 +45,7 @@ def test_compute_queue_stack(fractal_compute_server):
     }
 
     # Ask the server to compute a new computation
-    r = requests.post(fractal_compute_server.get_address("scheduler"), json=compute)
+    r = requests.post(fractal_compute_server.get_address("task_scheduler"), json=compute)
     assert r.status_code == 200
     compute_key = tuple(r.json()["data"][0])
 
@@ -101,7 +101,7 @@ def test_procedure_optimization(fractal_compute_server):
     }
 
     # Ask the server to compute a new computation
-    r = requests.post(fractal_compute_server.get_address("scheduler"), json=compute)
+    r = requests.post(fractal_compute_server.get_address("task_scheduler"), json=compute)
     assert r.status_code == 200
     compute_key = tuple(r.json()["data"][0])
 

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -80,8 +80,9 @@ def test_procedure_optimization(fractal_compute_server):
 
     # Add a hydrogen molecule
     hydrogen = portal.Molecule([[1, 0, 0, -0.672], [1, 0, 0, 0.672]], dtype="numpy", units="bohr")
+    client = portal.FractalClient(fractal_compute_server.get_address(""))
+    mol_ret = client.add_molecules({"hydrogen": hydrogen.to_json()})
     db = fractal_compute_server.objects["db_socket"]
-    mol_ret = db.add_molecules({"hydrogen": hydrogen.to_json()})
 
     # Add compute
     compute = {
@@ -97,7 +98,7 @@ def test_procedure_optimization(fractal_compute_server):
                 "program": "psi4"
             },
         },
-        "data": [mol_ret["data"]["hydrogen"]],
+        "data": [mol_ret["hydrogen"]],
     }
 
     # Ask the server to compute a new computation
@@ -111,11 +112,11 @@ def test_procedure_optimization(fractal_compute_server):
     assert len(nanny.list_current_tasks()) == 0
 
     # # Query result and check against out manual pul
-    query = {"program": "geometric", "options": "none", "initial_molecule": mol_ret["data"]["hydrogen"]}
-    results = db.get_procedures([query])["data"]
+    results = client.get_procedures({"program": "geometric"})
 
     assert len(results) == 1
-    assert pytest.approx(-1.117530188962681, 1e-5) == results[0]["energies"][-1]
+    assert isinstance(str(results[0]), str) # Check that repr runs
+    assert pytest.approx(-1.117530188962681, 1e-5) == results[0].final_energy()
 
 
 ### Tests an entire server and interaction energy database run

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -29,8 +29,9 @@ def test_service_torsiondrive(dask_server_fixture):
            "dihedrals": [[0, 1, 2, 3]],
            "grid_spacing": [90]
         },
-        "geometric_meta": {
-            "coordsys": "tric"
+        "optimization_meta": {
+            "program": "geometric",
+            "coordsys": "tric",
         },
         "qc_meta": {
             "driver": "gradient",
@@ -50,7 +51,7 @@ def test_service_torsiondrive(dask_server_fixture):
     assert len(nanny.list_current_tasks()) == 0
 
     # Get a TorsionDriveORM result and check data
-    result = client.get_service(compute_key)[0]
+    result = client.get_procedure({"procedure": "torsiondrive"})[0]
     assert isinstance(str(result), str) # Check that repr runs
 
     assert pytest.approx(0.002597541340221565, 1e-5) == result.final_energies(0)

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -51,7 +51,7 @@ def test_service_torsiondrive(dask_server_fixture):
     assert len(nanny.list_current_tasks()) == 0
 
     # Get a TorsionDriveORM result and check data
-    result = client.get_procedure({"procedure": "torsiondrive"})[0]
+    result = client.get_procedures({"procedure": "torsiondrive"})[0]
     assert isinstance(str(result), str) # Check that repr runs
 
     assert pytest.approx(0.002597541340221565, 1e-5) == result.final_energies(0)

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -191,7 +191,7 @@ class ResultHandler(APIHandler):
         self.write(ret)
 
 
-class ServiceHandler(APIHandler):
+class ProcedureHandler(APIHandler):
     """
     A handler to push and get molecules.
     """
@@ -201,8 +201,8 @@ class ServiceHandler(APIHandler):
 
         db = self.objects["db_socket"]
 
-        ret = db.get_services(self.json["data"], by_id=True)
-        self.logger.info("GET: Services - {} pulls.".format(len(ret["data"])))
+        ret = db.get_procedures(self.json["data"], by_id=True)
+        self.logger.info("GET: Procedures - {} pulls.".format(len(ret["data"])))
 
         self.write(ret)
 

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -201,7 +201,7 @@ class ProcedureHandler(APIHandler):
 
         db = self.objects["db_socket"]
 
-        ret = db.get_procedures(self.json["data"], by_id=True)
+        ret = db.get_procedures(self.json["data"], by_id=self.json.get("by_idx", False))
         self.logger.info("GET: Procedures - {} pulls.".format(len(ret["data"])))
 
         self.write(ret)


### PR DESCRIPTION
## Description
We previously had three types of compute pathways:
 - results, started in the queue, and were deposited in the results table.
 - procedures, started in the queue, and deposited their results in both the results and procedures table (geometry optimizations as an example).
 - services which iteratively created new tasks for the queue.

This above had several complexities:
 - The result and procedures table only contained complete results while the services table could contain both complete and incomplete results.
- The services and procedures table could have nearly identical jobs (geometry optimizations run all on node, or new geometries spawned from the server as a service)

This PR makes the following changes:
 - Changed the queue names to `task_queue` and `services_queue` to better reflect their purpose.
 - `services_queue` now deposits their results into the procedures 

This PR also adds geometry optimization ORM.

## Status
- [x] Ready to go