### PR TITLE
Docs: Update v0.3.0 changelog

### DIFF
--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -2,7 +2,7 @@ name: qcfractal-docs
 channels:
     - defaults
 dependencies:
-    - python=3
+    - python=3.6
     - numpy
     - sphinx
     - sphinx_rtd_theme

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,19 +13,34 @@ Enhancements
 Bug Fixes
 +++++++++
 
-X.Y.0 / 2018-11-DD
+0.3.0a / 2018-11-02
 -------------------
 
-This is potentially the first beta for QCFractal.
+This is the third alpha release of QCFractal focusing on a command line
+interface and the ability to have multiple queues interacting with a central
+server.
 
 New Features
 ++++++++++++
+- (:pr:`72`) Queues are no longer required of FractalServer instances, now separate QueueManager instances can be created that push and pull tasks to the server.
+- (:pr:`80`) A `Parsl <http://parsl-project.org>`_ queue manager was written.
+- (:pr:`75`) CLI's have been added for the `qcfractal-server` and `qcfractal-manager` instances.
+- (:pr:`83`) The status of server tasks and services can now be queried from a FractalClient.
+- (:pr:`82`) OpenFF Workflows can now add single optimizations for fragments.
 
 Enhancements
 ++++++++++++
 
+- (:pr:`74`) The documentation now has flowcharts showing task and service pathways through the code.
+- (:pr:`73`) Collection `.data` attributes are now typed and validated with pydantic.
+- (:pr:`85`) The CLI has been enhanced to cover additional features such as `queue-manager` ping time.
+- (:pr:`84`) QCEngine 0.4.0 and geomeTRIC 0.9.1 versions are now compatible with QCFractal.
+
+
 Bug Fixes
 +++++++++
+
+- (:pr:`92`) Fixes an error with query OpenFFWorkflows.
 
 0.2.0a / 2018-10-02
 -------------------


### PR DESCRIPTION
Provides the v0.3.0 Changelog. Also attempts to fix RTD builds by pinning to Py3.6 which passes on my laptop. @Lnaden seems to be an issue with Pydantic if you have ideas.

<details><summary>RTD Errors</summary>
<p>

Running Sphinx v1.8.1

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/validators.py", line 262, in find_validators
    if issubclass(type_, val_type):
TypeError: issubclass() arg 1 must be a class

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/docs/source/conf.py", line 13, in <module>
    import qcfractal
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/__init__.py", line 5, in <module>
    from . import interface
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/__init__.py", line 5, in <module>
    from . import collections
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/__init__.py", line 2, in <module>
    from .biofragment import BioFragment
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/biofragment.py", line 15, in <module>
    class BioFragment(Collection):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/biofragment.py", line 43, in BioFragment
    class DataModel(Collection.DataModel):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/main.py", line 124, in __new__
    config=config,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 107, in infer
    schema=schema,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 87, in __init__
    self.prepare()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 135, in prepare
    self._populate_sub_fields()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 241, in _populate_sub_fields
    self.key_field = self._create_sub_type(self.type_.__args__[0], 'key_' + self.name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 257, in _create_sub_type
    model_config=self.model_config,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 87, in __init__
    self.prepare()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 136, in prepare
    self._populate_validators()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 266, in _populate_validators
    self.model_config.arbitrary_types_allowed)),
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/validators.py", line 265, in find_validators
    raise RuntimeError(f'error checking inheritance of {type_!r} (type: {display_as_type(type_)})') from e
RuntimeError: error checking inheritance of ~KT (type: KT)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 303, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/application.py", line 201, in __init__
    self.config = Config.read(self.confdir, confoverrides or {}, self.tags)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/config.py", line 203, in read
    namespace = eval_config_file(filename, tags)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/config.py", line 380, in eval_config_file
    raise ConfigError(msg % traceback.format_exc())
sphinx.errors.ConfigError: There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/validators.py", line 262, in find_validators
    if issubclass(type_, val_type):
TypeError: issubclass() arg 1 must be a class

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/docs/source/conf.py", line 13, in <module>
    import qcfractal
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/__init__.py", line 5, in <module>
    from . import interface
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/__init__.py", line 5, in <module>
    from . import collections
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/__init__.py", line 2, in <module>
    from .biofragment import BioFragment
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/biofragment.py", line 15, in <module>
    class BioFragment(Collection):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/biofragment.py", line 43, in BioFragment
    class DataModel(Collection.DataModel):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/main.py", line 124, in __new__
    config=config,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 107, in infer
    schema=schema,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 87, in __init__
    self.prepare()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 135, in prepare
    self._populate_sub_fields()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 241, in _populate_sub_fields
    self.key_field = self._create_sub_type(self.type_.__args__[0], 'key_' + self.name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 257, in _create_sub_type
    model_config=self.model_config,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 87, in __init__
    self.prepare()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 136, in prepare
    self._populate_validators()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 266, in _populate_validators
    self.model_config.arbitrary_types_allowed)),
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/validators.py", line 265, in find_validators
    raise RuntimeError(f'error checking inheritance of {type_!r} (type: {display_as_type(type_)})') from e
RuntimeError: error checking inheritance of ~KT (type: KT)


Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/validators.py", line 262, in find_validators
    if issubclass(type_, val_type):
TypeError: issubclass() arg 1 must be a class

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/docs/source/conf.py", line 13, in <module>
    import qcfractal
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/__init__.py", line 5, in <module>
    from . import interface
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/__init__.py", line 5, in <module>
    from . import collections
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/__init__.py", line 2, in <module>
    from .biofragment import BioFragment
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/biofragment.py", line 15, in <module>
    class BioFragment(Collection):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/checkouts/latest/qcfractal/interface/collections/biofragment.py", line 43, in BioFragment
    class DataModel(Collection.DataModel):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/main.py", line 124, in __new__
    config=config,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 107, in infer
    schema=schema,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 87, in __init__
    self.prepare()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 135, in prepare
    self._populate_sub_fields()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 241, in _populate_sub_fields
    self.key_field = self._create_sub_type(self.type_.__args__[0], 'key_' + self.name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 257, in _create_sub_type
    model_config=self.model_config,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 87, in __init__
    self.prepare()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 136, in prepare
    self._populate_validators()
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/fields.py", line 266, in _populate_validators
    self.model_config.arbitrary_types_allowed)),
  File "/home/docs/checkouts/readthedocs.org/user_builds/qcfractal/conda/latest/lib/python3.7/site-packages/pydantic-0.14-py3.7.egg/pydantic/validators.py", line 265, in find_validators
    raise RuntimeError(f'error checking inheritance of {type_!r} (type: {display_as_type(type_)})') from e
RuntimeError: error checking inheritance of ~KT (type: KT)


</p>
</details>

## Status
- [x] Ready to go