### PR TITLE
Services submission overhaul

### DIFF
--- a/examples/parsl_torsiondrive/compute_torsion.py
+++ b/examples/parsl_torsiondrive/compute_torsion.py
@@ -8,7 +8,8 @@ hooh = portal.data.get_molecule("hooh.json")
 mol_ret = client.add_molecules({"hooh": hooh})
 
 # Geometric options
-options = {
+tdinput = {
+    "initial_molecule": [mol_ret["hooh"]],
     "torsiondrive_meta": {
         "dihedrals": [[0, 1, 2, 3]],
         "grid_spacing": [90]
@@ -20,13 +21,14 @@ options = {
     "qc_meta": {
         "driver": "gradient",
         "method": "UFF",
-        "basis": "",
+        "basis": None,
         "options": None,
         "program": "rdkit",
     },
 }
+# )
 
 # Compute!
-ret = client.add_service("torsiondrive", [mol_ret["hooh"]], options)
+ret = client.add_service(tdinput)
 
 print(ret)

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -13,11 +13,14 @@ from .collections import collection_factory
 
 from .models.common_models import Molecule
 from .models.rest_models import (
-    MoleculeGETBody, MoleculeGETResponse, MoleculePOSTBody, MoleculePOSTResponse, OptionGETBody, OptionGETResponse,
-    OptionPOSTBody, OptionPOSTResponse, CollectionGETBody, CollectionGETResponse, CollectionPOSTBody,
-    CollectionPOSTResponse, ResultGETBody, ResultGETResponse, ProcedureGETBody, ProcedureGETReponse, TaskQueueGETBody,
-    TaskQueueGETResponse, TaskQueuePOSTBody, TaskQueuePOSTResponse, ServiceQueuePOSTBody, ServiceQueuePOSTResponse,
-    ServiceQueueGETBody, ServiceQueueGETResponse)
+    MoleculeGETBody, MoleculeGETResponse, MoleculePOSTBody, MoleculePOSTResponse,
+    OptionGETBody, OptionGETResponse, OptionPOSTBody, OptionPOSTResponse,
+    CollectionGETBody, CollectionGETResponse, CollectionPOSTBody, CollectionPOSTResponse,
+    ResultGETBody, ResultGETResponse,
+    ProcedureGETBody, ProcedureGETReponse,
+    TaskQueueGETBody, TaskQueueGETResponse, TaskQueuePOSTBody, TaskQueuePOSTResponse,
+    ServiceQueuePOSTBody, ServiceQueuePOSTResponse, ServiceQueueGETBody, ServiceQueueGETResponse
+)
 from .models.gridoptimization import GridOptimizationInput
 from .models.torsiondrive import TorsionDriveInput
 

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -13,14 +13,13 @@ from .collections import collection_factory
 
 from .models.common_models import Molecule
 from .models.rest_models import (
-    MoleculeGETBody, MoleculeGETResponse, MoleculePOSTBody, MoleculePOSTResponse,
-    OptionGETBody, OptionGETResponse, OptionPOSTBody, OptionPOSTResponse,
-    CollectionGETBody, CollectionGETResponse, CollectionPOSTBody, CollectionPOSTResponse,
-    ResultGETBody, ResultGETResponse,
-    ProcedureGETBody, ProcedureGETReponse,
-    TaskQueueGETBody, TaskQueueGETResponse, TaskQueuePOSTBody, TaskQueuePOSTResponse,
-    ServiceQueuePOSTBody, ServiceQueuePOSTResponse, ServiceQueueGETBody, ServiceQueueGETResponse
-)
+    MoleculeGETBody, MoleculeGETResponse, MoleculePOSTBody, MoleculePOSTResponse, OptionGETBody, OptionGETResponse,
+    OptionPOSTBody, OptionPOSTResponse, CollectionGETBody, CollectionGETResponse, CollectionPOSTBody,
+    CollectionPOSTResponse, ResultGETBody, ResultGETResponse, ProcedureGETBody, ProcedureGETReponse, TaskQueueGETBody,
+    TaskQueueGETResponse, TaskQueuePOSTBody, TaskQueuePOSTResponse, ServiceQueuePOSTBody, ServiceQueuePOSTResponse,
+    ServiceQueueGETBody, ServiceQueueGETResponse)
+from .models.gridoptimization import GridOptimizationInput
+from .models.torsiondrive import TorsionDriveInput
 
 
 class FractalClient(object):
@@ -89,7 +88,8 @@ class FractalClient(object):
             self.server_name, self.address, self.username)
         return ret
 
-    def _request(self, method: str, service: str, payload: Dict[str, Any]=None, *, data: str=None, noraise: bool=False):
+    def _request(self, method: str, service: str, payload: Dict[str, Any]=None, *, data: str=None,
+                 noraise: bool=False):
 
         addr = self.address + service
         try:
@@ -204,7 +204,8 @@ class FractalClient(object):
         else:
             return r.data
 
-    def add_molecules(self, mol_list: Dict[str, Molecule], full_return: bool=False) -> Union[List[str], Dict[str, Any]]:
+    def add_molecules(self, mol_list: Dict[str, Molecule],
+                      full_return: bool=False) -> Union[List[str], Dict[str, Any]]:
         """Adds molecules to the Server
 
         Parameters
@@ -469,7 +470,6 @@ class FractalClient(object):
         [{"status": "WAITING"}]
         """
 
-        print(projection)
         payload = {"meta": {"projection": projection}, "data": query}
         body = TaskQueueGETBody(**payload)
 
@@ -481,24 +481,9 @@ class FractalClient(object):
         else:
             return r.data
 
-    def add_service(self, service: str,
-                    data: Union[Dict[str, Any], List[str], str],
-                    options: Dict[str, Any],
-                    return_full: bool=False):
+    def add_service(self, service: Union[GridOptimizationInput, TorsionDriveInput], return_full: bool=False):
 
-        # Always a list
-        if isinstance(data, str):
-            data = [data]
-
-        payload = {
-            "meta": {
-                "service": service,
-            },
-            "data": data
-        }
-        payload["meta"].update(options)
-
-        body = ServiceQueuePOSTBody(**payload)
+        body = ServiceQueuePOSTBody(meta={}, data=service)
 
         r = self._request("post", "service_queue", data=body.json())
         r = ServiceQueuePOSTResponse.parse_raw(r.text)

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -8,7 +8,7 @@ from . import collection_utils
 from .collection import Collection
 from .. import orm
 
-from ..models.torsiondrive import TorsionDrive
+from ..models.torsiondrive import TorsionDriveInput, TorsionDrive
 
 
 class OpenFFWorkflow(Collection):
@@ -221,12 +221,10 @@ class OpenFFWorkflow(Collection):
             torsion_meta["torsiondrive_meta"][k] = packet[k]
 
         # Get hash of torsion
-        ret = self.client.add_service("torsiondrive", [packet["initial_molecule"]], torsion_meta)
-        hash_lists = []
-        hash_lists.extend(ret.submitted)
-        if len(hash_lists) != 1:
-            raise KeyError("Something went very wrong.")
-        return hash_lists[0]
+        inp = TorsionDriveInput(**torsion_meta, initial_molecule=packet["initial_molecule"])
+        ret = self.client.add_service(inp)
+
+        return ret.hash_index
 
     def _add_optimize(self, packet):
         optimization_meta = copy.deepcopy(

--- a/qcfractal/interface/models/__init__.py
+++ b/qcfractal/interface/models/__init__.py
@@ -2,6 +2,8 @@
 Either pull in QCEl models or local models
 """
 
+
 from . import common_models
 from . import rest_models
 from . import torsiondrive
+from . import gridoptimization

--- a/qcfractal/interface/models/gridoptimization.py
+++ b/qcfractal/interface/models/gridoptimization.py
@@ -74,7 +74,7 @@ class GridOptimizationInput(BaseModel):
 
     program: str = "gridoptimization"
     procedure: str = "gridoptimization"
-    initial_molecule: Molecule
+    initial_molecule: Union[str, Molecule]
     gridoptimization_meta: GOOptions
     optimization_meta: OptOptions
     qc_meta: QCMeta

--- a/qcfractal/interface/models/gridoptimization.py
+++ b/qcfractal/interface/models/gridoptimization.py
@@ -72,7 +72,7 @@ class GridOptimizationInput(BaseModel):
     A GridOptimization Input base class
     """
 
-    program: str = "gridoptimization"
+    program: str = "qcfractal"
     procedure: str = "gridoptimization"
     initial_molecule: Union[str, Molecule]
     gridoptimization_meta: GOOptions

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -1,7 +1,7 @@
 """
 Models for the REST interface
 """
-from pydantic import BaseModel, validator
+from pydantic import BaseConfig, BaseModel, validator
 from typing import Dict, List, Tuple, Union, Any
 from enum import Enum
 
@@ -24,6 +24,9 @@ __all__ = [
 
 
 ### Generic and Common Models
+
+class RESTConfig(BaseConfig):
+    json_encoders = json_encoders
 
 
 class ResponseMeta(BaseModel):
@@ -290,6 +293,10 @@ class ServiceQueuePOSTBody(BaseModel):
     meta: Dict[str, Any]
     data: Union[TorsionDriveInput, GridOptimizationInput]
 
+    class Config(RESTConfig):
+        pass
+        # json_encoders = json_encoders
+
 
 class ServiceQueuePOSTResponse(BaseModel):
     class Data(BaseModel):
@@ -298,6 +305,7 @@ class ServiceQueuePOSTResponse(BaseModel):
 
     meta: ResponsePOSTMeta
     data: Data
+
 
 
 ### Queue Manager

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Tuple, Union, Any
 from enum import Enum
 
 from .common_models import Molecule, json_encoders
+from .gridoptimization import GridOptimizationInput
+from .torsiondrive import TorsionDriveInput
 
 __all__ = [
     "ResponseGETMeta",
@@ -286,14 +288,13 @@ class ServiceQueueGETResponse(BaseModel):
 
 class ServiceQueuePOSTBody(BaseModel):
     meta: Dict[str, Any]
-    data: List[Union[str, Dict[str, Any]]]
+    data: Union[TorsionDriveInput, GridOptimizationInput]
 
 
 class ServiceQueuePOSTResponse(BaseModel):
     class Data(BaseModel):
-        submitted: List[str]
-        completed: List[str]
-        queue: List[str]
+        hash_index: str
+        status: str
 
     meta: ResponsePOSTMeta
     data: Data

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -4,7 +4,7 @@ A model for TorsionDrive
 
 import copy
 import json
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -41,7 +41,7 @@ class TorsionDriveInput(BaseModel):
 
     program: str = "torsiondrive"
     procedure: str = "torsiondrive"
-    initial_molecule: Molecule
+    initial_molecule: Union[str, Molecule]
     torsiondrive_meta: TDOptions
     optimization_meta: OptOptions
     qc_meta: QCMeta

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -41,29 +41,21 @@ class TorsionDriveInput(BaseModel):
 
     program: str = "torsiondrive"
     procedure: str = "torsiondrive"
-    initial_molecule: Union[str, Molecule]
+    initial_molecule: List[Union[str, Molecule]]
     torsiondrive_meta: TDOptions
     optimization_meta: OptOptions
     qc_meta: QCMeta
 
+    def __init__(self, **data):
+        mol = data["initial_molecule"]
+        if isinstance(mol, (str, dict, Molecule)):
+            data["initial_molecule"] = [mol]
+
+        BaseModel.__init__(self, **data)
+
     class Config:
         allow_mutation = False
         json_encoders = json_encoders
-
-    def get_hash_index(self):
-        if isinstance(self.initial_molecule, str):
-            mol_id = self.initial_molecule
-
-        else:
-            if self.initial_molecule.id is None:
-                raise ValueError("Cannot get the hash_index without a valid intial_molecule.id field.")
-
-            mol_id = self.initial_molecule.id
-
-        data = self.dict(include=["program", "procedure", "torsiondrive_meta", "optimization_meta", "qc_meta"])
-        data["initial_molecule"] = mol_id
-
-        return hash_dictionary(data)
 
 
 class TorsionDrive(TorsionDriveInput):
@@ -84,7 +76,7 @@ class TorsionDrive(TorsionDriveInput):
     provenance: Provenance
 
     # Data pointers
-    initial_molecule: str
+    initial_molecule: List[str]
     final_energy_dict: Dict[str, float]
     optimization_history: Dict[str, List[str]]
     minimum_positions: Dict[str, int]
@@ -140,6 +132,13 @@ class TorsionDrive(TorsionDriveInput):
 
     def json_dict(self):
         return json.loads(self.json())
+
+    def get_hash_index(self):
+
+        data = self.dict(
+            include=["initial_molecule", "program", "procedure", "torsiondrive_meta", "optimization_meta", "qc_meta"])
+
+        return hash_dictionary(data)
 
 ## Query
 

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -118,7 +118,7 @@ class ServiceQueueHandler(APIHandler):
             hash_index=new_service.hash_index, projection={"hash_index": True})["data"]
         if duplicate:
             data["status"] = "completed"
-            meta["duplicates"] = duplicate
+            # meta["duplicates"] = duplicate
         else:
             # Add services to the database
             ret = storage.add_services([new_service.json_dict()])

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -9,12 +9,8 @@ from .. import procedures
 from .. import services
 from ..web_handlers import APIHandler
 
-from pydantic import BaseModel
-from typing import Dict
-
-from ..interface.models.common_models import Molecule, json_encoders
+from ..interface.models.common_models import Molecule
 from ..interface.models.rest_models import (
-    ResponseGETMeta,
     TaskQueueGETBody, TaskQueueGETResponse, TaskQueuePOSTBody, TaskQueuePOSTResponse,
     ServiceQueueGETBody, ServiceQueueGETResponse, ServiceQueuePOSTBody, ServiceQueuePOSTResponse,
     QueueManagerGETBody, QueueManagerGETResponse, QueueManagerPOSTBody, QueueManagerPOSTResponse,
@@ -100,7 +96,7 @@ class ServiceQueueHandler(APIHandler):
         # Get molecules with ids
         if isinstance(service_input.initial_molecule, list):
             mol_query = storage.get_add_molecules_mixed(service_input.initial_molecule)
-            molecules = [Molecule(**x) for x in mol_query["data"]]
+            molecules = [Molecule(**mol) for k, mol in mol_query["data"].items()]
             if len(molecules) != len(service_input.initial_molecule):
                 raise KeyError("We should catch this error.")
         else:

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -18,6 +18,7 @@ from ..interface.models.rest_models import (
     QueueManagerGETBody, QueueManagerGETResponse, QueueManagerPOSTBody, QueueManagerPOSTResponse, QueueManagerPUTBody,
     QueueManagerPUTResponse
 )
+
 from .adapters import build_queue_adapter
 
 from qcfractal.extras import get_information

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -372,7 +372,7 @@ class FractalServer:
 
             # Attempt to iteration and get message
             try:
-                obj = services.build(data["service"], self.storage, data)
+                obj = services.build(self.storage, data)
                 finished = obj.iterate()
                 data = obj.json_dict()
             except Exception as e:

--- a/qcfractal/services/gridoptimization_service.py
+++ b/qcfractal/services/gridoptimization_service.py
@@ -47,12 +47,14 @@ class GridOptimizationService(BaseService):
         json_encoders = json_encoders
 
     @classmethod
-    def initialize_from_api(cls, storage_socket, meta, molecule):
+    def initialize_from_api(cls, storage_socket, service_input):
 
-        # Validate input
+        # Build the results object
+        input_dict = service_input.dict()
+        input_dict["initial_molecule"] = input_dict["initial_molecule"]["id"]
+
         output = GridOptimization(
-            **meta,
-            initial_molecule=molecule["id"],
+            **input_dict,
             provenance={
                 "creator": "QCFractal",
                 "version": get_information("version"),
@@ -65,7 +67,7 @@ class GridOptimizationService(BaseService):
         meta = {"output": output}
 
         # Remove identity info from molecule template
-        molecule_template = copy.deepcopy(molecule)
+        molecule_template = copy.deepcopy(service_input.initial_molecule.json(as_dict=True))
         del molecule_template["id"]
         del molecule_template["identifiers"]
         meta["molecule_template"] = json.dumps(molecule_template)

--- a/qcfractal/services/gridoptimization_service.py
+++ b/qcfractal/services/gridoptimization_service.py
@@ -68,8 +68,8 @@ class GridOptimizationService(BaseService):
 
         # Remove identity info from molecule template
         molecule_template = copy.deepcopy(service_input.initial_molecule.json(as_dict=True))
-        del molecule_template["id"]
-        del molecule_template["identifiers"]
+        molecule_template.pop("id", None)
+        molecule_template.pop("identifiers", None)
         meta["molecule_template"] = json.dumps(molecule_template)
 
         # Build dihedral template

--- a/qcfractal/services/gridoptimization_service.py
+++ b/qcfractal/services/gridoptimization_service.py
@@ -56,7 +56,7 @@ class GridOptimizationService(BaseService):
         output = GridOptimization(
             **input_dict,
             provenance={
-                "creator": "QCFractal",
+                "creator": "qcfractal",
                 "version": get_information("version"),
                 "routine": "qcfractal.services.gridoptimization"
             },
@@ -94,7 +94,7 @@ class GridOptimizationService(BaseService):
         # Move around geometric data
         meta["optimization_program"] = output.optimization_meta.program
 
-        meta["hash_index"] = output.get_hash_index()
+        meta["hash_index"] = output.hash_index
 
         # Hard coded data, # TODO
         meta["dimensions"] = output.get_scan_dimensions()

--- a/qcfractal/services/services.py
+++ b/qcfractal/services/services.py
@@ -21,7 +21,7 @@ def _service_chooser(name):
         raise KeyError("Name {} not recognized.".format(name.title()))
 
 
-def initializer(name, storage_socket, meta, molecule):
+def initializer(storage_socket, service_input):
     """Initializes a service from a API call
 
     Parameters
@@ -41,10 +41,11 @@ def initializer(name, storage_socket, meta, molecule):
         Returns an instantiated service
 
     """
-    return _service_chooser(name).initialize_from_api(storage_socket, meta, molecule)
+    name = service_input.procedure
+    return _service_chooser(name).initialize_from_api(storage_socket, service_input)
 
 
-def build(name, storage_socket, data):
+def build(storage_socket, data):
     """Initializes a service from a JSON blob
 
     Parameters
@@ -60,4 +61,5 @@ def build(name, storage_socket, data):
         Returns an instantiated service
 
     """
+    name = data["service"]
     return _service_chooser(name)(**data, storage_socket=storage_socket)

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -60,7 +60,7 @@ class TorsionDriveService(BaseService):
 
         # Build the results object
         input_dict = service_input.dict()
-        input_dict["initial_molecule"] = input_dict["initial_molecule"]["id"]
+        input_dict["initial_molecule"] = [x["id"] for x in input_dict["initial_molecule"]]
 
         # Validate input
         output = TorsionDrive(
@@ -77,7 +77,7 @@ class TorsionDriveService(BaseService):
         meta = {"output": output}
 
         # Remove identity info from molecule template
-        molecule_template = copy.deepcopy(service_input.initial_molecule.json(as_dict=True))
+        molecule_template = copy.deepcopy(service_input.initial_molecule[0].json(as_dict=True))
         molecule_template.pop("id", None)
         molecule_template.pop("identifiers", None)
         meta["molecule_template"] = json.dumps(molecule_template)
@@ -87,7 +87,7 @@ class TorsionDriveService(BaseService):
             dihedrals=output.torsiondrive_meta.dihedrals,
             grid_spacing=output.torsiondrive_meta.grid_spacing,
             elements=molecule_template["symbols"],
-            init_coords=[molecule_template["geometry"]])
+            init_coords=[x.geometry for x in service_input.initial_molecule])
 
         # Build dihedral template
         dihedral_template = []

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -55,13 +55,16 @@ class TorsionDriveService(BaseService):
         json_encoders = json_encoders
 
     @classmethod
-    def initialize_from_api(cls, storage_socket, meta, molecule):
+    def initialize_from_api(cls, storage_socket, service_input):
         _check_td()
+
+        # Build the results object
+        input_dict = service_input.dict()
+        input_dict["initial_molecule"] = input_dict["initial_molecule"]["id"]
 
         # Validate input
         output = TorsionDrive(
-            **meta,
-            initial_molecule=molecule["id"],
+            **input_dict,
             provenance={
                 "creator": "torsiondrive",
                 "version": torsiondrive.__version__,
@@ -74,7 +77,7 @@ class TorsionDriveService(BaseService):
         meta = {"output": output}
 
         # Remove identity info from molecule template
-        molecule_template = copy.deepcopy(molecule)
+        molecule_template = copy.deepcopy(service_input.initial_molecule.json(as_dict=True))
         del molecule_template["id"]
         del molecule_template["identifiers"]
         meta["molecule_template"] = json.dumps(molecule_template)

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -78,8 +78,8 @@ class TorsionDriveService(BaseService):
 
         # Remove identity info from molecule template
         molecule_template = copy.deepcopy(service_input.initial_molecule.json(as_dict=True))
-        del molecule_template["id"]
-        del molecule_template["identifiers"]
+        molecule_template.pop("id", None)
+        molecule_template.pop("identifiers", None)
         meta["molecule_template"] = json.dumps(molecule_template)
 
         # Initiate torsiondrive meta

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -207,6 +207,8 @@ class MongoengineSocket:
                 id_mols[idx] = mol
             elif isinstance(mol, dict):
                 dict_mols[idx] = mol
+            elif isinstance(mol, interface.models.common_models.Molecule):
+                dict_mols[idx] = mol.json(as_dict=True)
             else:
                 meta["errors"].append((idx, "Data type not understood"))
 

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -9,6 +9,8 @@ import pytest
 import qcfractal.interface as portal
 from qcfractal.testing import fractal_compute_server, recursive_dict_merge, using_geometric, using_rdkit
 
+from qcfractal.interface.models.gridoptimization import GridOptimizationInput
+from qcfractal.interface.models.torsiondrive import TorsionDriveInput
 
 @pytest.fixture(scope="module")
 def torsiondrive_fixture(fractal_compute_server):
@@ -54,6 +56,7 @@ def torsiondrive_fixture(fractal_compute_server):
             status = client.check_services({"hash_index": compute_key}, return_full=True)
             assert 'READY' in status.data[0]['status']
             assert status.data[0]['id'] != compute_key  # Hash should never be id
+
         fractal_compute_server.await_services()
         assert len(fractal_compute_server.list_current_tasks()) == 0
         return ret.data
@@ -140,7 +143,7 @@ def test_service_gridoptimization_single(fractal_compute_server):
     mol_ret = client.add_molecules({"hooh": hooh})
 
     # Options
-    gridoptimization_options = {
+    service = GridOptimizationInput(**{
         "gridoptimization_meta": {
             "starting_grid": "zero",
             "scans": [{
@@ -164,9 +167,10 @@ def test_service_gridoptimization_single(fractal_compute_server):
             "options": None,
             "program": "rdkit",
         },
-    }
+        "initial_molecule": mol_ret["hooh"],
+    })
 
-    ret = client.add_service("gridoptimization", [mol_ret["hooh"]], gridoptimization_options)
+    ret = client.add_service(service)
     fractal_compute_server.await_services()
     assert len(fractal_compute_server.list_current_tasks()) == 0
 


### PR DESCRIPTION
## Description
Overhauls services to submit a single submission at a time as a normal Service input object. I think this is a better way to add services and procedures as the heterogeneity is likely to be much higher in these. We may want to allow multiple services to submitted at the same time as well, I would need to think a bit on that API.

This also allows torsion drive to have multiple input molecules.

## Status
- [x] Ready to go