### PR TITLE
Specifying Memory and Cores per job for QCEngine

### DIFF
--- a/qcfractal/queue/base_adapter.py
+++ b/qcfractal/queue/base_adapter.py
@@ -16,6 +16,8 @@ class BaseAdapter(abc.ABC):
     def __init__(self,
                  client: Any,
                  logger: Optional[logging.Logger] = None,
+                 cores_per_task: Optional[int] = None,
+                 memory_per_task: Optional[float] = None,
                  **kwargs):
         """
         Parameters
@@ -38,8 +40,8 @@ class BaseAdapter(abc.ABC):
 
         self.queue = {}
         self.function_map = {}
-        self.cores_per_task = kwargs.pop("cores_per_task", None)
-        self.memory_per_task = kwargs.pop("memory_per_task", None)
+        self.cores_per_task = cores_per_task
+        self.memory_per_task = memory_per_task
 
     def __repr__(self) -> str:
         return "<BaseAdapter>"
@@ -113,9 +115,8 @@ class BaseAdapter(abc.ABC):
 
             # Trap QCEngine Memory and CPU
             if task_spec["spec"]["function"].startswith("qcengine.compute") and self.qcengine_local_options:
-                task_kwargs = task_spec["spec"]["kwargs"]
                 task_spec = task_spec.copy()  # Copy for safety
-                task_spec["spec"]["kwargs"] = {**task_kwargs, **{"local_options": self.qcengine_local_options}}
+                task_spec["spec"]["kwargs"] = {**task_spec["spec"]["kwargs"], **{"local_options": self.qcengine_local_options}}
 
             queue_key, task = self._submit_task(task_spec)
 

--- a/qcfractal/queue/base_adapter.py
+++ b/qcfractal/queue/base_adapter.py
@@ -73,7 +73,7 @@ class BaseAdapter(abc.ABC):
         return self.function_map[function]
 
     @property
-    def qcengine_local_options(self) -> dict:
+    def qcengine_local_options(self) -> Dict[str, Any]:
         """
         Helper property to return the local QCEngine Options based on number of cores and memory per task
 

--- a/qcfractal/queue/base_adapter.py
+++ b/qcfractal/queue/base_adapter.py
@@ -6,7 +6,7 @@ import abc
 import importlib
 import logging
 import operator
-from typing import Any, Dict, Optional, List, Callable, Tuple, Union
+from typing import Any, Dict, Optional, List, Callable, Tuple, Hashable
 
 
 class BaseAdapter(abc.ABC):
@@ -175,7 +175,7 @@ class BaseAdapter(abc.ABC):
         """
 
     @abc.abstractmethod
-    def _submit_task(self, task_spec: Dict[str, Any]) -> Tuple[Union[str, float, int], Any]:
+    def _submit_task(self, task_spec: Dict[str, Any]) -> Tuple[Hashable, Any]:
         """
         Add a specific task to the queue
 
@@ -186,7 +186,7 @@ class BaseAdapter(abc.ABC):
 
         Returns
         -------
-        queue_key : str, int, float, or other Immutable
+        queue_key : Valid Dictionary Key
             Identifier for the queue to use for lookup of the task
         task
             Submitted task object for the adapter to look up later after its formatted it

--- a/qcfractal/queue/base_adapter.py
+++ b/qcfractal/queue/base_adapter.py
@@ -13,7 +13,11 @@ class BaseAdapter(abc.ABC):
     """A BaseAdapter for wrapping compute engines
     """
 
-    def __init__(self, client: Any, logger: Optional[logging.Logger] = None):
+    def __init__(self,
+                 client: Any,
+                 logger: Optional[logging.Logger] = None,
+                 cpu_per_task: Optional[int] = None,
+                 memory_per_task: Optional[int] = None):
         """
         Parameters
         ----------
@@ -21,9 +25,17 @@ class BaseAdapter(abc.ABC):
             A activate Parsl DataFlow
         logger : None, optional
             A optional logging object to write output to
+        cpu_per_task : int, optional, Default: None
+            How many CPU's per computation task to allocate for QCEngine
+            None indicates "use however many you can detect"
+        memory_per_task: int, optional, Default: None
+            How much memory, in GB, per computation task to allocate for QCEngine
+            None indicates "use however much you can consume"
         """
         self.client = client
         self.logger = logger or logging.getLogger(self.__class__.__name__)
+        self.cpu_per_task = cpu_per_task
+        self.memory_per_task = memory_per_task
 
         self.queue = {}
         self.function_map = {}

--- a/qcfractal/queue/executor_adapter.py
+++ b/qcfractal/queue/executor_adapter.py
@@ -37,6 +37,13 @@ class ExecutorAdapter(BaseAdapter):
 
             # Form run tuple
             func = self.get_function(spec["spec"]["function"])
+            # Trap QCEngine Memory and CPU
+            if spec["spec"]["function"].startswith("qcengine.compute"):
+                local_options = self.qcengine_local_options
+                if local_options:
+                    task_kwargs = spec["spec"]["kwargs"]
+                    spec = spec.copy()  # Copy for safety
+                    spec["spec"]["kwargs"] = {**task_kwargs, **{"local_options": local_options}}
             task = self.client.submit(func, *spec["spec"]["args"], **spec["spec"]["kwargs"])
 
             self.queue[tag] = (task, spec["parser"], spec["hooks"])

--- a/qcfractal/queue/executor_adapter.py
+++ b/qcfractal/queue/executor_adapter.py
@@ -4,7 +4,7 @@ Queue adapter for Dask
 
 import time
 import traceback
-from typing import Dict, List, Any, Tuple, Union
+from typing import Dict, List, Any, Tuple, Hashable
 
 from .base_adapter import BaseAdapter
 
@@ -27,7 +27,7 @@ class ExecutorAdapter(BaseAdapter):
         return "<ExecutorAdapter client=<{} max_workers={}>>".format(self.client.__class__.__name__,
                                                                      self.client._max_workers)
 
-    def _submit_task(self, task_spec: Dict[str, Any]) -> Tuple[Union[str, float, int], Any]:
+    def _submit_task(self, task_spec: Dict[str, Any]) -> Tuple[Hashable, Any]:
         func = self.get_function(task_spec["spec"]["function"])
         task = self.client.submit(func, *task_spec["spec"]["args"], **task_spec["spec"]["kwargs"])
         return task_spec["id"], task

--- a/qcfractal/queue/fireworks_adapter.py
+++ b/qcfractal/queue/fireworks_adapter.py
@@ -3,7 +3,7 @@ Queue adapter for Fireworks
 """
 
 import logging
-from typing import Dict, List, Any, Optional, Tuple, Union
+from typing import Dict, List, Any, Optional, Tuple, Hashable
 
 from .base_adapter import BaseAdapter
 
@@ -16,7 +16,7 @@ class FireworksAdapter(BaseAdapter):
     def __repr__(self):
         return "<FireworksAdapter client=<LaunchPad host='{}' name='{}'>>".format(self.client.host, self.client.name)
 
-    def _submit_task(self, task_spec: Dict[str, Any]) -> Tuple[Union[str, float, int], Any]:
+    def _submit_task(self, task_spec: Dict[str, Any]) -> Tuple[Hashable, Any]:
         import fireworks
         fw = fireworks.Firework(
             fireworks.PyTask(

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -95,7 +95,7 @@ class QueueManager:
         self.memory_per_task = memory_per_task
         self.queue_adapter = build_queue_adapter(queue_client,
                                                  logger=self.logger,
-                                                 cpus_per_task=self.cores_per_task,
+                                                 cores_per_task=self.cores_per_task,
                                                  memory_per_task=self.memory_per_task)
         self.max_tasks = max_tasks
         self.queue_tag = queue_tag
@@ -388,7 +388,7 @@ class QueueManager:
                 }, "program"],
                 "kwargs": {}
             },
-            "parser": "nothing",
+            "parser": "single",
             "hooks": []
         })
 
@@ -435,7 +435,7 @@ class QueueManager:
         missing_programs = results.keys() - set(found_programs)
         if len(missing_programs):
             self.logger.error("Not all tasks were retrieved, missing programs {}.".format(missing_programs))
-            raise ValueError("Testing failed, not all tasks were retrived.")
+            raise ValueError("Testing failed, not all tasks were retrieved.")
         else:
             self.logger.info("All tasks retrieved successfully.")
 

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -430,7 +430,7 @@ class QueueManager:
         self.queue_adapter.await_results()
 
         results = self.queue_adapter.acquire_complete()
-        self.logger.info("Testing results aquired.")
+        self.logger.info("Testing results acquired.")
 
         missing_programs = results.keys() - set(found_programs)
         if len(missing_programs):

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -204,7 +204,7 @@ class QueueManager:
         heartbeat.start()
         self.periodic["heartbeat"] = heartbeat
 
-        # Soft quit with a keyboard interupt
+        # Soft quit with a keyboard interrupt
         self.running = True
         self.loop.start()
 
@@ -236,7 +236,7 @@ class QueueManager:
 
     def close_adapter(self) -> bool:
         """
-        Closes down the underlying adapater
+        Closes down the underlying adapter
         """
 
         return self.queue_adapter.close()

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -49,7 +49,9 @@ class QueueManager:
                  queue_tag: str=None,
                  cluster: str="unknown",
                  update_frequency: int=2,
-                 verbose: bool=True):
+                 verbose: bool=True,
+                 cores_per_task: Optional[int] = None,
+                 memory_per_task: Optional[int] = None):
         """
         Parameters
         ----------
@@ -71,6 +73,12 @@ class QueueManager:
             The cluster the manager belongs to
         update_frequency : int
             The frequency to check for new tasks in seconds
+        cores_per_task : int, optional, Default: None
+            How many CPU cores per computation task to allocate for QCEngine
+            None indicates "use however many you can detect"
+        memory_per_task: int, optional, Default: None
+            How much memory, in GiB, per computation task to allocate for QCEngine
+            None indicates "use however much you can consume"
         """
 
         # Setup logging
@@ -83,7 +91,12 @@ class QueueManager:
         self._name = self.name_data["cluster"] + "-" + self.name_data["hostname"] + "-" + self.name_data["uuid"]
 
         self.client = client
-        self.queue_adapter = build_queue_adapter(queue_client, logger=self.logger)
+        self.cores_per_task = cores_per_task
+        self.memory_per_task = memory_per_task
+        self.queue_adapter = build_queue_adapter(queue_client,
+                                                 logger=self.logger,
+                                                 cpus_per_task=self.cores_per_task,
+                                                 memory_per_task=self.memory_per_task)
         self.max_tasks = max_tasks
         self.queue_tag = queue_tag
         self.verbose = verbose

--- a/qcfractal/queue/parsl_adapter.py
+++ b/qcfractal/queue/parsl_adapter.py
@@ -5,7 +5,7 @@ Queue adapter for Parsl
 import logging
 import time
 import traceback
-from typing import Callable, Dict, List, Any, Optional, Tuple, Union
+from typing import Callable, Dict, List, Any, Optional, Tuple, Hashable
 
 from .base_adapter import BaseAdapter
 
@@ -66,7 +66,7 @@ class ParslAdapter(BaseAdapter):
 
         return self.app_map[function]
 
-    def _submit_task(self, task_spec: Dict[str, Any]) -> Tuple[Union[str, float, int], Any]:
+    def _submit_task(self, task_spec: Dict[str, Any]) -> Tuple[Hashable, Any]:
 
         # Form run tuple
         func = self.get_app(task_spec["spec"]["function"])

--- a/qcfractal/queue/parsl_adapter.py
+++ b/qcfractal/queue/parsl_adapter.py
@@ -24,12 +24,14 @@ class ParslAdapter(BaseAdapter):
     """A Adapter for Parsl
     """
 
-    def __init__(self, client: Any, logger: Optional[logging.Logger] = None):
-        BaseAdapter.__init__(self, client, logger)
+    def __init__(self, client: Any, logger: Optional[logging.Logger] = None, **kwargs):
+        BaseAdapter.__init__(self, client, logger, **kwargs)
 
         import parsl
         self.client = parsl.dataflow.dflow.DataFlowKernel(self.client)
         self.app_map = {}
+        import pdb; pdb.set_trace()
+        pass
 
     def __repr__(self):
         return "<ParslAdapter client=<DataFlow label='{}'>>".format(self.client.config.executors[0].label)
@@ -76,6 +78,10 @@ class ParslAdapter(BaseAdapter):
 
             # Form run tuple
             func = self.get_app(spec["spec"]["function"])
+            # Trap QCEngine Memory and CPU
+            if spec["spec"].startswith("qcengine.compute"):
+                task_kwargs = spec["spec"]["kwargs"]
+
             task = func(*spec["spec"]["args"], **spec["spec"]["kwargs"])
 
             self.queue[tag] = (task, spec["parser"], spec["hooks"])

--- a/qcfractal/queue/parsl_adapter.py
+++ b/qcfractal/queue/parsl_adapter.py
@@ -30,8 +30,6 @@ class ParslAdapter(BaseAdapter):
         import parsl
         self.client = parsl.dataflow.dflow.DataFlowKernel(self.client)
         self.app_map = {}
-        import pdb; pdb.set_trace()
-        pass
 
     def __repr__(self):
         return "<ParslAdapter client=<DataFlow label='{}'>>".format(self.client.config.executors[0].label)
@@ -79,8 +77,12 @@ class ParslAdapter(BaseAdapter):
             # Form run tuple
             func = self.get_app(spec["spec"]["function"])
             # Trap QCEngine Memory and CPU
-            if spec["spec"].startswith("qcengine.compute"):
-                task_kwargs = spec["spec"]["kwargs"]
+            if spec["spec"]["function"].startswith("qcengine.compute"):
+                local_options = self.qcengine_local_options
+                if local_options:
+                    task_kwargs = spec["spec"]["kwargs"]
+                    spec = spec.copy()  # Copy for safety
+                    spec["spec"]["kwargs"] = {**task_kwargs, **{"local_options": local_options}}
 
             task = func(*spec["spec"]["args"], **spec["spec"]["kwargs"])
 

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -2,7 +2,6 @@
 Contains testing infrastructure for QCFractal
 """
 
-import logging
 import os
 import pkgutil
 import signal
@@ -20,6 +19,7 @@ from tornado.ioloop import IOLoop
 
 from .server import FractalServer
 from .storage_sockets import storage_socket_factory
+from .queue import build_queue_adapter
 
 ### Addon testing capabilities
 
@@ -135,14 +135,6 @@ def preserve_cwd():
         yield cwd
     finally:
         os.chdir(cwd)
-
-
-@contextmanager
-def queue_manager(client, adapter, **kwargs):
-    """
-    Parameterizable Queue manager safely wrapped in a context manager
-    """
-
 
 
 ### Background thread loops
@@ -392,6 +384,8 @@ def build_managed_compute_server(mtype):
 def adapter_client_fixture(request):
     adapter_client = build_adapter_clients(request.param)
     yield adapter_client
+    # Do a final close with existing tech
+    build_queue_adapter(adapter_client).close()
 
 
 @pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -319,7 +319,7 @@ def test_server(request):
         yield server
 
 
-def build_managed_compute_server(mtype):
+def build_managed_compute_server(mtype, ncore=None, memory=None):
 
     # Check mongo
     check_active_mongo_server()
@@ -370,7 +370,7 @@ def build_managed_compute_server(mtype):
         client = FractalClient(server)
 
         from qcfractal.queue import QueueManager
-        manager = QueueManager(client, adapter_client)
+        manager = QueueManager(client, adapter_client, cores_per_task=ncore, memory_per_task=memory)
 
         # Yield the server instance
         yield client, server, manager

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -380,7 +380,8 @@ def build_managed_compute_server(mtype):
         manager.close_adapter()
 
 
-@pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
+# @pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
+@pytest.fixture(scope="module", params=["pool", "dask", "fireworks"])
 def adapter_client_fixture(request):
     adapter_client = build_adapter_clients(request.param)
     yield adapter_client
@@ -388,7 +389,8 @@ def adapter_client_fixture(request):
     build_queue_adapter(adapter_client).close()
 
 
-@pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
+# @pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
+@pytest.fixture(scope="module", params=["pool", "dask", "fireworks"])
 def managed_compute_server(request):
     """
     A FractalServer with compute associated parametrize for all managers

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -374,7 +374,7 @@ def build_compute_server(mtype):
             queue_socket=adapter_client,
             ssl_options=False)
 
-        # Clean and re-init the databse
+        # Clean and re-init the database
         reset_server_database(server)
 
         # Build Client and Manager
@@ -392,14 +392,12 @@ def build_managed_compute_server(mtype):
             yield client, server, manager
 
 
-# @pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
-@pytest.fixture(scope="function", params=["pool"])
+@pytest.fixture(scope="function", params=["pool", "dask", "fireworks", "parsl"])
 def parameterizable_fractal_compute_server(request):
     yield from build_compute_server(request.param)
 
 
-# @pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
-@pytest.fixture(scope="module", params=["pool"])
+@pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
 def managed_compute_server(request):
     """
     A FractalServer with compute associated parametrize for all managers

--- a/qcfractal/tests/test_adapaters.py
+++ b/qcfractal/tests/test_adapaters.py
@@ -11,6 +11,12 @@ from qcfractal import testing
 from qcfractal.testing import reset_server_database, managed_compute_server
 
 
+# @pytest.mark.parametrize("cores_per_task,memory_per_task", [
+#     (None, None),
+#     (1, 2),
+#     pytest.param(50000, 100000,
+#                  marks=pytest.mark.xfail)
+# ])
 @testing.using_rdkit
 def test_adapter_single(managed_compute_server):
     client, server, manager = managed_compute_server
@@ -67,7 +73,7 @@ def test_adapter_raised_error(managed_compute_server):
     del hooh["connectivity"]
     mol_ret = client.add_molecules({"hooh": hooh})
 
-    ret = client.add_compute("something_bas", "UFF", "", "energy", None, mol_ret["hooh"])
+    ret = client.add_compute("something_bad", "UFF", "", "energy", None, mol_ret["hooh"])
     queue_id = ret.submitted[0]
 
     manager.await_results()


### PR DESCRIPTION
## Description
This PR (a work in progress) adds the ability to set the Number of CPU cores and memory QCEngine is allowed to take. 

After a large number of failed attempts, I don't think there is an easy, reliable, or even safe way to access how many workers any of the queue managers are spinning up.

e.g. The Parsl blocks cannot be accessed once the Config file is created so no inspection can be done to figure out how many workers its going to spin up. So at the base, very simple level, we can assume the user locks that in to the Executor they feed into the config file. Each Executor is different per cluster queueing service (SLURM, PBS, etc.) and may not even be specified at Config time. 

The result was that the user hard codes it somehow in the Config, so the Adapter class can intercept it, but because everyone of them is different, it turned out to be easier, and I think more strait-forward, to just lock it in at QueueManger or Adapter init. This does mean the individual implemented Adapter classes must catch this setting, but thats not too hard to do. 

Still working through how to properly test this, but I wanted to get it up and talk about it so I don't get caught in the trap of trying to work through more complicated inspection to determine cores/memory if this is sufficient.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Figure out how to parameterize a fixture or a single test to past to the fixture constructor in PyTest.
  - [x] Figure out how to intercept the QCEngine calls from the manager to test that memory and cores got set correctly

## Status
- [x] Ready to go