### PR TITLE
Allow queries with keys that are intentionally empty

### DIFF
--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -185,6 +185,10 @@ class ResultGETBody(BaseModel):
             "program", "molecule", "driver", "method", "basis", "keywords", "task_id", "id", "status"
         }
         data = {key: v[key] for key in (v.keys() & valid_keys)}
+        if "keywords" in data and data["keywords"] is None:
+            data["keywords"] = 'null'
+        if "basis" in data and data["basis"] is None:
+            data["basis"] = 'null'
         return data
 
 

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -470,7 +470,7 @@ class MongoengineSocket:
 
         return ret
 
-    def get_molecules(self, molecule_ids, index="id"):
+    def get_molecules(self, molecule_ids=None, index="id"):
 
         ret = {"meta": storage_utils.get_metadata(), "data": []}
 
@@ -613,7 +613,8 @@ class MongoengineSocket:
         ret = {"data": keywords, "meta": meta}
         return ret
 
-    def get_keywords(self, id: str=None, program: str=None, hash_index: str=None, return_json: bool=True, with_ids: bool=True, limit=None):
+    def get_keywords(self, id: str=None, program: str=None, hash_index: str=None,
+                     return_json: bool=True, with_ids: bool=True, limit=None):
         """Search for one (unique) option based on the 'program'
         and the 'name'. No overwrite allowed.
 
@@ -621,8 +622,6 @@ class MongoengineSocket:
         ----------
         program : str
             program name
-        name : str
-            option name
         return_json : bool, optional
             Return the results as a json object
             Default is True
@@ -644,11 +643,11 @@ class MongoengineSocket:
 
         meta = storage_utils.get_metadata()
         query = {}
-        if program:
+        if program is not None:
             query['program'] = program
-        if hash_index:
+        if hash_index is not None:
             query['hash_index'] = hash_index
-        if id:
+        if id is not None:
             query['id'] = ObjectId(id)
         q_limit = limit if limit and limit < self._max_limit else self._max_limit
 
@@ -941,7 +940,7 @@ class MongoengineSocket:
         ret = {"data": results, "meta": meta}
         return ret
 
-    def get_results_by_id(self, id: List[str]=None, projection=None, return_json=True, with_ids=True):
+    def get_results_by_id(self, id: List[str], projection=None, return_json=True, with_ids=True):
         """
         Get list of Results using the given list of Ids
 
@@ -1041,18 +1040,18 @@ class MongoengineSocket:
         meta = storage_utils.get_metadata()
         query = {}
         parsed_query = {}
-        if program:
+        if program is not None:
             query['program'] = program
-        if method:
+        if method is not None:
             query['method'] = method
-        if basis:
-            query['basis'] = basis
-        if molecule:
+        if basis is not None:
+            query['basis'] = basis if basis != 'null' else None
+        if molecule is not None:
             query['molecule'], _ = _str_to_indices_with_errors(molecule)
-        if driver:
+        if driver is not None:
             query['driver'] = driver
-        if keywords:
-            query['keywords'] = keywords
+        if keywords is not None:
+            query['keywords'] = keywords if keywords != 'null' else None
         if status:
             query['status'] = status
 
@@ -1063,8 +1062,10 @@ class MongoengineSocket:
                 parsed_query[key] = value
             elif isinstance(value, (list, tuple)):
                 parsed_query[key + "__in"] = [v.lower() for v in value]
-            else:
+            elif isinstance(value, str):
                 parsed_query[key] = value.lower()
+            else:
+                parsed_query[key] = value
 
         q_limit = limit if limit and limit < self._max_limit else self._max_limit
 

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -923,6 +923,8 @@ class MongoengineSocket:
             if doc.count() == 0 or update_existing:
                 if not isinstance(d['molecule'], ObjectId):
                     d['molecule'] = ObjectId(d['molecule'])
+                d['basis'] = d['basis'] if d['basis'] is not None else ""
+                d['keywords'] = d['keywords'] if d['keywords'] is not None else ""
                 doc = doc.upsert_one(**d)
                 results.append(str(doc.id))
                 meta['n_inserted'] += 1
@@ -1193,6 +1195,7 @@ class MongoengineSocket:
             doc = Procedure.objects(hash_index=d['hash_index'])
 
             if doc.count() == 0 or update_existing:
+                d['keywords'] = d['keywords'] if d['keywords'] is not None else ""
                 doc = doc.upsert_one(**d)
                 results.append(str(doc.id))
                 meta['n_inserted'] += 1

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -923,8 +923,6 @@ class MongoengineSocket:
             if doc.count() == 0 or update_existing:
                 if not isinstance(d['molecule'], ObjectId):
                     d['molecule'] = ObjectId(d['molecule'])
-                d['basis'] = d['basis'] if d['basis'] is not None else ""
-                d['keywords'] = d['keywords'] if d['keywords'] is not None else ""
                 doc = doc.upsert_one(**d)
                 results.append(str(doc.id))
                 meta['n_inserted'] += 1
@@ -1028,7 +1026,7 @@ class MongoengineSocket:
             (This is to avoid overloading the server)
         skip : int, default is None TODO
             skip the first 'skip' resaults. Used to paginate
-        return_json : bool, deafult is True
+        return_json : bool, default is True
             Return the results as a list of json inseated of objects
         with_ids : bool, default is True
             Include the ids in the returned objects/dicts
@@ -1195,7 +1193,6 @@ class MongoengineSocket:
             doc = Procedure.objects(hash_index=d['hash_index'])
 
             if doc.count() == 0 or update_existing:
-                d['keywords'] = d['keywords'] if d['keywords'] is not None else ""
                 doc = doc.upsert_one(**d)
                 results.append(str(doc.id))
                 meta['n_inserted'] += 1

--- a/qcfractal/tests/test_storage_sockets_me.py
+++ b/qcfractal/tests/test_storage_sockets_me.py
@@ -44,7 +44,7 @@ def test_identical_mol_insert(storage_socket):
 
     water = portal.data.get_molecule("water_dimer_minima.psimol")
 
-    # Add two idential molecules
+    # Add two identical molecules
     ret1 = storage_socket.add_molecules({"w1": water.json_dict(), "w2": water.json_dict()})
     assert ret1["meta"]["success"] is True
     assert ret1["meta"]["n_inserted"] == 1
@@ -375,7 +375,7 @@ def storage_results(storage_socket):
         "molecule": mol_insert["data"]["water2"],
         "method": "M3",
         "basis": "B1",
-        "keywords": "default",
+        "keywords": None,
         "program": "P1",
         "driver": "gradient",
         "return_result": 20,
@@ -395,6 +395,19 @@ def storage_results(storage_socket):
 
     ret = storage_socket.del_molecules(list(mol_insert["data"].values()), index="id")
     assert ret == mol_insert["meta"]["n_inserted"]
+
+
+def test_empty_get(storage_results):
+
+    assert 0 == len(storage_results.get_molecules(None)["data"])
+    assert 0 == len(storage_results.get_molecules([])["data"])
+    assert 0 == len(storage_results.get_molecules("")["data"])
+    # Todo: This needs to return top limit of the table
+    assert 0 == len(storage_results.get_molecules()["data"])
+
+    assert 6 == len(storage_results.get_results()['data'])
+    assert 1 == len(storage_results.get_results(keywords='null')['data'])
+    assert 0 == len(storage_results.get_results(program='null')['data'])
 
 
 def test_results_query_total(storage_results):

--- a/qcfractal/tests/test_storage_sockets_me.py
+++ b/qcfractal/tests/test_storage_sockets_me.py
@@ -406,8 +406,8 @@ def test_empty_get(storage_results):
     assert 0 == len(storage_results.get_molecules()["data"])
 
     assert 6 == len(storage_results.get_results()['data'])
-    assert 1 == len(storage_results.get_results(keywords='null')['data'])
-    assert 0 == len(storage_results.get_results(program='null')['data'])
+    assert 1 == len(storage_results.get_results(keywords='')['data'])
+    assert 0 == len(storage_results.get_results(program='')['data'])
 
 
 def test_results_query_total(storage_results):

--- a/qcfractal/tests/test_storage_sockets_me.py
+++ b/qcfractal/tests/test_storage_sockets_me.py
@@ -406,8 +406,8 @@ def test_empty_get(storage_results):
     assert 0 == len(storage_results.get_molecules()["data"])
 
     assert 6 == len(storage_results.get_results()['data'])
-    assert 1 == len(storage_results.get_results(keywords='')['data'])
-    assert 0 == len(storage_results.get_results(program='')['data'])
+    assert 1 == len(storage_results.get_results(keywords='null')['data'])
+    assert 0 == len(storage_results.get_results(program='null')['data'])
 
 
 def test_results_query_total(storage_results):


### PR DESCRIPTION
## Description
Fixes issue #157 

## Questions
1. In results, only basis and keywords are optional, thus allowed to be None, other required fields can't be empty so there is no meaning to search for, say, program=None; it doesn't exist.
1. In molecule, it doesn't support returing the full list (i.e., get_molecule() -> all molecules up to the max_limit).
1. Collection has both fields (collection, name) as required, so no meaning to search for name=None. Also, the Web hander gets any empty query to None in Pydantic validation. Therefore, it assumes storage.get_collection(name=None, collection=None) to return ALL collections.

## Status
- [x] Ready to go