### PR TITLE
Fixes codecov reporting stats

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,7 @@
 coverage:
   ignore:
-    - qcfractal/test/.*
+    - */tests/*
+    - qcfractal/_version.py
     - setup.py
   status:
     patch: false


### PR DESCRIPTION
## Description
Something changed so that `codecov` now looks at omited coverage lines as well. This PR should ignore these files.

## Status
- [ ] Ready to go