### PR TITLE
Skipif for Mongo

### DIFF
--- a/qcfractal/tests/test_authentication.py
+++ b/qcfractal/tests/test_authentication.py
@@ -33,6 +33,9 @@ def sec_server(request):
     Builds a server instance with the event loop running in a thread.
     """
 
+    # Check mongo
+    testing.check_active_mongo_server()
+
     storage_name = "qcf_local_server_auth_test"
 
     with testing.pristine_loop() as loop:


### PR DESCRIPTION
## Description
Skips tests that require an active mongo connection. `pytest.mark.skipif` does not apply to fixture so an explicit call is required.

Closes #18.

## Questions
- [x] We skip 40/53 tests currently without a Mongo connection. Not sure if we should fail or not.

@dnascimento13 `py.test -v` now passes with many skips in ~5 seconds as opposed to many minutes previously.

## Status
- [x] Ready to go