### PR TITLE
Convert torsion drive job and result fetching to track ID

### DIFF
--- a/qcfractal/storage_sockets/mongo_socket.py
+++ b/qcfractal/storage_sockets/mongo_socket.py
@@ -293,7 +293,7 @@ class MongoSocket:
                 if isinstance(v, (list, tuple)):
                     query[k] = {"$in": v}
 
-            data = list(self._tables[table].find(query))
+            data = list(self._tables[table].find(query, projection=projection))
         else:
             meta["errors"] = "Malformed query"
 
@@ -728,7 +728,7 @@ class MongoSocket:
 
     def get_procedures(self, query, projection=None):
 
-        return self._get_generic(query, "procedures", allow_generic=True)
+        return self._get_generic(query, "procedures", allow_generic=True, projection=projection)
 
     def add_services(self, data):
 


### PR DESCRIPTION
## Description

The torsion drive job and results tracking now searches and tracks
by ID instead of Hash. Partial progress to #60.

## Todos
This is a TODO which needs to be done before merging
  - [x] Fix the Completed

## Questions

In the `submit_optimization_tasks` call, the
check for `completed` jobs will return the ID of the *procedure_id*, but
the rest of the jobs are based on the *task_id*. This is a bug, however,
none of the tests reach this code and none of our own work has tripped
it since #57 introduced a syntax bug which would have been raised
if it ever did. We should try to fix this, but I don't know of a good
test to reach this code outside of production.

## Status
- [x] Ready to go