### PR TITLE
Results hash index

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -278,7 +278,7 @@ class FractalClient(object):
 
     def get_procedures(self, procedure_id, return_objects=True):
 
-        payload = {"meta": {}, "data": [procedure_id]}
+        payload = {"meta": {}, "data": procedure_id}
         r = self._request("get", "procedure", payload)
 
         if return_objects:

--- a/qcfractal/interface/data/molecules/helium_dimer.json
+++ b/qcfractal/interface/data/molecules/helium_dimer.json
@@ -2,5 +2,5 @@
   "name": "Helium Dimer",
   "geometry": [0.0, 0.0, 0.0, 1.8897261329, 0.0, 0.0],
   "symbols": ["HE", "HE"],
-  "connectivity": [[0, 1, 1]]
+  "connectivity": []
 }

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -203,7 +203,7 @@ def procedure_optimization_input_parser(storage, data, duplicate_id="hash_index"
 
         full_tasks.append(task)
 
-    query = storage.get_procedures([{"hash_index": duplicate_lookup}], projection={"hash_index": True, "id": True})["data"]
+    query = storage.get_procedures({"hash_index": duplicate_lookup}, projection={"hash_index": True, "id": True})["data"]
     if len(query):
         found_hashes = set(x["hash_index"] for x in query)
 

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -62,6 +62,8 @@ def procedure_single_input_parser(storage, data):
             continue
 
         keys = {"procedure_type": "single", "single_key": k}
+        hash_index = procedures_util.hash_procedure_keys(keys)
+        v["hash_index"] = hash_index
 
         task = {
             "hash_index": procedures_util.hash_procedure_keys(keys),

--- a/qcfractal/queue_handlers/queue_handlers.py
+++ b/qcfractal/queue_handlers/queue_handlers.py
@@ -156,7 +156,7 @@ class QueueNanny:
 
         new_procedures = []
         complete_ids = []
-        for data in self.storage_socket.get_services(list(self.services), by_id=True)["data"]:
+        for data in self.storage_socket.get_services({"id": list(self.services)})["data"]:
             obj = services.build(data["service"], self.storage_socket, self, data)
 
             finished = obj.iterate()

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -106,7 +106,7 @@ class TorsionDriveService:
         if (self.data["remaining_jobs"] is not False) and (self.data["remaining_jobs"] == 0):
 
             # Query the jobs
-            job_query = self.storage_socket.get_procedures(list(self.data["complete_jobs"].values()), by_id=True)
+            job_query = self.storage_socket.get_procedures({"id": list(self.data["complete_jobs"].values())})
 
             # Figure out the structure
             job_results = {k: [None] * v for k, v in self.data["update_structure"].items()}

--- a/qcfractal/storage_sockets/mongo_socket.py
+++ b/qcfractal/storage_sockets/mongo_socket.py
@@ -173,7 +173,8 @@ class MongoSocket:
             self._tables[tbl].create_index(idx, unique=self._table_unique_indices[tbl])
 
         # Special queue index, hash_index should be unique
-        self._tables["task_queue"].create_index([("hash_index", pymongo.ASCENDING)], unique=True)
+        for table in ["result", "procedure", "task_queue", "service_queue"]:
+            self._tables[table].create_index([("hash_index", pymongo.ASCENDING)], unique=True)
 
         # Return the success array
         return table_creation

--- a/qcfractal/storage_sockets/storage_utils.py
+++ b/qcfractal/storage_sockets/storage_utils.py
@@ -22,7 +22,7 @@ def translate_molecule_index(index):
 
 
 def translate_generic_index(index):
-    if index in ["id", "ids"]:
+    if index in ["_id", "id", "ids"]:
         return "_id"
     elif index in ["key"]:
         return "key"

--- a/qcfractal/tests/test_queue.py
+++ b/qcfractal/tests/test_queue.py
@@ -52,7 +52,7 @@ def test_queue_error(fractal_compute_server):
     assert len(nanny.list_current_tasks()) == 0
 
     db = fractal_compute_server.objects["storage_socket"]
-    ret = db.get_queue([{"status": "ERROR"}])["data"]
+    ret = db.get_queue({"status": "ERROR"})["data"]
 
     assert len(ret) == 1
     assert "connectivity graph" in ret[0]["error"]

--- a/qcfractal/tests/test_storage_sockets.py
+++ b/qcfractal/tests/test_storage_sockets.py
@@ -405,7 +405,7 @@ def test_queue_duplicate(storage_socket):
     assert len(r["data"]) == 0
 
     # Pull out the data and check the hooks
-    r = storage_socket.get_queue([uid], by_id=True)
+    r = storage_socket.get_queue({"id": uid})
     hooks = r["data"][0]["hooks"]
     assert len(hooks) == 2
     assert hooks[0][0] == "service"

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -201,7 +201,7 @@ class ProcedureHandler(APIHandler):
 
         storage = self.objects["storage_socket"]
 
-        ret = storage.get_procedures(self.json["data"], by_id=self.json.get("by_idx", False))
+        ret = storage.get_procedures(self.json["data"])
         self.logger.info("GET: Procedures - {} pulls.".format(len(ret["data"])))
 
         self.write(ret)


### PR DESCRIPTION
## Description
This PR makes the following changes:
- Adds a `hash_index` to the results table to allow add_compute returns return a single index (hash) rather than this return having multiple meanings depending on context (molecule_id for single runs, hash for procedures).
 - Reworks database `get_generic` to allow arbitrary queries for internal usage.
 - Blank hooks are now correctly ignored.


## Status
- [x] Ready to go