### PR TITLE
[WIP] add optimization service to openffworkflow 

### DIFF
--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -180,7 +180,7 @@ class OpenFFWorkflow(Collection):
 
     def add_optimize(self, fragment_id, data, provenance={}):
         """
-        Adds a new fragment to the workflow along with the associated torsiondrives required.
+        Adds a new fragment to the workflow along with the associated optimization required.
 
         Parameters
         ----------
@@ -188,7 +188,7 @@ class OpenFFWorkflow(Collection):
             The tag associated with fragment. In general this should be the canonical isomeric
             explicit hydrogen mapped SMILES tag for this fragment.
         data : dict
-            A dictionary of label : {intial_molecule, grid_spacing, dihedrals} keys.
+            A dictionary of label : {intial_molecule, constraints} keys.
 
         provenance : dict, optional
             The provenance of the fragments creation
@@ -199,8 +199,7 @@ class OpenFFWorkflow(Collection):
         data = {
            "label1": {
                 "initial_molecule": ptl.data.get_molecule("butane.json"),
-                "grid_spacing": [60],
-                "dihedrals": [[0, 2, 3, 1]],
+                "constraints" : {'scan': [('dihedral', '1', '5', '6', '7', '110.0', '150.0', '3')]}
             },
             ...
         }
@@ -224,7 +223,7 @@ class OpenFFWorkflow(Collection):
                 optimization_meta["optimization_meta"][k] = packet[k]
 
             # Get hash of optimization
-            ret = self.client.add_service("optimization", [packet["initial_molecule"]], optimization_meta)
+            ret = self.client.add_procedure("optimization", "geoemetric", optimization_meta, [packet["initial_molecule"]])
 
             hash_lists = []
             [hash_lists.extend(x) for x in ret.values()]

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -199,8 +199,9 @@ class OpenFFWorkflow(Collection):
             optimization_meta["optimization_meta"][k] = packet[k]
 
         optimization_meta["keywords"] = optimization_meta.pop("optimization_meta")
+        program = optimization_meta["keywords"]["program"]
         # Get hash of optimization
-        ret = self.client.add_procedure("optimization", "geometric", optimization_meta, [packet["initial_molecule"]])
+        ret = self.client.add_procedure("optimization", program, optimization_meta, [packet["initial_molecule"]])
 
         return ret
 

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -141,7 +141,7 @@ def test_compute_openffworkflow(fractal_compute_server):
         },
         "optimization_static_options": {
             "optimization_meta": {
-                "program": "rdkit",
+                "program": "geometric",
                 "coordsys": "tric",
             },
             "qc_meta": {

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -159,12 +159,13 @@ def test_compute_openffworkflow(fractal_compute_server):
     hooh = portal.data.get_molecule("hooh.json")
     fragment_input = {
         "label1": {
+            "type": "torsiondrive_input",
             "initial_molecule": hooh.to_json(),
             "grid_spacing": [120],
             "dihedrals": [[0, 1, 2, 3]],
         },
     }
-    wf.add_torsiondrive("HOOH", fragment_input, provenance={})
+    wf.add_fragment("HOOH", fragment_input, provenance={})
     assert set(wf.list_fragments()) == {"HOOH"}
     fractal_compute_server.await_services(max_iter=5)
 
@@ -182,12 +183,13 @@ def test_compute_openffworkflow(fractal_compute_server):
 
     fragment_input = {
         "label1": {
+            "type": "torsiondrive_input",
             "initial_molecule": butane.to_json(),
             "grid_spacing": [90],
             "dihedrals": [[0, 2, 3, 1]],
         },
     }
-    wf.add_torsiondrive(butane_id, fragment_input, provenance={})
+    wf.add_fragment(butane_id, fragment_input, provenance={})
     assert set(wf.list_fragments()) == {butane_id, "HOOH"}
 
     final_energies = wf.list_final_energies()
@@ -197,12 +199,13 @@ def test_compute_openffworkflow(fractal_compute_server):
 
     optimization_input = {
         "label2": {
+            "type": "optimization_input",
             "initial_molecule": butane.to_json(),
             "constraints": {'scan': [('dihedral', '0', '2', '3', '1', '0', '120', '4')]}
         }
     }
 
-    wf.add_optimize(butane_id, optimization_input, provenance={})
+    wf.add_fragment(butane_id, optimization_input, provenance={})
     fractal_compute_server.await_services(max_iter=5)
 
     final_energies = wf.list_final_energies()

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -155,7 +155,7 @@ def test_compute_openffworkflow(fractal_compute_server):
     }
     wf = portal.collections.OpenFFWorkflow("Workflow1", client=client, options=openff_workflow_options)
 
-    # Add a fragment and wait for the compute
+    # # Add a fragment and wait for the compute
     hooh = portal.data.get_molecule("hooh.json")
     fragment_input = {
         "label1": {
@@ -181,7 +181,7 @@ def test_compute_openffworkflow(fractal_compute_server):
         "label2": {
             "type": "optimization_input",
             "initial_molecule": hooh.to_json(),
-            "constraints": {'scan': [('dihedral', '0', '1', '2', '3', '0', '180', '2')]}
+            "constraints": {'set': [('dihedral', '1', '2', '3', '4', '0')]}
         }
     }
 


### PR DESCRIPTION
## Description
This PR adds an splits up `add_fragment()` to `add_torsiondrive()` and `add_optimize()`. This will allow us to submit general and constrained geometry optimization jobs. This is needed for running limited torsion scans for rings and  double bonds.  

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Changed `_required_fields` `torsiondrive_meta` and `optimization_meta` to `torsiondrive_static_options` and `optimization_static_options`. An example corresponding `workflow.json` lives [here](https://github.com/openforcefield/fragmenter/blob/workflow/examples/example_workflow.json)
  - [x] replaces `add_fragment()` with `add_torsiondrive()`
  - [x] adds `add_optimize()` to submit geometric jobs directly without `torsiondrive`
  - [ ] build out an optimization service

## Questions
- [ ] @dgasmith,  I still need to add an `optimize` service. Should I model it on [`torsiondrive_service`](https://github.com/MolSSI/QCFractal/blob/master/qcfractal/services/torsiondrive_service.py)?

## Status
- [ ] Ready to go