### PR TITLE
Task/Service Error queries

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -444,4 +444,18 @@ class FractalClient(object):
         else:
             return r.json()["data"]
 
+    def check_services(self, query, return_full=False):
+
+        payload = {
+            "meta": {},
+            "data": query
+        }
+
+        r = self._request("get", "service_queue", payload)
+
+        if return_full:
+            return r.json()
+        else:
+            return r.json()["data"]
+
     # Def add_service

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -29,6 +29,7 @@ class FractalClient(object):
             FractalServer was not provided a SSL certificate and defaults back to self-signed
             SSL keys.
         """
+
         if "http" not in address:
             address = "https://" + address
 
@@ -423,6 +424,34 @@ class FractalClient(object):
         else:
             return r.json()["data"]
 
+    def check_tasks(self, query, return_full=False):
+        """Checks the status of tasks in the Fractal queue.
+
+        Parameters
+        ----------
+        query : dict
+            A query to find tasks
+        return_full : bool, optional
+            Returns the full JSON return if True
+
+        Returns
+        -------
+        list of dict
+            A dictionary of each match that contains the current status
+            and, if an error has occured, the error message.
+
+        >>> client.check_tasks({"id": "5bd35af47b878715165f8225"})
+        [{"status": "WAITING"}]
+        """
+        payload = {"meta": {}, "data": query}
+
+        r = self._request("get", "task_queue", payload)
+
+        if return_full:
+            return r.json()
+        else:
+            return r.json()["data"]
+
     def add_service(self, service, data, options, return_full=False):
 
         # Always a list
@@ -445,11 +474,26 @@ class FractalClient(object):
             return r.json()["data"]
 
     def check_services(self, query, return_full=False):
+        """Checks the status of services in the Fractal queue.
 
-        payload = {
-            "meta": {},
-            "data": query
-        }
+        Parameters
+        ----------
+        query : dict
+            A query to find services
+        return_full : bool, optional
+            Returns the full JSON return if True
+
+        Returns
+        -------
+        list of dict
+            A dictionary of each match that contains the current status
+            and, if an error has occured, the error message.
+
+        >>> client.check_services({"id": "5bd35af47b878715165f8225"})
+        [{"status": "RUNNING"}]
+        """
+
+        payload = {"meta": {}, "data": query}
 
         r = self._request("get", "service_queue", payload)
 
@@ -457,5 +501,3 @@ class FractalClient(object):
             return r.json()
         else:
             return r.json()["data"]
-
-    # Def add_service

--- a/qcfractal/queue/dask_adapter.py
+++ b/qcfractal/queue/dask_adapter.py
@@ -13,7 +13,7 @@ def _get_future(future):
         return future.result()
     else:
         msg = "".join(traceback.format_exception(TypeError, future.exception(), future.traceback()))
-        ret = {"success": False, "error": msg}
+        ret = {"success": False, "error_message": msg}
         return ret
 
 

--- a/qcfractal/queue/fireworks_adapter.py
+++ b/qcfractal/queue/fireworks_adapter.py
@@ -68,7 +68,7 @@ class FireworksAdapter:
             else:
                 blob = tmp_data["action"]["stored_data"]["_task"]["args"][0]
                 msg = tmp_data["action"]["stored_data"]["_exception"]["_stacktrace"]
-                blob["error"] = msg
+                blob["error_message"] = msg
                 blob["success"] = False
                 ret[key] = (blob, parser, hooks)
 

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -38,6 +38,19 @@ class TaskQueueHandler(APIHandler):
 
         self.write(ret)
 
+    def get(self):
+        """Posts new services to the service queue
+        """
+        self.authenticate("read")
+
+        # Grab objects
+        storage = self.objects["storage_socket"]
+
+        projection = {x: True for x in ["status", "error_message", "tag"]}
+        ret = storage.get_services(self.json["data"], projection=projection)
+
+        self.write(ret)
+
 
 class ServiceQueueHandler(APIHandler):
     """
@@ -96,7 +109,7 @@ class ServiceQueueHandler(APIHandler):
         # Grab objects
         storage = self.objects["storage_socket"]
 
-        projection = {x: True for x in ["status", "error_message", "tag", "created_on", "modified_on"]}
+        projection = {x: True for x in ["status", "error_message", "tag"]}
         ret = storage.get_services(self.json["data"], projection=projection)
 
         self.write(ret)

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -47,7 +47,7 @@ class TaskQueueHandler(APIHandler):
         storage = self.objects["storage_socket"]
 
         projection = {x: True for x in ["status", "error_message", "tag"]}
-        ret = storage.get_services(self.json["data"], projection=projection)
+        ret = storage.get_queue(self.json["data"], projection=projection)
 
         self.write(ret)
 
@@ -141,7 +141,11 @@ class QueueManagerHandler(APIHandler):
                 # Failed task
                 else:
                     if "error" in result:
+                        logger.warning("Found old-style error field, please change to 'error_message'. Will be deprecated")
                         error = result["error"]
+                        result["error_message"] = error
+                    elif "error_message" in result:
+                        error = result["error_message"]
                     else:
                         error = "No error supplied"
 

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -88,6 +88,18 @@ class ServiceQueueHandler(APIHandler):
 
         self.write(ret)
 
+    def get(self):
+        """Posts new services to the service queue
+        """
+        self.authenticate("read")
+
+        # Grab objects
+        storage = self.objects["storage_socket"]
+
+        projection = {x: True for x in ["status", "error_message", "tag", "created_on", "modified_on"]}
+        ret = storage.get_services(self.json["data"], projection=projection)
+
+        self.write(ret)
 
 class QueueManagerHandler(APIHandler):
     """

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -121,7 +121,7 @@ class FractalServer:
 
         # Handle SSL
         ssl_ctx = None
-        client_verify = True
+        self.client_verify = True
         if ssl_options is None:
             self.logger.warning("No SSL files passed in, generating self-signed SSL certificate.")
             self.logger.warning("Clients must use `verify=False` when connecting.\n")
@@ -148,7 +148,7 @@ class FractalServer:
             import os
             atexit.register(os.remove, cert_name)
             atexit.register(os.remove, key_name)
-            client_verify = False
+            self.client_verify = False
         elif ssl_options is False:
             ssl_ctx = None
         elif isinstance(ssl_options, dict):
@@ -197,7 +197,7 @@ class FractalServer:
                 raise ValueError("Cannot yet use local security with a internal QueueManager")
 
             # Add the socket to passed args
-            client = interface.FractalClient(self._address, verify=client_verify)
+            client = interface.FractalClient(self._address, verify=self.client_verify)
             self.objects["queue_manager"] = queue.QueueManager(
                 client, queue_socket, loop=loop, logger=self.logger, cluster="FractalServer")
 
@@ -339,7 +339,7 @@ class FractalServer:
                 data = obj.get_json()
             except Exception as e:
                 data["status"] = "ERROR"
-                data["error_message"] = "Service Build and Iterate Error:\n" + traceback.format_exc()
+                data["error_message"] = "FractalServer Service Build and Iterate Error:\n" + traceback.format_exc()
                 finished = False
 
             self.storage.update_services([(data["id"], data)])

--- a/qcfractal/storage_sockets/mongo_socket.py
+++ b/qcfractal/storage_sockets/mongo_socket.py
@@ -884,7 +884,7 @@ class MongoSocket:
             update = {
                 "$set": {
                     "status": "ERROR",
-                    "error": msg,
+                    "error_message": msg,
                     "modified_on": dt,
                 }
             }

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -350,6 +350,8 @@ def dask_server_fixture(request):
 
             client.close()
 
+        cluster.close()
+
 
 @pytest.fixture(scope="module")
 def fireworks_server_fixture(request):

--- a/qcfractal/tests/test_queue.py
+++ b/qcfractal/tests/test_queue.py
@@ -31,7 +31,7 @@ def test_queue_error(fractal_compute_server):
     ret = db.get_queue({"status": "ERROR"})["data"]
 
     assert len(ret) == 1
-    assert "connectivity graph" in ret[0]["error"]
+    assert "connectivity graph" in ret[0]["error_message"]
     fractal_compute_server.objects["storage_socket"].queue_mark_complete([(queue_id, "completed_pointer")])
 
 

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -95,3 +95,17 @@ def test_service_torsiondrive_duplicates(torsiondrive_fixture):
     assert len(procedures) == 2  # Make sure only 2 procedures are yielded
     base_run, duplicate_run = procedures
     assert base_run._optimization_history == duplicate_run._optimization_history
+
+def test_service_iterate_error(torsiondrive_fixture):
+    """Ensure errors are caught and logged when iterating serivces"""
+
+    spin_up_test, client = torsiondrive_fixture
+
+    # Run the test without modifications
+    ret = spin_up_test(grid_spacing="waffles_crasher")
+
+    status = client.check_services({"hash_index": ret["submitted"][0]})
+    assert len(status) == 1
+
+    assert status[0]["status"] == "ERROR"
+    assert "Service Build" in status[0]["error_message"]

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -30,8 +30,8 @@ def torsiondrive_fixture(dask_server_fixture):
     # Geometric options
     torsiondrive_options = {
         "torsiondrive_meta": {
-           "dihedrals": [[0, 1, 2, 3]],
-           "grid_spacing": [default_grid_spacing]
+            "dihedrals": [[0, 1, 2, 3]],
+            "grid_spacing": [default_grid_spacing]
         },
         "optimization_meta": {
             "program": "geometric",
@@ -96,6 +96,7 @@ def test_service_torsiondrive_duplicates(torsiondrive_fixture):
     base_run, duplicate_run = procedures
     assert base_run._optimization_history == duplicate_run._optimization_history
 
+
 def test_service_iterate_error(torsiondrive_fixture):
     """Ensure errors are caught and logged when iterating serivces"""
 
@@ -109,3 +110,18 @@ def test_service_iterate_error(torsiondrive_fixture):
 
     assert status[0]["status"] == "ERROR"
     assert "Service Build" in status[0]["error_message"]
+
+
+def test_service_torsiondrive_compute_error(torsiondrive_fixture):
+    """Ensure errors are caught and logged when iterating serivces"""
+
+    spin_up_test, client = torsiondrive_fixture
+
+    # Run the test without modifications
+    ret = spin_up_test(qc_meta={"method": "waffles_crasher"})
+
+    status = client.check_services({"hash_index": ret["submitted"][0]})
+    assert len(status) == 1
+
+    assert status[0]["status"] == "ERROR"
+    assert "All tasks" in status[0]["error_message"]


### PR DESCRIPTION
## Description
The client is now able to provide the status of any job along with possible error messages. This interface will evolve significantly over time, but presents a working example. Items added:
 - `client.check_tasks` to find status of tasks
 - `client.check_serivces` to find the status of services
 - Error message field renamed from "error" to "error_message" to be better reflect the intent.

## Status
- [x] Ready to go