### PR TITLE
CI: Fixes python version 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ matrix:
         - PYTHON_VER=3.6
         - ENVIRON=FIREWORKS
 
-    - os: linux
-      python: 3.6
-      env:
-        - PYTHON_VER=3.7
-        - ENVIRON=FIREWORKS
+#    - os: linux
+#      python: 3.7
+#      env:
+#        - PYTHON_VER=3.7
+#        - ENVIRON=FIREWORKS
 
     - os: linux
       python: 3.6
@@ -73,11 +73,11 @@ install:
     # Create test environment for package
   - |
     if [ $ENVIRON == "DASK" ]; then
-      conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/dask.yaml
+      python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/dask.yaml
     elif [ $ENVIRON == "FIREWORKS" ]; then
-      conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/fireworks.yaml
+      python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/fireworks.yaml
     elif [ $ENVIRON == "OPENFF" ]; then
-      conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/openff.yaml
+      python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/openff.yaml
     else
       echo "ERROR: No match for ENVIRON ($ENVIRON)."
       exit 1

--- a/devtools/conda-envs/dask.yaml
+++ b/devtools/conda-envs/dask.yaml
@@ -10,6 +10,7 @@ dependencies:
   - distributed
 
     # Base depends
+  - python
   - numpy
   - pandas
   - mongodb

--- a/devtools/conda-envs/fireworks.yaml
+++ b/devtools/conda-envs/fireworks.yaml
@@ -6,6 +6,7 @@ dependencies:
   - psi4=1.2
 
     # Base depends
+  - python
   - numpy
   - pandas
   - mongodb

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -12,6 +12,7 @@ dependencies:
   - distributed
 
     # Base depends
+  - python
   - numpy
   - pandas
   - mongodb

--- a/devtools/scripts/conda_env.py
+++ b/devtools/scripts/conda_env.py
@@ -1,0 +1,28 @@
+import argparse
+import os
+import sys
+import subprocess as sp
+
+# Args
+parser = argparse.ArgumentParser(description='Creates a conda environment from file for a given Python version.')
+parser.add_argument('-n', '--name', type=str, nargs=1,
+                    help='The name of the created Python environment')
+parser.add_argument('-p', '--python', type=str, nargs=1,
+                    help='The version of the created Python environment')
+parser.add_argument('conda_file', nargs='*',
+                    help='The file for the created Python environment')
+
+args = parser.parse_args()
+
+with open(args.conda_file[0], "r") as handle:
+    script = handle.read()
+
+tmp_file = "tmp_env.yaml"
+script = script.replace("- python", "- python {}*".format(args.python[0]))
+
+with open(tmp_file, "w") as handle:
+    handle.write(script)
+
+conda_path = os.environ["CONDA_EXE"]
+sp.call("{} env create -n {} -f {}".format(conda_path, args.name[0], tmp_file), shell=True)
+os.unlink(tmp_file)


### PR DESCRIPTION
## Description
Previous uses of `conda env create` were not pinning a Python version so only 3.6 was ever tested. A script has been built to overcome this issue. Issue brought up by @loriab.

Python 3.7 cannot be satisfied at the moment as neither RDKit nor Psi4 are built with Py3.7 at the moment. 

## Status
- [x] Ready to go