### PR TITLE
 Fix import for interface's port testing

### DIFF
--- a/qcfractal/interface/README.md
+++ b/qcfractal/interface/README.md
@@ -1,5 +1,17 @@
-DQM Client
-==========
+QC Portal
+=========
 
-A client interface to the DQM project. Note that this folder will be compiled into a standalone Python
-module via conda variants. This folder should not use modules below this level.
+A client interface to the QC Archive project.
+
+This module is acessible through the semi-auto compiled [QCPortal](https://github.com/molssi/qcportal)
+project as `qcportal`; this is the most common use case for end-users and those 
+ who want to access a remote QCFractal instance. 
+ 
+Alternatively, it can be imported as part of [QCFractal](https://github.com/molssi/qcfractal) directly as the `interface` module; 
+this is the primary way developers and those who manage their own QCFractal instances will 
+access it.
+
+This module specifically (`interface` on QCFractal) is automatically ported to the 
+QCPortal repository as the main source code of QCPortal.
+
+This folder should not use modules above this level.

--- a/qcfractal/interface/dict_utils.py
+++ b/qcfractal/interface/dict_utils.py
@@ -5,7 +5,7 @@ Utilities for dictionary and JSON handeling.
 
 def replace_dict_keys(data, replacement):
     """
-    Recurisvely replaces the keys in data from a dictionary `replacement`.
+    Recursively replaces the keys in data from a dictionary `replacement`.
     """
 
     if isinstance(data, dict):

--- a/qcfractal/interface/tests/__init__.py
+++ b/qcfractal/interface/tests/__init__.py
@@ -3,8 +3,8 @@ Init file for tests, blank to avoid automatic imports.
 """
 
 try:
-    # QCFractal based import
+    # QCFractal based imports
     from ... import interface as portal
-except ImportError:
+except (ImportError, ValueError):  # Catches not importable, and importing too high
     # QCPortal based import
-    from ... import qcportal as portal
+    import qcportal as portal

--- a/qcfractal/interface/tests/__init__.py
+++ b/qcfractal/interface/tests/__init__.py
@@ -1,3 +1,10 @@
 """
 Init file for tests, blank to avoid automatic imports.
 """
+
+try:
+    # QCFractal based import
+    from ... import interface as portal
+except ImportError:
+    # QCPortal based import
+    from ... import qcportal as portal

--- a/qcfractal/interface/tests/test_database.py
+++ b/qcfractal/interface/tests/test_database.py
@@ -2,8 +2,8 @@
 Tests the QCPortal database object
 """
 
+from . import portal
 from . import test_helper as th
-from ... import interface as portal
 import pytest
 
 

--- a/qcfractal/interface/tests/test_molecule.py
+++ b/qcfractal/interface/tests/test_molecule.py
@@ -1,10 +1,10 @@
 """
-Tets the inports and exports of the Molecule object.
+Tests the imports and exports of the Molecule object.
 """
+
 import numpy as np
 import pytest
-
-from ... import interface as portal
+from . import portal
 
 
 def test_molecule_constructors():

--- a/qcfractal/interface/tests/test_schema.py
+++ b/qcfractal/interface/tests/test_schema.py
@@ -2,9 +2,7 @@
 Tests the various schema involved in the project that are not tested elsewhere.
 """
 
-import pytest
-
-from ... import interface as portal
+from . import portal
 
 
 def test_options():

--- a/qcfractal/interface/tests/test_utils.py
+++ b/qcfractal/interface/tests/test_utils.py
@@ -2,7 +2,7 @@
 Tests for the interface utility functions.
 """
 
-from ... import interface as portal
+from . import portal
 
 
 def test_replace_dict_keys():

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import versioneer
 if __name__ == "__main__":
     setuptools.setup(
         name='qcfractal',
-        description='A high throughput computing and database tool for quantum chemsitry.',
+        description='A high throughput computing and database tool for quantum chemistry.',
         author='Daniel Smith',
         author_email='dgasmith@vt.edu',
         url="https://github.com/molssi/qcfractal",
@@ -45,7 +45,6 @@ if __name__ == "__main__":
         classifiers=[
             'Development Status :: 4 - Beta',
             'Intended Audience :: Science/Research',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
         ],
         zip_safe=True,


### PR DESCRIPTION
## Description
This fixes a bug with the standalone QCPortal port of the `interface`
test directory.

 The QCPortal project's/interface's tests can now be
imported from both QCFractal as part of interface, and through
QCPortal as a standalone.

There should be no change to the behavior here on the QCFractal repository.

## Status
- [x] Ready to go