### PR TITLE
Heartbeat Manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_script:
   - conda list
 
 script:
-  - py.test -v --runslow --cov=qcfractal qcfractal/
+  - py.test -v -rsx --runslow --cov=qcfractal qcfractal/
   - py.test -v --runexamples examples/
 
 notifications:

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -137,6 +137,9 @@ def main(args=None):
     if args["rapidfire"]:
         manager.await_results()
     else:
+
+        cli_utils.install_signal_handlers(manager.loop, manager.stop)
+
         # Blocks until keyboard interupt
         manager.start()
 

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -72,11 +72,8 @@ def main(args=None):
 
         if args["local_cluster"]:
             # Build localcluster and exit callbacks
-            local_cluster = dd.LocalCluster(threads_per_worker=1, n_workers=args["local_workers"])
-            queue_client = dd.Client(local_cluster)
+            queue_client = dd.Client(threads_per_worker=1, n_workers=args["local_workers"])
             exit_callbacks.append([queue_client.close, (), {}])
-            exit_callbacks.append([local_cluster.scale_down, (local_cluster.workers, ), {}])
-            exit_callbacks.append([local_cluster.close, (4, ), {}])
         else:
             if args["dask_uri"] is None:
                 raise KeyError("A 'dask-uri' must be specified.")

--- a/qcfractal/cli/qcfractal_server.py
+++ b/qcfractal/cli/qcfractal_server.py
@@ -118,6 +118,9 @@ def main(args=None):
     for cb in exit_callbacks:
         server.add_exit_callback(cb[0], *cb[1], **cb[2])
 
+    # Register closing
+    cli_utils.install_signal_handlers(server.loop, server.stop)
+
     # Blocks until keyboard interupt
     server.start()
 

--- a/qcfractal/cli/qcfractal_server.py
+++ b/qcfractal/cli/qcfractal_server.py
@@ -34,6 +34,7 @@ def parse_args():
     server.add_argument("--tls-cert", type=str, default=None, help="Certificate file for TLS (in PEM format)")
     server.add_argument("--tls-key", type=str, default=None, help="Private key file for TLS (in PEM format)")
     server.add_argument("--config-file", type=str, default=None, help="A configuration file to use")
+    server.add_argument("--heartbeat-frequency", type=int, default=300, help="The manager heartbeat frequency.")
 
     parser._action_groups.reverse()
 
@@ -103,6 +104,7 @@ def main(args=None):
         storage_uri=args["database_uri"],
         storage_project_name=args["name"],
         logfile_prefix=args["log_prefix"],
+        heartbeat_frequency=args["heartbeat_frequency"],
         queue_socket=adapter)
 
     # Print Queue Manager data

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -18,8 +18,9 @@ class FractalClient(object):
 
         Parameters
         ----------
-        address : str
-            The IP and port of the FractalServer instance ("192.168.1.1:8888")
+        address : str or FractalServer
+            The IP and port of the FractalServer instance ("192.168.1.1:8888") or
+            a FractalServer instance
         username : None, optional
             The username to authenticate with.
         password : None, optional
@@ -29,6 +30,11 @@ class FractalClient(object):
             FractalServer was not provided a SSL certificate and defaults back to self-signed
             SSL keys.
         """
+
+        if hasattr(address, "get_address"):
+            # We are a FractalServer-like object
+            verify = address.client_verify
+            address = address.get_address()
 
         if "http" not in address:
             address = "https://" + address

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -63,9 +63,13 @@ class FractalClient(object):
         try:
             self.server_info = self._request("get", "information", {}).json()
         except requests.exceptions.SSLError as exc:
-            error_msg = ("SSL handshake failed. This is likely caused by a failure to retrive certificates.\n"
+            error_msg = ("\n\nSSL handshake failed. This is likely caused by a failure to retrive 3rd party SSL certificates.\n"
                          "If you trust the server you are connecting to, try 'FractalClient(... verify=False)'")
             raise requests.exceptions.SSLError(error_msg)
+        except requests.exceptions.ConnectionError as exc:
+            error_msg = (
+                "\n\nCould not connect to server {}, please check the address and try again.".format(self.address))
+            raise requests.exceptions.ConnectionError(error_msg)
 
         self.server_name = self.server_info["name"]
 

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -59,12 +59,14 @@ class FractalClient(object):
         if (username is not None) or (password is not None):
             self._headers["Authorization"] = json.dumps({"username": username, "password": password})
 
+        # Try to connect and pull general data
         try:
             self.server_info = self._request("get", "information", {}).json()
         except requests.exceptions.SSLError as exc:
             error_msg = ("SSL handshake failed. This is likely caused by a failure to retrive certificates.\n"
                          "If you trust the server you are connecting to, try 'FractalClient(... verify=False)'")
             raise requests.exceptions.SSLError(error_msg)
+
         self.server_name = self.server_info["name"]
 
     def __str__(self):

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -74,7 +74,6 @@ class QueueManager:
         self._name = self.name_data["cluster"] + "-" + self.name_data["hostname"] + "-" + self.name_data["uuid"]
 
         self.client = client
-        print(client.server_information())
         self.queue_adapter = build_queue_adapter(queue_client, logger=self.logger)
         self.max_tasks = max_tasks
         self.queue_tag = queue_tag

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -137,12 +137,8 @@ class QueueManager:
         self.periodic["heartbeat"] = heartbeat
 
         # Soft quit with a keyboard interupt
-        try:
-            self.running = True
-            if not asyncio.get_event_loop().is_running():  # Only works on Py3
-                self.loop.start()
-        except KeyboardInterrupt:
-            self.stop()
+        self.running = True
+        self.loop.start()
 
     def stop(self):
         """

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -100,7 +100,7 @@ class QueueManager:
         # Tell the server we are up and running
         payload = self._payload_template()
         payload["data"]["operation"] = "startup"
-        r = self.client._request("put", "queue_manager", payload)
+        self.client._request("put", "queue_manager", payload)
 
         self.logger.info("QueueManager '{}' successfully initialized.".format(self.name()))
         self.logger.info("    QCFractal server name:     {}".format(self.server_name))

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -162,7 +162,7 @@ class QueueManager:
         else:
             self.logger.info("Shutdown was successful, {} tasks returned to master queue.".format(len(task_ids)))
 
-        return True
+        return r.json()["data"]
 
     def add_exit_callback(self, callback, *args, **kwargs):
         """Adds additional callbacks to perform when closing down the server

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -5,7 +5,6 @@ The FractalServer class
 import asyncio
 import datetime
 import logging
-import json
 import ssl
 import threading
 import traceback
@@ -34,7 +33,6 @@ def _build_ssl():
 
     import sys
     import socket
-    import datetime
     import ipaddress
     import random
 

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -235,8 +235,6 @@ class FractalServer:
         Starts up all IOLoops and processes
         """
 
-        self.logger.info("FractalServer successfully started. Starting IOLoop.\n")
-
         # If we have a queue socket start up the nanny
         if "queue_manager" in self.objects:
             # Add canonical queue callback
@@ -257,10 +255,11 @@ class FractalServer:
         # Soft quit with a keyboard interrupt
         try:
             self.loop_active = True
-            if not asyncio.get_event_loop().is_running():  # Only works on Py3
-                self.loop.start()
+            self.loop.start()
         except KeyboardInterrupt:
             self.stop()
+
+        self.logger.info("FractalServer successfully started.\n")
 
     def stop(self):
         """

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -77,6 +77,7 @@ class FractalServer:
             self,
 
             # Server info options
+            name="QCFractal Server",
             port=8888,
             loop=None,
             security=None,
@@ -86,16 +87,16 @@ class FractalServer:
             storage_uri="mongodb://localhost",
             storage_project_name="molssistorage",
 
-            # Queue options
-            queue_socket=None,
-
             # Log options
             logfile_prefix=None,
 
             # Queue options
-            max_active_services=10):
+            queue_socket=None,
+            max_active_services=10,
+            heartbeat_interval=300):
 
         # Save local options
+        self.name = name
         self.port = port
         if ssl_options is False:
             self._address = "http://localhost:" + str(self.port) + "/"
@@ -103,6 +104,7 @@ class FractalServer:
             self._address = "https://localhost:" + str(self.port) + "/"
 
         self.max_active_services = max_active_services
+        self.heartbeat_interval = heartbeat_interval
 
         # Setup logging.
         if logfile_prefix is not None:
@@ -174,9 +176,13 @@ class FractalServer:
             "logger": self.logger,
         }
 
+        # Public information
+        self.objects["public_information"] = {"name": self.name, "heartbeat_interval": self.heartbeat_interval}
+
         endpoints = [
 
             # Generic web handlers
+            (r"/information", web_handlers.InformationHandler, self.objects),
             (r"/molecule", web_handlers.MoleculeHandler, self.objects),
             (r"/option", web_handlers.OptionHandler, self.objects),
             (r"/collection", web_handlers.CollectionHandler, self.objects),

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -93,7 +93,7 @@ class FractalServer:
             # Queue options
             queue_socket=None,
             max_active_services=10,
-            heartbeat_interval=300):
+            heatbeat_frequency=300):
 
         # Save local options
         self.name = name
@@ -104,7 +104,7 @@ class FractalServer:
             self._address = "https://localhost:" + str(self.port) + "/"
 
         self.max_active_services = max_active_services
-        self.heartbeat_interval = heartbeat_interval
+        self.heatbeat_frequency = heatbeat_frequency
 
         # Setup logging.
         if logfile_prefix is not None:
@@ -177,7 +177,7 @@ class FractalServer:
         }
 
         # Public information
-        self.objects["public_information"] = {"name": self.name, "heartbeat_interval": self.heartbeat_interval}
+        self.objects["public_information"] = {"name": self.name, "heatbeat_frequency": self.heatbeat_frequency}
 
         endpoints = [
 

--- a/qcfractal/storage_sockets/models.py
+++ b/qcfractal/storage_sockets/models.py
@@ -254,6 +254,8 @@ class TaskQueue(db.DynamicDocument):
     parser = db.StringField(default='')
     status = db.StringField(default='WAITING')
                             # choices=['RUNNING', 'WAITING', 'ERROR', 'COMPLETE'])
+    manager = db.StringField(default=None)
+
 
     created_on = db.DateTimeField(required=True, default=datetime.datetime.now)
     modified_on = db.DateTimeField(required=True, default=datetime.datetime.now)
@@ -264,6 +266,7 @@ class TaskQueue(db.DynamicDocument):
         'indexes': [
             '-created_on',
             'status',
+            'manager',
             # {'fields': ("status", "tag", "hash_index"), 'unique': False}
             {'fields': ("base_result",), 'unique': True}  # new
 

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -1294,7 +1294,7 @@ class MongoengineSocket:
 
 ### QueueManagers
 
-    def manager_update(self, name, tag=None, submitted=0, completed=0, failures=0, returned=0):
+    def manager_update(self, name, **kwargs):
         dt = datetime.datetime.utcnow()
 
         r = self._tables["queue_managers"].update_one(
@@ -1305,8 +1305,11 @@ class MongoengineSocket:
                 # Provide base data
                 "$setOnInsert": {
                     "name": name,
+                    "cluster": kwargs.get("cluster", None),
+                    "hostname": kwargs.get("hostname", None),
+                    "uuid": kwargs.get("uuid", None),
+                    "tag": kwargs.get("tag", None),
                     "created_on": dt,
-                    "tag": tag,
                 },
                 # Set the date
                 "$set": {
@@ -1314,10 +1317,10 @@ class MongoengineSocket:
                 },
                 # Incremement relevant data
                 "$inc": {
-                    "submitted": submitted,
-                    "completed": completed,
-                    "returned": returned,
-                    "failures": failures
+                    "submitted": kwargs.get("submitted", 0),
+                    "completed": kwargs.get("completed", 0),
+                    "returned": kwargs.get("returned", 0),
+                    "failures": kwargs.get("failures", 0)
                 }
             },
             upsert=True)

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -1341,7 +1341,6 @@ class MongoengineSocket:
             if value in kwargs:
                 upd["$set"][value] = kwargs[value]
 
-        print(upd)
         r = self._tables["queue_managers"].update_one({"name": name}, upd, upsert=True)
         return r.matched_count == 1
 

--- a/qcfractal/tests/test_authentication.py
+++ b/qcfractal/tests/test_authentication.py
@@ -37,7 +37,7 @@ def sec_server(request):
 
     storage_name = "qcf_local_server_auth_test"
 
-    with testing.pristine_loop() as loop:
+    with testing.loop_in_thread() as loop:
 
         # Build server, manually handle IOLoop (no start/stop needed)
         server = qcfractal.FractalServer(
@@ -51,8 +51,7 @@ def sec_server(request):
         for k, v in _users.items():
             assert server.storage.add_user(k, _users[k]["pw"], _users[k]["perm"])
 
-        with testing.active_loop(loop) as act:
-            yield server
+        yield server
 
 
 ### Tests the compute queue stack

--- a/qcfractal/tests/test_authentication.py
+++ b/qcfractal/tests/test_authentication.py
@@ -57,41 +57,35 @@ def sec_server(request):
 
 ### Tests the compute queue stack
 def test_security_auth_decline_none(sec_server):
-    client = portal.FractalClient(sec_server)
-    assert "FractalClient" in str(client)
+    with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+        client = portal.FractalClient(sec_server)
 
-    with pytest.raises(requests.exceptions.HTTPError):
-        r = client.get_molecules([])
-
-    with pytest.raises(requests.exceptions.HTTPError):
-        r = client.add_molecules({})
+    assert "user not found" in str(excinfo.value).lower()
 
 
 def test_security_auth_bad_ssl(sec_server):
-    client = portal.FractalClient.from_file({
-        "address": sec_server.get_address(),
-        "username": "read",
-        "password": _users["write"]["pw"],
-        "verify": True
-    })
+    with pytest.raises(requests.exceptions.SSLError) as excinfo:
+        client = portal.FractalClient.from_file({
+            "address": sec_server.get_address(),
+            "username": "read",
+            "password": _users["write"]["pw"],
+            "verify": True
+        })
 
-    with pytest.raises(requests.exceptions.SSLError):
-        r = client.get_molecules([])
+    assert "ssl handshake" in str(excinfo.value).lower()
+    assert "verify=false" in str(excinfo.value).lower()
 
 
 def test_security_auth_decline_bad_user(sec_server):
-    client = portal.FractalClient.from_file({
-        "address": sec_server.get_address(),
-        "username": "hello",
-        "password": "something",
-        "verify": False
-    })
+    with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+        client = portal.FractalClient.from_file({
+            "address": sec_server.get_address(),
+            "username": "hello",
+            "password": "something",
+            "verify": False
+        })
 
-    with pytest.raises(requests.exceptions.HTTPError):
-        r = client.get_molecules([])
-
-    with pytest.raises(requests.exceptions.HTTPError):
-        r = client.add_molecules({})
+    assert "user not found" in str(excinfo.value).lower()
 
 
 def test_security_auth_accept(sec_server):

--- a/qcfractal/tests/test_authentication.py
+++ b/qcfractal/tests/test_authentication.py
@@ -41,10 +41,7 @@ def sec_server(request):
 
         # Build server, manually handle IOLoop (no start/stop needed)
         server = qcfractal.FractalServer(
-            port=testing.find_open_port(),
-            storage_project_name=storage_name,
-            loop=loop,
-            security="local")
+            port=testing.find_open_port(), storage_project_name=storage_name, loop=loop, security="local")
 
         # Clean and re-init the databse
         server.storage.client.drop_database(server.storage._project_name)
@@ -60,7 +57,7 @@ def sec_server(request):
 
 ### Tests the compute queue stack
 def test_security_auth_decline_none(sec_server):
-    client = portal.FractalClient(sec_server.get_address(), verify=False)
+    client = portal.FractalClient(sec_server)
     assert "FractalClient" in str(client)
 
     with pytest.raises(requests.exceptions.HTTPError):
@@ -68,6 +65,7 @@ def test_security_auth_decline_none(sec_server):
 
     with pytest.raises(requests.exceptions.HTTPError):
         r = client.add_molecules({})
+
 
 def test_security_auth_bad_ssl(sec_server):
     client = portal.FractalClient.from_file({
@@ -79,6 +77,7 @@ def test_security_auth_bad_ssl(sec_server):
 
     with pytest.raises(requests.exceptions.SSLError):
         r = client.get_molecules([])
+
 
 def test_security_auth_decline_bad_user(sec_server):
     client = portal.FractalClient.from_file({
@@ -97,8 +96,7 @@ def test_security_auth_decline_bad_user(sec_server):
 
 def test_security_auth_accept(sec_server):
 
-    client = portal.FractalClient(
-        sec_server.get_address(), username="write", password=_users["write"]["pw"], verify=False)
+    client = portal.FractalClient(sec_server, username="write", password=_users["write"]["pw"])
 
     r = client.add_molecules({})
     r = client.get_molecules([])

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -14,7 +14,7 @@ from qcfractal.testing import dask_server_fixture as fractal_compute_server
 @testing.using_psi4
 def test_compute_dataset(fractal_compute_server):
 
-    client = portal.FractalClient(fractal_compute_server.get_address(""))
+    client = portal.FractalClient(fractal_compute_server)
     ds_name = "He_PES"
     ds = portal.collections.Dataset(ds_name, client, ds_type="ie")
 
@@ -71,7 +71,7 @@ def test_compute_dataset(fractal_compute_server):
 def test_compute_openffworkflow(fractal_compute_server):
 
     # Obtain a client and build a BioFragment
-    client = portal.FractalClient(fractal_compute_server.get_address(""))
+    client = portal.FractalClient(fractal_compute_server)
 
     openff_workflow_options = {
         # Blank Fragmenter options

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -95,7 +95,7 @@ def test_queue_manager_shutdown(compute_manager_fixture):
     # Pull job to manager and shutdown
     manager.update()
     assert len(manager.list_current_tasks()) == 1
-    manager.shutdown()
+    assert manager.shutdown()["nshutdown"] == 1
 
     # Boot new manager and await results
     manager = queue.QueueManager(client, lpad)

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -97,6 +97,10 @@ def test_queue_manager_shutdown(compute_manager_fixture):
     assert len(manager.list_current_tasks()) == 1
     assert manager.shutdown()["nshutdown"] == 1
 
+    sman = server.list_managers(name=manager.name())
+    assert len(sman) == 1
+    assert sman[0]["status"] == "INACTIVE"
+
     # Boot new manager and await results
     manager = queue.QueueManager(client, lpad)
     manager.await_results()

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -13,7 +13,7 @@ from qcfractal.testing import test_server, reset_server_database
 @pytest.fixture(scope="module")
 def compute_manager_fixture(test_server):
 
-    client = portal.FractalClient(test_server.get_address())
+    client = portal.FractalClient(test_server)
 
     # Build Fireworks test server and manager
     fireworks = pytest.importorskip("fireworks")

--- a/qcfractal/tests/test_portal.py
+++ b/qcfractal/tests/test_portal.py
@@ -11,7 +11,7 @@ from qcfractal.testing import test_server
 
 def test_molecule_portal(test_server):
 
-    client = portal.FractalClient(test_server.get_address(""))
+    client = portal.FractalClient(test_server)
 
     water = portal.data.get_molecule("water_dimer_minima.psimol")
 
@@ -29,7 +29,7 @@ def test_molecule_portal(test_server):
 
 def test_options_portal(test_server):
 
-    client = portal.FractalClient(test_server.get_address(""))
+    client = portal.FractalClient(test_server)
 
     opts = portal.data.get_options("psi_default")
 
@@ -46,7 +46,7 @@ def test_collection_portal(test_server):
 
     db = {"collection": "torsiondrive", "name": "Torsion123", "something": "else", "array": ["54321"]}
 
-    client = portal.FractalClient(test_server.get_address(""))
+    client = portal.FractalClient(test_server)
 
     # Test add
     ret = client.add_collection(db)

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -136,7 +136,7 @@ def test_procedure_optimization(fractal_compute_server):
 
 @testing.using_rdkit
 def test_procedure_task_error(fractal_compute_server):
-    client = portal.FractalClient(fractal_compute_server.get_address())
+    client = portal.FractalClient(fractal_compute_server)
 
     ret = client.add_compute("rdkit", "cookiemonster", "", "energy", None, [{
         "geometry": [0, 0, 0],

--- a/qcfractal/tests/test_queue.py
+++ b/qcfractal/tests/test_queue.py
@@ -11,7 +11,7 @@ from qcfractal.testing import fractal_compute_server
 @testing.using_rdkit
 def test_queue_error(fractal_compute_server):
 
-    client = portal.FractalClient(fractal_compute_server.get_address())
+    client = portal.FractalClient(fractal_compute_server)
 
     hooh = portal.data.get_molecule("hooh.json").to_json()
     del hooh["connectivity"]
@@ -38,7 +38,7 @@ def test_queue_error(fractal_compute_server):
 @testing.using_rdkit
 def test_queue_duplicate_compute(fractal_compute_server):
 
-    client = portal.FractalClient(fractal_compute_server.get_address())
+    client = portal.FractalClient(fractal_compute_server)
 
     hooh = portal.data.get_molecule("hooh.json").to_json()
     mol_ret = client.add_molecules({"hooh": hooh})
@@ -61,7 +61,7 @@ def test_queue_duplicate_compute(fractal_compute_server):
 @testing.using_geometric
 def test_queue_duplicate_procedure(fractal_compute_server):
 
-    client = portal.FractalClient(fractal_compute_server.get_address())
+    client = portal.FractalClient(fractal_compute_server)
 
     hooh = portal.data.get_molecule("hooh.json").to_json()
     mol_ret = client.add_molecules({"hooh": hooh})
@@ -94,7 +94,7 @@ def test_queue_duplicate_procedure(fractal_compute_server):
 @testing.using_rdkit
 def test_queue_duplicate_submissions(fractal_compute_server):
 
-    client = portal.FractalClient(fractal_compute_server.get_address())
+    client = portal.FractalClient(fractal_compute_server)
 
     he2 = portal.data.get_molecule("helium_dimer.json").to_json()
     mol_ret = client.add_molecules({"he2": he2})

--- a/qcfractal/tests/test_server.py
+++ b/qcfractal/tests/test_server.py
@@ -41,7 +41,7 @@ def test_server_information(test_server):
     client = portal.FractalClient(test_server)
 
     server_info = client.server_information()
-    assert {"name", "heartbeat_interval"} <= server_info.keys()
+    assert {"name", "heatbeat_frequency"} <= server_info.keys()
 
 
 def test_molecule_socket(test_server):

--- a/qcfractal/tests/test_server.py
+++ b/qcfractal/tests/test_server.py
@@ -41,7 +41,7 @@ def test_server_information(test_server):
     client = portal.FractalClient(test_server)
 
     server_info = client.server_information()
-    assert {"name", "heatbeat_frequency"} <= server_info.keys()
+    assert {"name", "heartbeat_frequency"} <= server_info.keys()
 
 
 def test_molecule_socket(test_server):

--- a/qcfractal/tests/test_server.py
+++ b/qcfractal/tests/test_server.py
@@ -40,6 +40,9 @@ def test_server_information(test_server):
 
     client = portal.FractalClient(test_server)
 
+    server_info = client.server_information()
+    assert {"name", "heartbeat_interval"} <= server_info.keys()
+
 
 def test_molecule_socket(test_server):
 

--- a/qcfractal/tests/test_server.py
+++ b/qcfractal/tests/test_server.py
@@ -36,6 +36,10 @@ def test_start_stop():
         except:
             pass
 
+def test_server_information(test_server):
+
+    client = portal.FractalClient(test_server)
+
 
 def test_molecule_socket(test_server):
 

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -20,7 +20,7 @@ def torsiondrive_fixture(dask_server_fixture):
     pytest.importorskip("geometric")
     pytest.importorskip("rdkit")
 
-    client = portal.FractalClient(dask_server_fixture.get_address())
+    client = portal.FractalClient(dask_server_fixture)
 
     # Add a HOOH
     hooh = portal.data.get_molecule("hooh.json")

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -46,7 +46,10 @@ def torsiondrive_fixture(dask_server_fixture):
         },
     }
 
-    def spin_up_test(grid_spacing=default_grid_spacing, **keyword_augments):
+    def spin_up_test(grid_spacing=None, **keyword_augments):
+        if grid_spacing is None:
+            grid_spacing = default_grid_spacing
+
         instance_options = copy.deepcopy(torsiondrive_options)
         instance_options["torsiondrive_meta"]["grid_spacing"] = [grid_spacing]
 
@@ -64,6 +67,7 @@ def test_service_torsiondrive_single(torsiondrive_fixture):
     """"Tests torsiondrive pathway and checks the result result"""
 
     spin_up_test, client = torsiondrive_fixture
+    print(client)
 
     ret = spin_up_test()
     compute_key = ret["submitted"][0]

--- a/qcfractal/tests/test_storage_sockets_me.py
+++ b/qcfractal/tests/test_storage_sockets_me.py
@@ -472,7 +472,7 @@ def test_storage_queue_roundtrip(storage_results):
     assert len(r["data"]) == 1
 
     # Query for next tasks
-    r = storage_results.queue_get_next()
+    r = storage_results.queue_get_next("test_manager")
     assert r[0]["spec"]["function"] == task1["spec"]["function"]
     queue_id = r[0]["id"]
 
@@ -486,7 +486,7 @@ def test_storage_queue_roundtrip(storage_results):
     assert found[0]["status"] == "COMPLETE"
 
     # Check queue is empty
-    r = storage_results.queue_get_next()
+    r = storage_results.queue_get_next("test_manager")
     assert len(r) == 0
 
 
@@ -505,7 +505,7 @@ def test_storage_queue_duplicate(storage_results):
     queue_id = r["data"][0]
 
     # Put the first task in a waiting state
-    r = storage_results.queue_get_next()
+    r = storage_results.queue_get_next("test_manager")
     assert len(r) == 1
 
     # Change hooks, only one submission due to hash_index conflict

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -46,6 +46,22 @@ class APIHandler(tornado.web.RequestHandler):
             raise tornado.web.HTTPError(status_code=401, reason=msg)
 
 
+class InformationHandler(APIHandler):
+    """
+    A handler that returns public server information
+    """
+
+    def get(self):
+        """
+
+        """
+        self.authenticate("read")
+
+        self.logger.info("GET: Information")
+
+        self.write(self.objects["public_information"])
+
+
 class MoleculeHandler(APIHandler):
     """
     A handler to push and get molecules.


### PR DESCRIPTION
## Description
This PR adds manager heartbeats to the project. This allows jobs that have been allocated to managers that do not shut down properly to be recycled and given to other managers.

The heartbeat interval is set by the FractalServer instance and passed to the managers to ensure consistency.

## Todos
 - [x] Adds heartbeats, closes #95.
 - [x] Allows shutdown of CLI invocations via SIGINT and SIGTERM to have a better chance of a clean shutdown, closes #90.
 - [x] A new FractalClient requests some data from the server to ensure the connection is live. Error messages should be slightly more explicit now.
 - [x] When a FractalServer owns a Manager, all manager REST queries are now run in a background thread so that communication is not blocked. This is not exactly an ideal solution as we need to continuously build threads. There are plenty of ways to improve in the future, but the current version works and is relatively robust.

## Status
- [x] Ready to go