### PR TITLE
OpenFF: convert key string to id

### DIFF
--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -209,10 +209,11 @@ class TorsionDriveService:
 
                 # Construct constraints
                 constraints = copy.deepcopy(self.data["torsiondrive_meta"]["dihedral_template"])
-                if not isinstance(key, (tuple, list)):
-                    constraints[0]["value"] = key
+                grid_id = td_api.grid_id_from_string(key)
+                if len(grid_id) == 1:
+                    constraints[0]["value"] = grid_id[0]
                 else:
-                    for con_num, k in enumerate(key):
+                    for con_num, k in enumerate(grid_id):
                         constraints[con_num]["value"] = k
                 packet["meta"]["keywords"]["constraints"] = {"set": constraints}
 


### PR DESCRIPTION
## Description
This fixes a bug when running multi-dimensional torsion scan. 
The grid ids in `task_dict` are strings. Therefore, only the first constraint got a value for the dihedral angle and that value included a string of multiple angles. 

The key needs to remain a string because the keys in `task_map` are strings. 
## Status
- [ ] Ready to go