### PR TITLE
Add pagination to queries

### DIFF
--- a/qcfractal/storage_sockets/me_models.py
+++ b/qcfractal/storage_sockets/me_models.py
@@ -212,10 +212,8 @@ class Procedure(BaseResult):
     keywords = db.DynamicField()
 
     meta = {
-        'collection':
-        'procedure',
-        'allow_inheritance':
-        True,
+        'collection': 'procedure',
+        'allow_inheritance': True,
         'indexes': [
             # TODO: needs a unique index, + molecule?
             {

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -485,7 +485,7 @@ class MongoengineSocket:
 
             meta["n_found"] = data.count()
             meta["success"] = True
-        except Exception as err:  # TODO: remove 
+        except Exception as err:  # TODO: remove
             meta['error_description'] = str(err)
 
         if return_json:
@@ -862,6 +862,7 @@ class MongoengineSocket:
         """
 
         meta = get_metadata_template()
+
         query, error = format_query(
             program=program,
             method=method,
@@ -1677,6 +1678,22 @@ class MongoengineSocket:
                 status="WAITING", modified_on=dt.utcnow())
 
         return updated
+
+    def del_tasks(self, id: Union[str, list]):
+        """Delete a task from the queue. Use with cautious
+
+        Parameters
+        ----------
+        id : str or list
+            Ids of the tasks to delete
+        Returns
+        -------
+        int
+            Number of tasks deleted
+        """
+
+        return TaskQueue.objects(id__in=id).delete()
+
 
     def handle_hooks(self, hooks):
 

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -187,6 +187,14 @@ class MongoengineSocket:
     def get_project_name(self):
         return self._project_name
 
+    def get_limit(self, limit):
+        """Get the allowed limit on results to return in queries based on the
+         given `limit`. If this number is greater than the
+         mongoengine_soket.max_limit then the max_limit will be returned instead.
+        """
+
+        return limit if limit and limit < self._max_limit else self._max_limit
+
     def get_add_molecules_mixed(self, data):
         """
         Get or add the given molecules (if they don't exit).
@@ -448,7 +456,7 @@ class MongoengineSocket:
             Include the DB ids in the returned object (names 'id')
             Default is True
         limit : int, optional
-            Maximum number of resaults to return.
+            Maximum number of results to return.
             If this number is greater than the mongoengine_soket.max_limit then
             the max_limit will be returned instead.
             Default is to return the socket's max_limit (when limit=None or 0)
@@ -463,11 +471,9 @@ class MongoengineSocket:
         meta = get_metadata_template()
         query, errors = format_query(id=id, hash_index=hash_index)
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
-
         data = []
         try:
-            data = Keywords.objects(**query).limit(q_limit)
+            data = Keywords.objects(**query).limit(self.get_limit(limit))
 
             meta["n_found"] = data.count()
             meta["success"] = True
@@ -633,11 +639,9 @@ class MongoengineSocket:
         meta = get_metadata_template()
         query, errors = format_query(name=name, collection=collection)
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
-
         data = []
         try:
-            data = Collection.objects(**query).limit(q_limit)
+            data = Collection.objects(**query).limit(self.get_limit(limit))
 
             meta["n_found"] = data.count()
             meta["success"] = True
@@ -773,7 +777,7 @@ class MongoengineSocket:
 
         meta = get_metadata_template()
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
+        q_limit = self.get_limit(limit)
 
         data = []
         # try:
@@ -859,7 +863,7 @@ class MongoengineSocket:
             keywords=keywords,
             status=status)
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
+        q_limit = self.get_limit(limit)
 
         data = []
         try:
@@ -916,7 +920,7 @@ class MongoengineSocket:
         else:
             query['task_id'] = task_id
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
+        q_limit = self.get_limit(limit)
 
         data = []
         try:
@@ -1050,7 +1054,7 @@ class MongoengineSocket:
         meta = get_metadata_template()
         query, error = format_query(procedure=procedure, program=program, hash_index=hash_index, id=id, status=status)
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
+        q_limit = self.get_limit(limit)
 
         data = []
         try:
@@ -1146,7 +1150,7 @@ class MongoengineSocket:
         meta = get_metadata_template()
         query, error = format_query(task_id=task_id)
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
+        q_limit = self.get_limit(limit)
 
         data = []
         try:
@@ -1277,7 +1281,7 @@ class MongoengineSocket:
         meta = get_metadata_template()
         query, error = format_query(id=id, hash_index=hash_index, procedure_id=procedure_id, status=status)
 
-        q_limit = int(limit if limit and limit < self._max_limit else self._max_limit)
+        q_limit = self.get_limit(limit)
 
         data = []
         # try:
@@ -1493,7 +1497,7 @@ class MongoengineSocket:
         meta = get_metadata_template()
         query, error = format_query(program=program, id=id, hash_index=hash_index, status=status)
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
+        q_limit = self.get_limit(limit)
 
         data = []
         try:
@@ -1531,8 +1535,7 @@ class MongoengineSocket:
         list of the found tasks
         """
 
-        q_limit = limit if limit and limit < self._max_limit else self._max_limit
-        found = TaskQueue.objects(id__in=ids).limit(q_limit)
+        found = TaskQueue.objects(id__in=ids).limit(self.get_limit(limit))
 
         if as_json:
             found = [task.to_json_obj() for task in found]

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -439,8 +439,13 @@ class MongoengineSocket:
         ret = {"data": keywords, "meta": meta}
         return ret
 
-    def get_keywords(self, id: str=None, hash_index: str=None, return_json: bool=True, with_ids: bool=True,
-                     limit=None):
+    def get_keywords(self,
+                     id: str=None,
+                     hash_index: str=None,
+                     limit: int=None,
+                     skip: int=0,
+                     return_json: bool=True,
+                     with_ids: bool=True):
         """Search for one (unique) option based on the 'program'
         and the 'name'. No overwrite allowed.
 
@@ -448,17 +453,19 @@ class MongoengineSocket:
         ----------
         program : str
             program name
+        limit : int, optional
+            Maximum number of results to return.
+            If this number is greater than the mongoengine_soket.max_limit then
+            the max_limit will be returned instead.
+            Default is to return the socket's max_limit (when limit=None or 0)
+        skip : int, optional
         return_json : bool, optional
             Return the results as a json object
             Default is True
         with_ids : bool, optional
             Include the DB ids in the returned object (names 'id')
             Default is True
-        limit : int, optional
-            Maximum number of results to return.
-            If this number is greater than the mongoengine_soket.max_limit then
-            the max_limit will be returned instead.
-            Default is to return the socket's max_limit (when limit=None or 0)
+
 
         Returns
         -------
@@ -472,7 +479,7 @@ class MongoengineSocket:
 
         data = []
         try:
-            data = Keywords.objects(**query).limit(self.get_limit(limit))
+            data = Keywords.objects(**query).limit(self.get_limit(limit)).skip(skip)
 
             meta["n_found"] = data.count()
             meta["success"] = True

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -440,8 +440,8 @@ class MongoengineSocket:
         return ret
 
     def get_keywords(self,
-                     id: str=None,
-                     hash_index: str=None,
+                     id: Union[str, list]=None,
+                     hash_index: Union[str, list]=None,
                      limit: int=None,
                      skip: int=0,
                      return_json: bool=True,
@@ -451,8 +451,10 @@ class MongoengineSocket:
 
         Parameters
         ----------
-        program : str
-            program name
+        id : list or str
+            Ids of the keywords
+        hash_index : list or str
+            hash index of keywords
         limit : int, optional
             Maximum number of results to return.
             If this number is greater than the mongoengine_soket.max_limit then
@@ -483,7 +485,7 @@ class MongoengineSocket:
 
             meta["n_found"] = data.count()
             meta["success"] = True
-        except Exception as err:
+        except Exception as err:  # TODO: remove 
             meta['error_description'] = str(err)
 
         if return_json:

--- a/qcfractal/tests/test_mongoengine_socket.py
+++ b/qcfractal/tests/test_mongoengine_socket.py
@@ -12,6 +12,7 @@ from qcfractal.storage_sockets.me_models import Molecule, Result, Keywords, \
 from qcfractal.testing import mongoengine_socket_fixture as storage_socket
 import pytest
 from bson import ObjectId
+from time import time
 
 
 @pytest.fixture
@@ -265,6 +266,69 @@ def test_add_task_queue(storage_socket, molecules_H4O2):
     task = TaskQueue(base_result=tor)
     task.save()
     assert TaskQueue.objects().count() == 3
+
+
+def test_results_pagination(storage_socket, molecules_H4O2, kw_fixtures):
+    """
+        Test results pagination
+    """
+
+    assert Result.objects().count() == 0
+
+    result_template = {
+        "molecule": ObjectId(molecules_H4O2[0]),
+        "method": "M1",
+        "basis": "B1",
+        "keywords": kw_fixtures[0],
+        "program": "P1",
+        "driver": "energy",
+    }
+
+    # Save (~ 1 msec/doc)
+    t1 = time()
+
+    total_results = 1000
+    first_half = int(total_results/2)
+    limit = 100
+    skip = 50
+
+    for i in range(first_half):
+        result_template['basis'] = str(i)
+        Result(**result_template).save()
+
+    result_template['method'] = 'M2'
+    for i in range(first_half, total_results):
+        result_template['basis'] = str(i)
+        Result(**result_template).save()
+
+    # total_time = (time() - t1) * 1000 / total_results
+    # print('Inserted {} results in {:.2f} msec / doc'.format(total_results, total_time))
+
+    # query (~ 0.13 msec/doc)
+    t1 = time()
+
+    ret1 = Result.objects(method='M1')
+    ret2 = Result.objects(method='M2').limit(limit).skip(skip)
+
+    data1 = [d.to_json_obj() for d in ret1]
+    data2 = [d.to_json_obj() for d in ret2]
+
+    # count is total, but actual data size is the limit
+    assert ret1.count() == first_half
+    assert len(data1) == first_half
+
+    assert ret2.count() == total_results - first_half
+    assert len(ret2) == limit
+    assert len(data2) == limit
+
+    assert int(data2[0]['basis']) == first_half + skip
+
+    # get the last page when with fewer than limit are remaining
+    ret = Result.objects(method='M1').limit(limit).skip(int(first_half - limit / 2))
+    assert len(ret) == limit / 2
+
+    # total_time = (time() - t1) * 1000 / total_results
+    # print('Query {} results in {:.2f} msec /doc'.format(total_results, total_time))
 
 
 def test_queue(storage_socket):

--- a/qcfractal/tests/test_mongoengine_socket.py
+++ b/qcfractal/tests/test_mongoengine_socket.py
@@ -267,6 +267,10 @@ def test_add_task_queue(storage_socket, molecules_H4O2):
     task.save()
     assert TaskQueue.objects().count() == 3
 
+    # cleanup
+    Result.objects.delete()
+    TaskQueue.objects.delete()
+
 
 def test_results_pagination(storage_socket, molecules_H4O2, kw_fixtures):
     """
@@ -330,6 +334,8 @@ def test_results_pagination(storage_socket, molecules_H4O2, kw_fixtures):
     # total_time = (time() - t1) * 1000 / total_results
     # print('Query {} results in {:.2f} msec /doc'.format(total_results, total_time))
 
+    # cleanup
+    Result.objects.delete()
 
 def test_queue(storage_socket):
     tasks = TaskQueue.objects(status='WAITING')\
@@ -340,4 +346,4 @@ def test_queue(storage_socket):
                 # .fields(..)
                 # .exculde(..)
                 # .no_dereference()  # don't get any of the ReferenceFields (ids) (Turning off dereferencing)
-    assert len(tasks) == 3
+    assert len(tasks) == 0


### PR DESCRIPTION
This is done by adding `limit` and `skip`. Here `skip` is a number of results to skip not number of pages. Alternatively, this can be done by specifying page numbers inserted of skipping results.

An important note here is that the total number of results (`result`, `procedure`, `molecule`, etc) is returned in `meta['n_found']` and the size of the data itself is, obviously, not the size of all possible results.

## Todos
  - [x] Add tests

## Status
- [x] Ready to go