### PR TITLE
Queue and store structure overhaul

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -130,6 +130,18 @@ class FractalClient(object):
 
         return cls(address, username=username, password=password, verify=verify)
 
+    ### Generics
+
+    def locator(self, data, return_full=False):
+
+        payload = {"meta": {}, "data": data}
+        r = self._request("get", "locator", payload)
+
+        if return_full:
+            return r.json()
+        else:
+            return r.json()["data"]
+
     ### Molecule section
 
     def get_molecules(self, mol_list, index="id", full_return=False):

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -261,7 +261,7 @@ class FractalClient(object):
     def get_results(self, **kwargs):
 
         query = {}
-        for key in ["program", "molecule_id", "driver", "method", "basis", "options"]:
+        for key in ["program", "molecule_id", "driver", "method", "basis", "options", "hash_index", "id"]:
             if key in kwargs:
                 query[key] = kwargs[key]
 

--- a/qcfractal/interface/collections/__init__.py
+++ b/qcfractal/interface/collections/__init__.py
@@ -1,5 +1,6 @@
 
 from .database import Database
 from .biofragment import BioFragment
+from .openffworkflow import OpenFFWorkflow
 
-__all__ = ['Database', 'BioFragment']
+__all__ = ['Database', 'BioFragment', "OpenFFWorkflow"]

--- a/qcfractal/interface/collections/biofragment.py
+++ b/qcfractal/interface/collections/biofragment.py
@@ -1,4 +1,5 @@
-"""Mongo QCDB Fragment object and helpers
+"""
+OpenFF BioFragment ODM
 """
 
 import json
@@ -9,7 +10,7 @@ from .collection import Collection
 
 class BioFragment(Collection):
     """
-    This is a QCA Fragment class.
+    This is a QCA BioFragment class.
 
     Attributes
     ----------
@@ -21,14 +22,14 @@ class BioFragment(Collection):
 
     def __init__(self, name, initial_molecule=None, client=None, **kwargs):
         """
-        Initializer for the Database object. If no Portal is supplied or the database name
+        Initializer for the BioFragment object. If no Portal is supplied or the database name
         is not present on the server that the Portal is connected to a blank database will be
         created.
 
         Parameters
         ----------
         name : str
-            The name of the Database
+            The name of the BioFragment
         client : client.FractalClient, optional
             A Portal client to connect to a server
 

--- a/qcfractal/interface/collections/database.py
+++ b/qcfractal/interface/collections/database.py
@@ -1,4 +1,5 @@
-"""Mongo QCDB Database object and helpers
+"""
+QCPortal Database ODM
 """
 import itertools as it
 

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -17,9 +17,12 @@ class OpenFFWorkflow(Collection):
         A optional server portal to connect the database
     """
 
-    __required_fields = {"initial_molecule"}
+    __required_fields = {
+        "enumerate_states", "enumerate_fragments", "torsiondrive_input", "torsiondrive_meta", "optimization_meta",
+        "qc_meta"
+    }
 
-    def __init__(self, name, options=None, **kwargs):
+    def __init__(self, name, options=None, client=None, **kwargs):
         """
         Initializer for the OpenFFWorkflow object. If no Portal is supplied or the database name
         is not present on the server that the Portal is connected to a blank database will be
@@ -33,24 +36,18 @@ class OpenFFWorkflow(Collection):
             A Portal client to connect to a server
 
         """
-        super().__init__(name, client=client, initial_molecule=initial_molecule)
-
-        self._option_sets = {
-            "enumerate_states", "enumerate_fragments", "torsiondrive_input", "torsiondrive_meta", "optimization_meta",
-            "qc_meta"
-        }
+        super().__init__(name, client=client, options=options, **kwargs)
 
     def _init_collection_data(self, additional_args):
         options = additional_args.get("options", None)
         if options is None:
             raise KeyError("No record of OpenFFWorkflow {} found and no initial options passed in.".format(name))
 
-        if len(options.keys() ^ self._option_sets):
-            raise KeyError("'options' kwargs must have keys {}".format(self._option_sets))
-
         ret = copy.deepcopy(options)
-        ret["fragments"] = [] # No known fragments
+        ret["fragments"] = {}  # No known fragments
         ret["molecules"] = []
+
+        ret["fragment_cache"] = {}  # Caches pulled fragment data
 
         return ret
 
@@ -64,10 +61,24 @@ class OpenFFWorkflow(Collection):
         return copy.deepcopy(self._option_sets[key])
 
     def list_fragments(self):
-        return copy.deepcopy(self.data["fragments"])
+        return copy.deepcopy(list(self.data["fragments"]))
 
     def list_initial_molecules(self):
         return copy.deepcopy(self.data["molecules"])
 
+    def add_fragment(self, fragment_id, data, provenance={}):
 
+        if fragment_id in self.data["fragments"]:
+            raise KeyError("Fragment ID {} already used.".format(fragment_id))
 
+        frag_data = {}
+        for name, packet in data.items():
+            torsion_meta = copy.deepcopy(
+                {k: self.data[k]
+                 for k in ("torsiondrive_meta", "optimization_meta", "qc_meta")})
+
+            for k in ["grid_spacing", "dihedrals"]:
+                torsion_meta["torsiondrive_meta"][k] = packet[k]
+
+            ret = self.client.add_service("torsiondrive", [packet["initial_molecule"]], torsion_meta)
+            print(ret)

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -1,0 +1,73 @@
+"""Mongo QCDB Fragment object and helpers
+"""
+
+import json
+import copy
+
+from .collection import Collection
+
+
+class OpenFFWorkflow(Collection):
+    """
+    This is a QCA OpenFFWorkflow class.
+
+    Attributes
+    ----------
+    client : client.FractalClient
+        A optional server portal to connect the database
+    """
+
+    __required_fields = {"initial_molecule"}
+
+    def __init__(self, name, options=None, **kwargs):
+        """
+        Initializer for the OpenFFWorkflow object. If no Portal is supplied or the database name
+        is not present on the server that the Portal is connected to a blank database will be
+        created.
+
+        Parameters
+        ----------
+        name : str
+            The name of the OpenFFWorkflow
+        client : client.FractalClient, optional
+            A Portal client to connect to a server
+
+        """
+        super().__init__(name, client=client, initial_molecule=initial_molecule)
+
+        self._option_sets = {
+            "enumerate_states", "enumerate_fragments", "torsiondrive_input", "torsiondrive_meta", "optimization_meta",
+            "qc_meta"
+        }
+
+    def _init_collection_data(self, additional_args):
+        options = additional_args.get("options", None)
+        if options is None:
+            raise KeyError("No record of OpenFFWorkflow {} found and no initial options passed in.".format(name))
+
+        if len(options.keys() ^ self._option_sets):
+            raise KeyError("'options' kwargs must have keys {}".format(self._option_sets))
+
+        ret = copy.deepcopy(options)
+        ret["fragments"] = [] # No known fragments
+        ret["molecules"] = []
+
+        return ret
+
+    def _pre_save_prep(self, client):
+        pass
+
+    def get_options(self, key):
+        if key not in self._option_sets:
+            raise KeyError("Key `{}` not understood, key must be in {}.".format(self._option_sets))
+
+        return copy.deepcopy(self._option_sets[key])
+
+    def list_fragments(self):
+        return copy.deepcopy(self.data["fragments"])
+
+    def list_initial_molecules(self):
+        return copy.deepcopy(self.data["molecules"])
+
+
+

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -55,10 +55,10 @@ class OpenFFWorkflow(Collection):
         pass
 
     def get_options(self, key):
-        if key not in self._option_sets:
-            raise KeyError("Key `{}` not understood, key must be in {}.".format(self._option_sets))
+        if key not in self.__required_fields:
+            raise KeyError("Key `{}` not understood.".format(key))
 
-        return copy.deepcopy(self._option_sets[key])
+        return copy.deepcopy(self.data[key])
 
     def list_fragments(self):
         return copy.deepcopy(list(self.data["fragments"]))

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -68,11 +68,15 @@ class OpenFFWorkflow(Collection):
 
     def add_fragment(self, fragment_id, data, provenance={}):
 
-        if fragment_id in self.data["fragments"]:
-            raise KeyError("Fragment ID {} already used.".format(fragment_id))
+        if fragment_id not in self.data["fragments"]:
+            self.data["fragments"][fragment_id] = {}
 
-        frag_data = {}
+        frag_data = self.data["fragments"][fragment_id]
         for name, packet in data.items():
+            if name in frag_data:
+                print("Already found label {} for fragment_ID {}, skipping.".format(name, fragment_id))
+                continue
+
             torsion_meta = copy.deepcopy(
                 {k: self.data[k]
                  for k in ("torsiondrive_meta", "optimization_meta", "qc_meta")})
@@ -106,7 +110,11 @@ class OpenFFWorkflow(Collection):
         for frag, reqs in self.data["fragments"].items():
             ret[frag] = {}
             for label, hash_index in reqs.items():
-                ret[frag][label] = {json.dumps(k):v for k, v in data[hash_index].final_energies().items()}
+                try:
+                    ret[frag][label] = {json.dumps(k):v for k, v in data[hash_index].final_energies().items()}
+                except KeyError:
+                    ret[frag][label] = None
+
 
         return ret
 

--- a/qcfractal/interface/orm/optimization_orm.py
+++ b/qcfractal/interface/orm/optimization_orm.py
@@ -3,6 +3,7 @@ A ORM for Optimization results
 """
 
 import json
+import copy
 
 
 class OptimizationORM:
@@ -145,6 +146,8 @@ class OptimizationORM:
         list of dict
             A list of results documents
         """
-        return client.get_results(id=self._trajectory, projection=projection)
+        payload = copy.deepcopy(self._trajectory)
+        payload["projections"] = projection
+        return client.locator(payload)
 
 

--- a/qcfractal/interface/orm/optimization_orm.py
+++ b/qcfractal/interface/orm/optimization_orm.py
@@ -147,7 +147,7 @@ class OptimizationORM:
             A list of results documents
         """
         payload = copy.deepcopy(self._trajectory)
-        payload["projections"] = projection
+        payload["projection"] = projection
         return client.locator(payload)
 
 

--- a/qcfractal/interface/orm/optimization_orm.py
+++ b/qcfractal/interface/orm/optimization_orm.py
@@ -14,6 +14,7 @@ class OptimizationORM:
     __json_mapper = {
         "_id": "id",
         "_success": "success",
+        "_hash_index": "hash_index",
 
         # Options
         "_program": "program",

--- a/qcfractal/interface/orm/optimization_orm.py
+++ b/qcfractal/interface/orm/optimization_orm.py
@@ -110,6 +110,16 @@ class OptimizationORM:
 
         return ret
 
+    def energies(self):
+        """A list of energies along the trajectory path.
+
+        Returns
+        -------
+        list of float
+            The energy of each point in [Eh]
+        """
+        return self._energies[:]
+
     def final_energy(self):
         """The final energy of the geometry optimization.
 
@@ -119,3 +129,22 @@ class OptimizationORM:
             The optimization molecular energy.
         """
         return self._energies[-1]
+
+    def get_trajectory(self, client, projection=None):
+        """Returns the raw documents for each gradient evaluation in the trajectory.
+
+        Parameters
+        ----------
+        client : qcportal.FractalClient
+            A active client connected to a server.
+        projection : None, optional
+            A dictionary of the project to apply to the document
+
+        Returns
+        -------
+        list of dict
+            A list of results documents
+        """
+        return client.get_results(id=self._trajectory, projection=projection)
+
+

--- a/qcfractal/interface/orm/torsiondrive_orm.py
+++ b/qcfractal/interface/orm/torsiondrive_orm.py
@@ -14,6 +14,7 @@ class TorsionDriveORM:
     __json_mapper = {
         "_id": "id",
         "_success": "success",
+        "_hash_index": "hash_index",
 
         # Options
         "_optimization_history": "optimization_history",

--- a/qcfractal/interface/schema/schema_getters.py
+++ b/qcfractal/interface/schema/schema_getters.py
@@ -34,8 +34,8 @@ _table_indices = {
     "result": ("molecule_id", "program", "driver", "method", "basis", "options"),
     "options": ("program", "name"),
 
-    "task_queue": ("status", "hash_index", "tag"),
-    "service_queue": ("status", "hash_index", "tag"),
+    "task_queue": ("status", "tag", "hash_index"),
+    "service_queue": ("status", "tag", "hash_index"),
 }  # yapf: disable
 
 

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -49,7 +49,7 @@ def procedure_single_input_parser(storage, data):
     runs, errors = procedures_util.unpack_single_run_meta(storage, data["meta"], data["data"])
 
     # Remove duplicates
-    query = {k : data["meta"][k] for k in ["driver", "method", "basis", "options", "program"]}
+    query = {k: data["meta"][k] for k in ["driver", "method", "basis", "options", "program"]}
     query["molecule_id"] = [x["molecule"]["id"] for x in runs.values()]
 
     search = storage.get_results(query, projection={"molecule_id": True})
@@ -221,7 +221,11 @@ def procedure_optimization_input_parser(storage, data, duplicate_id="hash_index"
 
         full_tasks.append(task)
 
-    query = storage.get_procedures({"hash_index": duplicate_lookup}, projection={"hash_index": True, "id": True})["data"]
+    query = storage.get_procedures(
+        {
+            "hash_index": duplicate_lookup
+        }, projection={"hash_index": True,
+                       "id": True})["data"]
     if len(query):
         found_hashes = set(x["hash_index"] for x in query)
 
@@ -249,36 +253,52 @@ def procedure_optimization_input_parser(storage, data, duplicate_id="hash_index"
 def procedure_optimization_output_parser(storage, data):
 
     new_procedures = {}
+    new_hooks = {}
 
     # Each optimization is a unique entry:
-    for k, (v, hooks) in data.items():
+    for result, hooks in data:
+        key = result["queue_id"]
 
         # Convert start/stop molecules to hash
-        mols = {"initial": v["initial_molecule"], "final": v["final_molecule"]}
+        mols = {"initial": result["initial_molecule"], "final": result["final_molecule"]}
         mol_keys = storage.add_molecules(mols)["data"]
-        v["initial_molecule"] = mol_keys["initial"]
-        v["final_molecule"] = mol_keys["final"]
+        result["initial_molecule"] = mol_keys["initial"]
+        result["final_molecule"] = mol_keys["final"]
 
-        # Add individual computations
-        traj_dict = {k: v for k, v in enumerate(v["trajectory"])}
+        # Parse trajectory computations and add queue_id
+        traj_dict = {k: v for k, v in enumerate(result["trajectory"])}
         results = procedures_util.parse_single_runs(storage, traj_dict)
+        for k, v in results.items():
+            v["queue_id"] = key
 
+        # Add trajectory results and return locator object
         ret = storage.add_results(list(results.values()))
-        v["trajectory"] = [x[1] for x in ret["data"]]
+        result["trajectory"] = {"table": "results", "index": "id", "data": [x[1] for x in ret["data"]]}
 
         # Coerce tags
-        v.update(v["qcfractal_tags"])
-        del v["input_specification"]
-        del v["qcfractal_tags"]
+        result.update(result["qcfractal_tags"])
+        del result["input_specification"]
+        del result["qcfractal_tags"]
         # print("Adding optimization result")
         # print(json.dumps(v, indent=2))
-        new_procedures[k] = v
+        new_procedures[key] = result
+        if len(hooks):
+            new_hooks[key] = hooks
 
     ret = storage.add_procedures(list(new_procedures.values()))
 
-    hook_data = procedures_util.parse_hooks(data, new_procedures)
+    # Create a list of (queue_id, located) to update the queue with
+    completed = [(k, {"table": "procedures", "index": "id", "data": v["id"]}) for k, v in new_procedures.items()]
 
-    return (ret, hook_data)
+    errors = []
+    if len(ret["meta"]["errors"]):
+        # errors = [(k, "Duplicate results found")]
+        raise ValueError("TODO: Cannot yet handle queue result duplicates.")
+
+    hook_data = procedures_util.parse_hooks(new_procedures, new_hooks)
+
+    # return (ret, hook_data)
+    return (completed, errors, hook_data)
 
 
 # Add in all registered procedures

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -61,12 +61,11 @@ def procedure_single_input_parser(storage, data):
         if v["molecule"]["id"] in completed:
             continue
 
-        keys = {"procedure_type": "single", "single_key": k}
-        hash_index = procedures_util.hash_procedure_keys(keys)
+        keys, hash_index = procedures_util.single_run_hash(v)
         v["hash_index"] = hash_index
 
         task = {
-            "hash_index": procedures_util.hash_procedure_keys(keys),
+            "hash_index": hash_index,
             "hash_keys": keys,
             "spec": {
                 "function": "qcengine.compute",

--- a/qcfractal/procedures/procedures_util.py
+++ b/qcfractal/procedures/procedures_util.py
@@ -162,6 +162,8 @@ def parse_hooks(data, results):
                 # Custom commands
                 if command[-1] == "$task_id":
                     command[-1] = results[k]["id"]
+                elif command[-1] == "$hash_index":
+                    command[-1] = results[k]["hash_index"]
                 # else:
                 #     raise KeyError("Hook command `{}` not understood.".format(command))
 

--- a/qcfractal/procedures/procedures_util.py
+++ b/qcfractal/procedures/procedures_util.py
@@ -125,7 +125,17 @@ def parse_single_runs(storage, results):
 
         del v["qcfractal_tags"]
 
+        if "hash_index" not in v:
+            v["hash_index"] = single_run_hash(v)
+
     return results
+
+def single_run_hash(data, program=None):
+
+    single_keys = interface.schema.format_result_indices(data, program=program)
+    keys = {"procedure_type": "single", "single_key": single_keys}
+    hash_index =hash_procedure_keys(keys)
+    return (keys, hash_index)
 
 
 def hash_procedure_keys(keys):

--- a/qcfractal/procedures/procedures_util.py
+++ b/qcfractal/procedures/procedures_util.py
@@ -167,7 +167,9 @@ def parse_hooks(rdata, rhooks):
             # Loop over individual commands
             for command in h["updates"]:
                 # Custom commands
-                if "$" not in command[-1]:
+                if not isinstance(command[-1], str):
+                    continue
+                elif "$" not in command[-1]:
                     continue
                 elif command[-1] == "$task_id":
                     command[-1] = results[k]["id"]

--- a/qcfractal/queue_handlers/queue_handlers.py
+++ b/qcfractal/queue_handlers/queue_handlers.py
@@ -92,7 +92,7 @@ class QueueNanny:
 
         self.services |= set(task_ids)
 
-        self.logger.info("QUEUE: Added {} services.\n".format(len(new_tasks)))
+        self.logger.info("QUEUE: Added {} services.\n".format(tmp["meta"]["n_inserted"]))
         self.update()
 
         return tmp

--- a/qcfractal/queue_handlers/queue_handlers.py
+++ b/qcfractal/queue_handlers/queue_handlers.py
@@ -88,7 +88,7 @@ class QueueNanny:
             new_tasks.append(task.get_json())
 
         tmp = self.storage_socket.add_services(new_tasks)
-        task_ids = [x[0] for x in tmp["data"]]
+        task_ids = [x["id"] for x in new_tasks]
 
         self.services |= set(task_ids)
 
@@ -289,7 +289,6 @@ class ServiceScheduler(APIHandler):
         service_hashes = [x.data["hash_index"] for x in submitted_services]
         found_hashes = storage.get_procedures({"hash_index": service_hashes}, projection={"hash_index": True})
         found_hashes = set(x["hash_index"] for x in found_hashes["data"])
-        print("complete jobs", found_hashes)
 
         new_services = []
         complete_jobs = []

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -233,15 +233,17 @@ class FractalServer(object):
 
         self.logger.info("DQM Server successfully started. Starting IOLoop.\n")
 
-        # Add canonical queue callback
-        nanny = tornado.ioloop.PeriodicCallback(self.objects["queue_nanny"].update, 2000)
-        nanny.start()
-        self.periodic["queue_nanny_update"] = nanny
+        # If we have a queue socket start up the nanny
+        if "queue_socket" in self.objects:
+            # Add canonical queue callback
+            nanny = tornado.ioloop.PeriodicCallback(self.objects["queue_nanny"].update, 2000)
+            nanny.start()
+            self.periodic["queue_nanny_update"] = nanny
 
-        # Add services callback
-        nanny_services = tornado.ioloop.PeriodicCallback(self.objects["queue_nanny"].update_services, 2000)
-        nanny_services.start()
-        self.periodic["queue_nanny_services"] = nanny_services
+            # Add services callback
+            nanny_services = tornado.ioloop.PeriodicCallback(self.objects["queue_nanny"].update_services, 2000)
+            nanny_services.start()
+            self.periodic["queue_nanny_services"] = nanny_services
 
         # Soft quit with a keyboard interupt
         try:

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -192,6 +192,7 @@ class FractalServer(object):
             (r"/collection", web_handlers.CollectionHandler, self.objects),
             (r"/result", web_handlers.ResultHandler, self.objects),
             (r"/procedure", web_handlers.ProcedureHandler, self.objects),
+            (r"/locator", web_handlers.LocatorHandler, self.objects),
         ]
 
         # Queue handlers

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -121,8 +121,6 @@ class TorsionDriveService:
 
         if next_iter:
 
-            print("NEXT ITER\n\n")
-
             # Query the jobs
             job_query = self.storage_socket.get_procedures({"hash_index": self.data["required_jobs"]})["data"]
             inv_job_lookup = {v["hash_index"]: v for v in job_query}

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -4,7 +4,6 @@ Wraps geometric procedures
 
 import copy
 import json
-import uuid
 import numpy as np
 
 from torsiondrive import td_api
@@ -95,39 +94,58 @@ class TorsionDriveService:
         # print("\nTorsionDrive State:")
         # print(json.dumps(self.data["torsiondrive_state"], indent=2))
         # print("Iterate")
-        if (self.data["remaining_jobs"] > 0):
+        #if (self.data["remaining_jobs"] > 0):
             # print("Iterate: not yet done", self.data["remaining_jobs"])
             # print("Complete jobs", self.data["complete_jobs"])
-            return False
+        #    return False
+        # if self.data["success"] is True:
+        #     return False
+
 
         # print(self.data["remaining_jobs"])
 
         # Required jobs is false on first iteration
-        if (self.data["remaining_jobs"] is not False) and (self.data["remaining_jobs"] == 0):
+        # next_iter = (self.data["remaining_jobs"] is not False) and (self.data["remaining_jobs"] == 0):
+        next_iter = False
+        # print("ID {} : REMAINING JOBS {}".format(self.data["hash_index"], self.data["queue_keys"]))
+        # print("rem job", self.data["remaining_jobs"])
+        if (self.data["remaining_jobs"] is not False):
+
+            # if (self.data["remaining_jobs"] == 0):
+            #     nex_iter = True
+            jq = self.storage_socket.get_procedures({"hash_index": self.data["required_jobs"]})
+            if len(jq["data"]) == len(self.data["required_jobs"]):
+                next_iter = True
+            else:
+                return False
+
+        if next_iter:
+
+            print("NEXT ITER\n\n")
 
             # Query the jobs
-            job_query = self.storage_socket.get_procedures({"id": list(self.data["complete_jobs"].values())})
+            job_query = self.storage_socket.get_procedures({"hash_index": self.data["required_jobs"]})["data"]
+            inv_job_lookup = {v["hash_index"]: v for v in job_query}
 
-            # Figure out the structure
-            job_results = {k: [None] * v for k, v in self.data["update_structure"].items()}
-            job_ids = {k: [None] * v for k, v in self.data["update_structure"].items()}
+            job_results = {}
+            for key, hashes in self.data["job_map"].items():
+                job_results[key] = []
 
-            inv_job_lookup = {v: k for k, v in self.data["complete_jobs"].items()}
+                # Check for history key
+                if key not in self.data["optimization_history"]:
+                    self.data["optimization_history"][key] = []
 
-            for ret in job_query["data"]:
-                job_uid = inv_job_lookup[ret["id"]]
-                value, pos = self.data["job_map"][job_uid]
-                mol_keys = self.storage_socket.get_molecules(
-                    [ret["initial_molecule"], ret["final_molecule"]], index="id")["data"]
+                for hash_index in hashes:
+                    ret = inv_job_lookup[hash_index]
 
-                job_results[value][int(pos)] = (mol_keys[0]["geometry"], mol_keys[1]["geometry"], ret["energies"][-1])
-                job_ids[value][int(pos)] = ret["id"]
+                    # Lookup molecules
+                    mol_keys = self.storage_socket.get_molecules(
+                        [ret["initial_molecule"], ret["final_molecule"]], index="id")["data"]
 
-            # Update the complete_jobs in order
-            for k, v in job_ids.items():
-                if k not in self.data["optimization_history"]:
-                    self.data["optimization_history"][k] = []
-                self.data["optimization_history"][k].extend(v)
+                    job_results[key].append((mol_keys[0]["geometry"], mol_keys[1]["geometry"], ret["energies"][-1]))
+
+                    # Update history
+                    self.data["optimization_history"][key].append(hash_index)
 
             td_api.update_state(self.data["torsiondrive_state"], job_results)
 
@@ -138,6 +156,7 @@ class TorsionDriveService:
 
         # Create new jobs from the current state
         next_jobs = td_api.next_jobs_from_state(self.data["torsiondrive_state"], verbose=True)
+        # print("\n\nNext Jobs:\n" + str(next_jobs))
 
         # All done
         if len(next_jobs) == 0:
@@ -156,19 +175,8 @@ class TorsionDriveService:
 
     def submit_optimization_tasks(self, job_dict):
 
-        # Build out all of the new molecules in a flat dictionary
-        flat_map = {}
-        initial_molecule = json.dumps(self.data["molecule_template"])
-        for v, k in job_dict.items():
-            for num, geom in enumerate(k):
-                mol = json.loads(initial_molecule)
-                mol["geometry"] = geom
-                flat_map[(v, str(num))] = mol
-
-        # Add new molecules
-        self.storage_socket.add_molecules(flat_map)
-
         # Prepare optimization
+        initial_molecule = json.dumps(self.data["molecule_template"])
         meta_packet = json.dumps({
             "meta": {
                 "procedure": "optimization",
@@ -180,50 +188,53 @@ class TorsionDriveService:
 
         hook_template = json.dumps({
             "document": ("service_queue", self.data["id"]),
-            "updates": [["inc", "remaining_jobs", -1], ["set", "complete_jobs", "$task_id"]]
+            "updates": [["inc", "remaining_jobs", -1]]
         })
 
-        job_map = {}
         full_tasks = []
-        complete_jobs = {}
-        for key, mol in flat_map.items():
-            packet = json.loads(meta_packet)
+        job_map = {}
+        for key, geoms in job_dict.items():
+            job_map[key] = []
+            for num, geom in enumerate(geoms):
 
-            # Construct constraints
-            containts = [
-                tuple(x) + (str(y), )
-                for x, y in zip(self.data["torsiondrive_meta"]["dihedral_template"], td_api.grid_id_from_string(key[0]))
-            ]
-            packet["meta"]["keywords"]["constraints"] = {"set": containts}
-            packet["data"] = [mol]
+                # Update molecule
+                packet = json.loads(meta_packet)
 
-            # Turn packet into a full task
-            task, complete, errors = procedures.get_procedure_input_parser("optimization")(
-                self.storage_socket, packet, duplicate_id="id")
+                # Construct constraints
+                containts = [
+                    tuple(x) + (str(y), )
+                    for x, y in zip(self.data["torsiondrive_meta"]["dihedral_template"], td_api.grid_id_from_string(key))
+                ]
+                packet["meta"]["keywords"]["constraints"] = {"set": containts}
 
-            uid = str(uuid.uuid4())
-            if len(complete):
-                # Job is already complete
-                complete_jobs[uid] = complete[0]
-            else:
-                # Create a hook which will update the complete jobs uid
-                hook = json.loads(hook_template)
-                hook["updates"][-1][1] = "complete_jobs." + uid
+                mol = json.loads(initial_molecule)
+                mol["geometry"] = geom
+                packet["data"] = [mol]
 
-                task[0]["hooks"].append(hook)
-                full_tasks.append(task[0])
-            job_map[uid] = key
+                # Turn packet into a full task
+                tasks, complete, errors = procedures.get_procedure_input_parser("optimization")(
+                    self.storage_socket, packet, duplicate_id="hash_index")
+
+                if len(complete):
+                    # Job is already complete
+                    job_map[k].append(complete[0])
+                else:
+                    # Create a hook which will update the complete jobs uid
+                    hook = json.loads(hook_template)
+
+                    tasks[0]["hooks"].append(hook)
+                    job_map[key].append(tasks[0]["hash_index"])
+                    full_tasks.append(tasks[0])
 
         # Create data for next round
-        self.data["update_structure"] = {k: len(v) for k, v in job_dict.items()}
+        # self.data["update_structure"] = {k: len(v) for k, v in job_dict.items()}
         self.data["job_map"] = job_map
+        self.data["required_jobs"] = list({x for v in job_map.values() for x in v})
         self.data["remaining_jobs"] = len(job_map)
-        self.data["complete_jobs"] = complete_jobs
-        # print(json.dumps(required_jobs, indent=2))
 
         # Add tasks to Nanny
         ret = self.queue_socket.submit_tasks(full_tasks)
-        self.data["queue_keys"] = [x[1] for x in ret["data"]]
+        self.data["queue_keys"] = ret["data"]
 
     def finalize(self):
         # Add finalize state
@@ -246,10 +257,8 @@ class TorsionDriveService:
         # print(self.data["final_energies"])
 
         # Pop temporaries
-        del self.data["update_structure"]
         del self.data["job_map"]
         del self.data["remaining_jobs"]
-        del self.data["complete_jobs"]
         del self.data["molecule_template"]
         del self.data["queue_keys"]
         del self.data["torsiondrive_state"]

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -80,7 +80,7 @@ class TorsionDriveService:
         meta["success"] = False
         meta["procedure"] = "torsiondrive"
         meta["program"] = "torsiondrive"
-        meta["hash_index"] = procedures.procedures_util.hash_procedure_keys(keys),
+        meta["hash_index"] = procedures.procedures_util.hash_procedure_keys(keys)
         meta["hash_keys"] = keys
         meta["tag"] = None
 

--- a/qcfractal/storage_sockets/mongo_socket.py
+++ b/qcfractal/storage_sockets/mongo_socket.py
@@ -628,10 +628,13 @@ class MongoSocket:
         ret = {"meta": storage_utils.get_metadata(), "data": []}
 
         # We are querying via id
-        if "_id" in query:
+        if ("_id" in query) or ("id" in query):
             if len(query) > 1:
                 ret["error_description"] = "ID index was provided, cannot use other indices"
                 return ret
+
+            if "id" in query:
+                query["_id"] = query["id"]
 
             if not isinstance(query, (list, tuple)):
                 parsed_query["_id"] = {"$in": query["_id"]}

--- a/qcfractal/storage_sockets/mongo_socket.py
+++ b/qcfractal/storage_sockets/mongo_socket.py
@@ -308,6 +308,26 @@ class MongoSocket:
         ret = {"meta": meta, "data": data}
         return ret
 
+    def locator(self, locator):
+        """Simple query by locator object
+
+        Parameters
+        ----------
+        locator : dict
+            A dictionary with the following fields:
+                - table: The table to query on
+                - index: The index to query on
+                - data: The queries to search for
+                - projection: optional, the projection to apply
+
+        Returns
+        -------
+        dict
+            The requested location
+        """
+        projection = locator.get("projection", None)
+        return self._get_generic({locator["index"]: locator["data"]}, locator["table"], projection=projection)
+
 ### Mongo molecule functions
 
     def add_molecules(self, data):
@@ -844,13 +864,7 @@ class MongoSocket:
 
         now = datetime.datetime.utcnow()
         for queue_id, result_location in updates:
-            update = {
-                "$set": {
-                    "status": "COMPLETE",
-                    "modified_on": now,
-                    "result_location": result_location
-                }
-            }
+            update = {"$set": {"status": "COMPLETE", "modified_on": now, "result_location": result_location}}
             bulk_commands.append(pymongo.UpdateOne({"_id": ObjectId(queue_id)}, update))
 
         if len(bulk_commands) == 0:

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -41,6 +41,7 @@ def test_compute_database(fractal_compute_server):
 
     # Compute SCF/sto-3g
     ret = db.compute("SCF", "STO-3G")
+    assert len(ret["submitted"]) == 3
     fractal_compute_server.objects["queue_nanny"].await_results()
 
     # Query computed results

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -110,7 +110,7 @@ def test_procedure_optimization(fractal_compute_server):
 
     # # Query result and check against out manual pul
     results1 = client.get_procedures({"program": "geometric"})
-    results2 = client.get_procedures({"hash_index": compute_key})
+    results2 = client.get_procedures({"queue_id": compute_key})
 
     for results in [results1, results2]:
         assert len(results) == 1

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -101,7 +101,7 @@ def test_procedure_optimization(fractal_compute_server):
 
     # Get the first submitted job, the second index will be a hash_index
     submitted = r.json()["data"]["submitted"]
-    compute_key = submitted[0][1]
+    compute_key = submitted[0]
 
     # Manually handle the compute
     nanny = fractal_compute_server.objects["queue_nanny"]

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -117,3 +117,12 @@ def test_procedure_optimization(fractal_compute_server):
         assert isinstance(str(results[0]), str)  # Check that repr runs
         assert pytest.approx(-1.117530188962681, 1e-5) == results[0].final_energy()
 
+        # Check pulls
+        traj = results[0].get_trajectory(client, projection={"properties": True})
+        energies = results[0].energies()
+        assert len(traj) == len(energies)
+
+        # Check individual elements
+        for ind in range(len(results[0]._trajectory)):
+            raw_energy = traj[ind]["properties"]["return_energy"]
+            assert pytest.approx(raw_energy, 1.e-5) == energies[ind]

--- a/qcfractal/tests/test_queue.py
+++ b/qcfractal/tests/test_queue.py
@@ -56,7 +56,7 @@ def test_queue_error(fractal_compute_server):
 
     assert len(ret) == 1
     assert "connectivity graph" in ret[0]["error"]
-    fractal_compute_server.objects["storage_socket"].queue_mark_complete([queue_id], index="hash_index")
+    fractal_compute_server.objects["storage_socket"].queue_mark_complete([(queue_id, "completed_pointer")])
 
 
 @testing.using_rdkit
@@ -138,5 +138,5 @@ def test_queue_duplicate_submissions(fractal_compute_server):
     assert ret["queue"][0] == queue_id
 
     # Cleanup
-    fractal_compute_server.objects["storage_socket"].queue_mark_complete([queue_id], index="hash_index")
+    fractal_compute_server.objects["storage_socket"].queue_mark_complete([(queue_id, "output")])
 

--- a/qcfractal/tests/test_queue.py
+++ b/qcfractal/tests/test_queue.py
@@ -42,7 +42,7 @@ def test_queue_error(fractal_compute_server):
     mol_ret = client.add_molecules({"hooh": hooh})
 
     ret = client.add_compute("rdkit", "UFF", "", "energy", "none", mol_ret["hooh"])
-    queue_id = ret["submitted"][0][0]
+    queue_id = ret["submitted"][0]
 
     # Pull out fireworks launchpad and queue nanny
     nanny = fractal_compute_server.objects["queue_nanny"]
@@ -56,7 +56,7 @@ def test_queue_error(fractal_compute_server):
 
     assert len(ret) == 1
     assert "connectivity graph" in ret[0]["error"]
-    fractal_compute_server.objects["storage_socket"].queue_mark_complete([queue_id])
+    fractal_compute_server.objects["storage_socket"].queue_mark_complete([queue_id], index="hash_index")
 
 
 @testing.using_rdkit
@@ -128,15 +128,15 @@ def test_queue_duplicate_submissions(fractal_compute_server):
     assert len(ret["submitted"]) == 1
     assert len(ret["completed"]) == 0
     assert len(ret["queue"]) == 0
-    queue_id = ret["submitted"][0][0]
+    queue_id = ret["submitted"][0]
 
     # Do not compute, add duplicate
     ret = client.add_compute("rdkit", "UFF", "", "energy", "none", mol_ret["he2"])
     assert len(ret["submitted"]) == 0
     assert len(ret["completed"]) == 0
     assert len(ret["queue"]) == 1
-    assert ret["queue"][0][0] == queue_id
+    assert ret["queue"][0] == queue_id
 
     # Cleanup
-    fractal_compute_server.objects["storage_socket"].queue_mark_complete([queue_id])
+    fractal_compute_server.objects["storage_socket"].queue_mark_complete([queue_id], index="hash_index")
 

--- a/qcfractal/tests/test_server.py
+++ b/qcfractal/tests/test_server.py
@@ -105,7 +105,8 @@ def test_result_socket(test_server):
         "options": "default",
         "program": "P1",
         "driver": "energy",
-        "other_data": 5
+        "other_data": 5,
+        "hash_index": 2,
     }
 
     page2 = {
@@ -115,7 +116,8 @@ def test_result_socket(test_server):
         "options": "default",
         "program": "P1",
         "driver": "energy",
-        "other_data": 10
+        "other_data": 10,
+        "hash_index": 4,
     }
     r = requests.post(result_api_addr, json={"meta": {}, "data": [page1, page2]})
     assert r.status_code == 200

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -42,7 +42,7 @@ def test_service_torsiondrive(dask_server_fixture):
     }
 
     ret = client.add_service("torsiondrive", [mol_ret["hooh"]], torsiondrive_options)
-    compute_key = ret[0]
+    compute_key = ret["submitted"][0]
 
     # Manually handle the compute
     nanny = dask_server_fixture.objects["queue_nanny"]

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -206,6 +206,48 @@ class ProcedureHandler(APIHandler):
 
         self.write(ret)
 
+class ResultHandler(APIHandler):
+    """
+    A handler to push and get molecules.
+    """
+
+    def get(self):
+        self.authenticate("read")
+
+        storage = self.objects["storage_socket"]
+        proj = self.json["meta"].get("projection", None)
+
+        ret = storage.get_results(self.json["data"], projection=proj)
+        self.logger.info("GET: Results - {} pulls.".format(len(ret["data"])))
+
+        self.write(ret)
+
+    def post(self):
+        self.authenticate("write")
+
+        storage = self.objects["storage_socket"]
+
+        ret = storage.add_results(self.json["data"])
+        self.logger.info("POST: Results - {} inserted.".format(ret["meta"]["n_inserted"]))
+
+        self.write(ret)
+
+
+class LocatorHandler(APIHandler):
+    """
+    A handler to aquire results from locators
+    """
+
+    def get(self):
+        self.authenticate("read")
+
+        storage = self.objects["storage_socket"]
+
+        ret = storage.locator(self.json["data"])
+        self.logger.info("GET: Locator - {} pulls.".format(len(ret["data"])))
+
+        self.write(ret)
+
     # def post(self):
 
     #     db = self.objects["db_socket"]

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -206,32 +206,6 @@ class ProcedureHandler(APIHandler):
 
         self.write(ret)
 
-class ResultHandler(APIHandler):
-    """
-    A handler to push and get molecules.
-    """
-
-    def get(self):
-        self.authenticate("read")
-
-        storage = self.objects["storage_socket"]
-        proj = self.json["meta"].get("projection", None)
-
-        ret = storage.get_results(self.json["data"], projection=proj)
-        self.logger.info("GET: Results - {} pulls.".format(len(ret["data"])))
-
-        self.write(ret)
-
-    def post(self):
-        self.authenticate("write")
-
-        storage = self.objects["storage_socket"]
-
-        ret = storage.add_results(self.json["data"])
-        self.logger.info("POST: Results - {} inserted.".format(ret["meta"]["n_inserted"]))
-
-        self.write(ret)
-
 
 class LocatorHandler(APIHandler):
     """


### PR DESCRIPTION
## Description
This is a bit of a winding PR that was caught up in our OpenFF requirements and local discussion a few days ago. This PR accomplishes the following:
  - The beginnings of "locator" structures (name in progress): `{table: .., index: .., data: ...}` to give a unique way of finding data later. Implemented on the client, server, and storage socket.
 - Starts a OpenFFWorkflow class to support their requirements (will radically change).
 - Moves away from `hash_indices` as locators (in progress).
 - The queue now holds the location of the resulting data and inserted results maintain a `queue_id` to point back to the queue.
 - The above changes have ripple effects on the rest of the code.

Overall I really like the new scheme where the queue contains a complete record of what happened and these locator objects are quite handy. There are a number of issues with the current changes, but considering the depth of these changes, I would like to merge this in soon and open issues to patch this up later. 

## Todos (perhaps not this PR)
 - [ ] Implement locator returns in more places (and come up with a better name than locator).
 - [ ] Implement a locator which can search the queue and return completed results or the status of the task in question (error, queue depth, etc).
 - [ ] Switch services to use the queue id lookup rather than `hash_index` lookups (will use the above).
 - [ ] Further reduce `hash_index` to a quick search index with object comparisons on duplicate results rather than a full unique index.

## Status
- [x] Ready to go