### PR TITLE
 Ensure torsion drive completed tasks pull from their queue id

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -10,7 +10,7 @@ from qcfractal import testing
 
 def _run_command(folder, script):
     # Get the examples director
-    root = os.path.abspath(os.path.dirname(__file__)) 
+    root = os.path.abspath(os.path.dirname(__file__))
     example_path = os.path.join(root, folder)
     os.chdir(example_path)
 
@@ -20,7 +20,7 @@ def _run_command(folder, script):
     except sp.CalledProcessError as e:
         output = e.output
         error = True
-    
+
     os.chdir(root)
     if error:
         msg = "Example {} failed. Output as follows\n\n".format(folder)
@@ -38,4 +38,4 @@ def test_fireworks_server_example():
 
     assert _run_command("fireworks_server", "run_fireworks_example.sh")
 
-        
+

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -61,8 +61,8 @@ using_unix = pytest.mark.skipif(os.name.lower() != 'posix', reason='Not on Unix 
                                                                    'assuming Bash is not present')
 
 
-# More complex than a simple top-level merge {**x, **y} which does not handle nested dict
 def recursive_dict_merge(base_dict, dict_to_merge_in):
+    """Recursive merge for more complex than a simple top-level merge {**x, **y} which does not handle nested dict"""
     for k, v in dict_to_merge_in.items():
         if (k in base_dict and isinstance(base_dict[k], dict)
                 and isinstance(dict_to_merge_in[k], Mapping)):
@@ -166,7 +166,6 @@ def test_server(request):
             yield server
 
 
-@using_dask
 @pytest.fixture(scope="module")
 def dask_server_fixture(request):
     """
@@ -206,7 +205,6 @@ def dask_server_fixture(request):
             client.close()
 
 
-@using_fireworks
 @pytest.fixture(scope="module")
 def fireworks_server_fixture(request):
     """
@@ -243,8 +241,6 @@ def fireworks_server_fixture(request):
     logging.basicConfig(level=None, filename=None)
 
 
-# @pytest.fixture(scope="module", params=["dask"])
-# @pytest.fixture(scope="module", params=["fireworks"])
 @pytest.fixture(scope="module", params=["dask", "fireworks"])
 def fractal_compute_server(request):
     if request.param == "dask":

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -126,3 +126,8 @@ def test_procedure_optimization(fractal_compute_server):
         for ind in range(len(results[0]._trajectory)):
             raw_energy = traj[ind]["properties"]["return_energy"]
             assert pytest.approx(raw_energy, 1.e-5) == energies[ind]
+
+    # Check that duplicates are caught
+    r = requests.post(fractal_compute_server.get_address("task_scheduler"), json=compute)
+    assert r.status_code == 200
+    assert len(r.json()["data"]["completed"]) == 1

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -6,31 +6,30 @@ from qcfractal import testing
 # Pytest Fixture import
 from qcfractal.testing import dask_server_fixture
 import pytest
+import copy
+from collections import Mapping
 
 import qcfractal.interface as portal
 
 
-### Tests the compute queue stack
 @testing.using_torsiondrive
 @testing.using_geometric
 @testing.using_rdkit
-def test_service_torsiondrive(dask_server_fixture):
-
-
-    ### Maybe turn the computation into a fixture and then query multiple results
-    ### See test authentication
+@pytest.fixture(scope="module")
+def torsiondrive_fixture(dask_server_fixture):
 
     client = portal.FractalClient(dask_server_fixture.get_address())
 
     # Add a HOOH
     hooh = portal.data.get_molecule("hooh.json")
     mol_ret = client.add_molecules({"hooh": hooh})
+    default_grid_spacing = 90
 
     # Geometric options
     torsiondrive_options = {
         "torsiondrive_meta": {
            "dihedrals": [[0, 1, 2, 3]],
-           "grid_spacing": [90]
+           "grid_spacing": [default_grid_spacing]
         },
         "optimization_meta": {
             "program": "geometric",
@@ -45,28 +44,62 @@ def test_service_torsiondrive(dask_server_fixture):
         },
     }
 
-    ret = client.add_service("torsiondrive", [mol_ret["hooh"]], torsiondrive_options)
+    def spin_up_test(grid_spacing=default_grid_spacing, **keyword_augments):
+        instance_options = copy.deepcopy(torsiondrive_options)
+        instance_options["torsiondrive_meta"]["grid_spacing"] = [grid_spacing]
+
+        # More complex than a simple top-level merge {**x} which does not handle nested dict
+        def recursive_dict_merge(base_dict, dict_to_merge_in):
+            for k, v in dict_to_merge_in.items():
+                if (k in base_dict and isinstance(base_dict[k], dict)
+                        and isinstance(dict_to_merge_in[k], Mapping)):
+                    recursive_dict_merge(base_dict[k], dict_to_merge_in[k])
+                else:
+                    base_dict[k] = dict_to_merge_in[k]
+        # instance_options = {**instance_options, **keyword_augments}
+        recursive_dict_merge(instance_options, keyword_augments)
+        return client.add_service("torsiondrive", [mol_ret["hooh"]], instance_options)
+
+    yield spin_up_test, dask_server_fixture, client
+
+
+def test_service_torsiondrive(torsiondrive_fixture):
+    """"Ensure torsiondrive works as intended gives the correct result"""
+    # This test does not ensure de-duplication of work,
+    spin_up_test, server_fixture, client = torsiondrive_fixture
+
+    ret = spin_up_test()
     compute_key = ret["submitted"][0]
 
-    # Manually handle the compute
-    nanny = dask_server_fixture.objects["queue_nanny"]
-    nanny.await_services(max_iter=12)
+    nanny = server_fixture.objects["queue_nanny"]
+    nanny.await_services(max_iter=5)
     assert len(nanny.list_current_tasks()) == 0
 
     # Get a TorsionDriveORM result and check data
     result = client.get_procedures({"procedure": "torsiondrive"})[0]
-    # assert isinstance(str(result), str)  # Check that repr runs
+    assert isinstance(str(result), str)  # Check that repr runs
 
-    # assert pytest.approx(0.002597541340221565, 1e-5) == result.final_energies(0)
-    # assert pytest.approx(0.000156553761859276, 1e-5) == result.final_energies(90)
-    # assert pytest.approx(0.000156553761859271, 1e-5) == result.final_energies(-90)
-    # assert pytest.approx(0.000753492556057886, 1e-5) == result.final_energies(180)
+    assert pytest.approx(0.002597541340221565, 1e-5) == result.final_energies(0)
+    assert pytest.approx(0.000156553761859276, 1e-5) == result.final_energies(90)
+    assert pytest.approx(0.000156553761859271, 1e-5) == result.final_energies(-90)
+    assert pytest.approx(0.000753492556057886, 1e-5) == result.final_energies(180)
 
-    print("\n\n\n\n\n")
-    torsiondrive_options["torsiondrive_meta"]["something"] = ""
-    # torsiondrive_options["torsiondrive_meta"]["grid_spacing"] = [60]
-    ret = client.add_service("torsiondrive", [mol_ret["hooh"]], torsiondrive_options)
 
+def test_service_torsiondrive_duplicates(torsiondrive_fixture):
+    """Ensure that duplicates are properly caught and yield the same results without calculation"""
+    # This test does not ensure accuracy, there is another test for that
+    spin_up_test, server_fixture, client = torsiondrive_fixture
+    # Run the test without modifications
+    _ = spin_up_test()
+    nanny = server_fixture.objects["queue_nanny"]
     nanny.await_services(max_iter=5)
-
-
+    # Ensure the job finished
+    assert len(nanny.list_current_tasks()) == 0
+    # Augment the input for torsion drive to yield a new hash procedure hash,
+    # but not a new task set
+    _ = spin_up_test(torsiondrive_meta={"meaningless_entry_to_change_hash": "Waffles!"})
+    nanny.await_services(max_iter=5)
+    procedures = client.get_procedures({"procedure": "torsiondrive"})
+    assert len(procedures) == 2  # Make sure only 2 procedures are yielded
+    base_run, duplicate_run = procedures
+    assert base_run._optimization_history == duplicate_run._optimization_history

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -11,11 +11,13 @@ import copy
 import qcfractal.interface as portal
 
 
-@testing.using_torsiondrive
-@testing.using_geometric
-@testing.using_rdkit
 @pytest.fixture(scope="module")
 def torsiondrive_fixture(dask_server_fixture):
+
+    # Cannot use this fixture without these services. Also cannot use `mark` and `fixture` decorators
+    pytest.importorskip("torsiondrive")
+    pytest.importorskip("geometric")
+    pytest.importorskip("rdkit")
 
     client = portal.FractalClient(dask_server_fixture.get_address())
 
@@ -60,7 +62,8 @@ def torsiondrive_fixture(dask_server_fixture):
 
 def test_service_torsiondrive(torsiondrive_fixture):
     """"Ensure torsiondrive works as intended gives the correct result"""
-    # This test does not ensure de-duplication of work,
+    # This test does not ensure de-duplication of work
+    # Test will be skipped if missing RDKit, Geomertic, and TorsionDrive from fixture
     spin_up_test, client = torsiondrive_fixture
 
     ret = spin_up_test()
@@ -79,6 +82,7 @@ def test_service_torsiondrive(torsiondrive_fixture):
 def test_service_torsiondrive_duplicates(torsiondrive_fixture):
     """Ensure that duplicates are properly caught and yield the same results without calculation"""
     # This test does not ensure accuracy, there is another test for that
+    # Test will be skipped if missing RDKit, Geomertic, and TorsionDrive from fixture
     spin_up_test, client = torsiondrive_fixture
     # Run the test without modifications
     _ = spin_up_test()

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -16,6 +16,10 @@ import qcfractal.interface as portal
 @testing.using_rdkit
 def test_service_torsiondrive(dask_server_fixture):
 
+
+    ### Maybe turn the computation into a fixture and then query multiple results
+    ### See test authentication
+
     client = portal.FractalClient(dask_server_fixture.get_address())
 
     # Add a HOOH
@@ -46,14 +50,23 @@ def test_service_torsiondrive(dask_server_fixture):
 
     # Manually handle the compute
     nanny = dask_server_fixture.objects["queue_nanny"]
-    nanny.await_services(max_iter=5)
+    nanny.await_services(max_iter=12)
     assert len(nanny.list_current_tasks()) == 0
 
     # Get a TorsionDriveORM result and check data
     result = client.get_procedures({"procedure": "torsiondrive"})[0]
-    assert isinstance(str(result), str)  # Check that repr runs
+    # assert isinstance(str(result), str)  # Check that repr runs
 
-    assert pytest.approx(0.002597541340221565, 1e-5) == result.final_energies(0)
-    assert pytest.approx(0.000156553761859276, 1e-5) == result.final_energies(90)
-    assert pytest.approx(0.000156553761859271, 1e-5) == result.final_energies(-90)
-    assert pytest.approx(0.000753492556057886, 1e-5) == result.final_energies(180)
+    # assert pytest.approx(0.002597541340221565, 1e-5) == result.final_energies(0)
+    # assert pytest.approx(0.000156553761859276, 1e-5) == result.final_energies(90)
+    # assert pytest.approx(0.000156553761859271, 1e-5) == result.final_energies(-90)
+    # assert pytest.approx(0.000753492556057886, 1e-5) == result.final_energies(180)
+
+    print("\n\n\n\n\n")
+    torsiondrive_options["torsiondrive_meta"]["something"] = ""
+    # torsiondrive_options["torsiondrive_meta"]["grid_spacing"] = [60]
+    ret = client.add_service("torsiondrive", [mol_ret["hooh"]], torsiondrive_options)
+
+    nanny.await_services(max_iter=5)
+
+


### PR DESCRIPTION
## Description
This makes sure the `job_map` for new Torsion Drive service tasks
reference the same table in the storage layer rather than different
layers.

A new bug was identified for a rare corner case where a secondary
service submits jobs after the initial query from a primary service, but
before the tasks from the primary are submitted to the queue. We have
elected not to fix that in this change, but will raise a helpful error
if someone ever actually gets it.

Fixes #62 

Credit to @dgasmith for coming up with the main fix.

Once this is merged in, we should make a pair of new issues:
1. Fix the duplicate entry bug mentioned above (easier)
2. Generalize the service submission process since we will have to do that anyways going forward so as to not have to fix this for every new service (harder)

## Status
- [x] Ready to go