### PR TITLE
General tweaks from live evaluation

### DIFF
--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -28,8 +28,8 @@ dependencies:
   - ipykernel
 
 # QCArchive includes
-  - qcengine>=0.6.0
-  - qcelemental>=0.3.0
+  - qcengine>=0.6.2
+  - qcelemental>=0.3.1
 
 # Pip includes
   - pip:

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -21,5 +21,5 @@ dependencies:
   - codecov
 
 # QCArchive includes
-  - qcengine>=0.6.0
-  - qcelemental>=0.3.0
+  - qcengine>=0.6.2
+  - qcelemental>=0.3.1

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -31,7 +31,7 @@ dependencies:
   - pytest-cov
   - codecov
 """
-qca_ecosystem_template = ["qcengine>=0.6.0", "qcelemental>=0.3.0"]
+qca_ecosystem_template = ["qcengine>=0.6.2", "qcelemental>=0.3.1"]
 
 # Note we temporarily duplicate mongoengine as conda-forge appears to be broken
 pip_depends_template = []

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -28,5 +28,5 @@ dependencies:
   - torsiondrive
 
 # QCArchive includes
-  - qcengine>=0.6.0
-  - qcelemental>=0.3.0
+  - qcengine>=0.6.2
+  - qcelemental>=0.3.1

--- a/qcfractal/cli/cli_utils.py
+++ b/qcfractal/cli/cli_utils.py
@@ -62,7 +62,7 @@ def argparse_config_merge(parser, parsed_options, config_options, parser_default
             config_options[k] = v
 
         # Add in missing defaults
-        if v not in config_options:
+        if k not in config_options:
             config_options[k] = v
 
     return config_options

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -6,6 +6,7 @@ import argparse
 
 import qcfractal
 import tornado.log
+import qcengine as qcng
 
 from . import cli_utils
 
@@ -13,56 +14,47 @@ __all__ = ["main"]
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='A CLI for the QCFractal QueueManager.')
-    subparsers = parser.add_subparsers(help='QueueManager Backend Type', dest='adapter_type')
-    subparsers.required = True
-
-    # Keywords for Dask
-    dask_parser = subparsers.add_parser('dask', help='Dask')
-    dask_parser.add_argument("--dask-uri", type=str, help="URI of the dask-server")
-    dask_parser.add_argument(
-        "--local-cluster", action="store_true", help="Start a Dask LocalCluster rather than connect to a scheduler")
-    dask_parser.add_argument(
-        "--local-workers", type=int, default=None, help="The number of workers for the LocalCluster")
-
-    # Keywords for Fireworks
-    fw_parser = subparsers.add_parser('fireworks', help='Fireworks')
-    fw_parser.add_argument("--fw-config", type=str, help="A FWConfig file")
-    fw_parser.add_argument("--fw-uri", type=str, help="URI of MongoDB server")
-    fw_parser.add_argument(
-        "--fw-name", type=str, default="qcfractal_fireworks_manager", help="The MongoDB Database to use locally")
+    parser = argparse.ArgumentParser(
+        description='A CLI for a QCFractal QueueManager with a ProcessPoolExecutor backend.')
 
     # Keywords for ProcessPoolExecutor
-    executor_parser = subparsers.add_parser('executor', help='ProcessPoolExecutor')
-    executor_parser.add_argument("--nprocs", type=int, help="The number of process for the executor")
+    executor = parser.add_argument_group('Executor settings')
+    executor.add_argument(
+        "--ntasks",
+        required=True,
+        type=int,
+        help="The number of simultaneous tasks for the executor to run, resources will be divided evenly.")
+    executor.add_argument("--cores", type=int, help="The number of process for the executor")
+    executor.add_argument("--memory", type=int, help="The total amount of memory on the system in GB")
 
     # FractalClient options
-    parser.add_argument(
+    server = parser.add_argument_group('FractalServer connection settings')
+    server.add_argument(
         "--fractal-uri", type=str, default="localhost:7777", help="FractalServer location to pull from")
-    parser.add_argument("-u", "--username", type=str, help="FractalServer username")
-    parser.add_argument("-p", "--password", type=str, help="FractalServer password")
-    parser.add_argument("--noverify", action="store_true", default=True, help="The logfile prefix to use")
+    server.add_argument("-u", "--username", type=str, help="FractalServer username")
+    server.add_argument("-p", "--password", type=str, help="FractalServer password")
+    server.add_argument("--noverify", action="store_true", default=True, help="The logfile prefix to use")
 
     # QueueManager options
-    parser.add_argument(
+    manager = parser.add_argument_group("QueueManager settings")
+    manager.add_argument(
         "--max-tasks", type=int, default=1000, help="Maximum number of tasks to hold at any given time.")
-    parser.add_argument("--cluster-name", type=str, default="unknown", help="The name of the compute cluster to start")
-    parser.add_argument("--queue-tag", type=str, help="The queue tag to pull from")
-    parser.add_argument("--logfile-prefix", type=str, default=None, help="The prefix of the logfile to write to.")
-    parser.add_argument(
+    manager.add_argument(
+        "--cluster-name", type=str, default="unknown", help="The name of the compute cluster to start")
+    manager.add_argument("--queue-tag", type=str, help="The queue tag to pull from")
+    manager.add_argument("--logfile-prefix", type=str, default=None, help="The prefix of the logfile to write to.")
+    manager.add_argument(
         "--update-frequency", type=int, default=15, help="The frequency in seconds to check for complete tasks.")
 
     # Additional args
-    parser.add_argument("--test", action="store_true", help="Boot and run a short test suite to validate setup")
-    parser.add_argument("--rapidfire", action="store_true", help="Boot and run jobs until complete")
-    parser.add_argument("--config-file", type=str, default=None, help="A configuration file to use")
+    optional = parser.add_argument_group('Optional Settings')
+    optional.add_argument("--test", action="store_true", help="Boot and run a short test suite to validate setup")
+    optional.add_argument("--config-file", type=str, default=None, help="A configuration file to use")
+
     args = vars(parser.parse_args())
     if args["config_file"] is not None:
         data = cli_utils.read_config_file(args["config_file"])
         args = cli_utils.argparse_config_merge(parser, args, data, parser_default=[args["adapter_type"]])
-
-    if args["rapidfire"] and args["test"]:
-        raise KeyError("Can only either select 'rapidfire' or 'test' options, but not both.")
 
     return args
 
@@ -74,47 +66,54 @@ def main(args=None):
         args = parse_args()
 
     exit_callbacks = []
+    args["adapter_type"] = "executor"
 
     # Handle Dask adapters
-    if args["adapter_type"] == "dask":
-        dd = cli_utils.import_module("distributed")
+    # if args["adapter_type"] == "dask":
+    #     dd = cli_utils.import_module("distributed")
 
-        if args["local_cluster"]:
-            # Build localcluster and exit callbacks
-            queue_client = dd.Client(threads_per_worker=1, n_workers=args["local_workers"])
-        else:
-            if args["dask_uri"] is None:
-                raise KeyError("A 'dask-uri' must be specified.")
-            queue_client = dd.Client(args["dask_uri"])
+    #     if args["local_cluster"]:
+    #         # Build localcluster and exit callbacks
+    #         queue_client = dd.Client(threads_per_worker=1, n_workers=args["local_workers"])
+    #     else:
+    #         if args["dask_uri"] is None:
+    #             raise KeyError("A 'dask-uri' must be specified.")
+    #         queue_client = dd.Client(args["dask_uri"])
 
-    # Handle Fireworks adapters
-    elif args["adapter_type"] == "fireworks":
+    # # Handle Fireworks adapters
+    # elif args["adapter_type"] == "fireworks":
 
-        # Check option conflicts
-        num_options = sum(args[x] is not None for x in ["fw_config", "fw_uri"])
-        if num_options == 0:
-            args["fw_uri"] = "mongodb://localhost:27017"
-        elif num_options != 1:
-            raise KeyError("Can only provide a single URI or config_file for Fireworks.")
+    #     # Check option conflicts
+    #     num_options = sum(args[x] is not None for x in ["fw_config", "fw_uri"])
+    #     if num_options == 0:
+    #         args["fw_uri"] = "mongodb://localhost:27017"
+    #     elif num_options != 1:
+    #         raise KeyError("Can only provide a single URI or config_file for Fireworks.")
 
-        fireworks = cli_utils.import_module("fireworks")
+    #     fireworks = cli_utils.import_module("fireworks")
 
-        if args["fw_uri"] is not None:
-            queue_client = fireworks.LaunchPad(args["fw_uri"], name=args["fw_name"])
-        elif args["fw_config"] is not None:
-            queue_client = fireworks.LaunchPad.from_file(args["fw_config"])
-        else:
-            raise KeyError("A URI or config_file must be specified.")
+    #     if args["fw_uri"] is not None:
+    #         queue_client = fireworks.LaunchPad(args["fw_uri"], name=args["fw_name"])
+    #     elif args["fw_config"] is not None:
+    #         queue_client = fireworks.LaunchPad.from_file(args["fw_config"])
+    #     else:
+    #         raise KeyError("A URI or config_file must be specified.")
 
-    elif args["adapter_type"] == "executor":
+    if args["cores"] is None:
+        args["cores"] = qcng.config.get_global("ncores")
+
+    if args["memory"] is None:
+        args["memory"] = qcng.config.get_global("memory")
+
+    if args["adapter_type"] == "executor":
 
         from concurrent.futures import ProcessPoolExecutor
 
-        queue_client = ProcessPoolExecutor(max_workers=args["nprocs"])
+        queue_client = ProcessPoolExecutor(max_workers=args["ntasks"])
 
     else:
-        raise KeyError("Unknown adapter type '{}', available options: 'fireworks', 'dask', .".format(
-            args["adapter_type"]))
+        raise KeyError(
+            "Unknown adapter type '{}', available options: 'fireworks', 'dask', .".format(args["adapter_type"]))
 
     # Quick logging
     if args["logfile_prefix"] is not None:
@@ -128,6 +127,12 @@ def main(args=None):
         client = qcfractal.interface.FractalClient(
             args["fractal_uri"], username=args["username"], password=args["password"], verify=(not args["noverify"]))
 
+    # Figure out per-task data
+    cores_per_task = args["cores"] // args["ntasks"]
+    memory_per_task = args["memory"] / args["ntasks"]
+    if cores_per_task < 1:
+        raise ValueError("Cores per task must be larger than one!")
+
     # Build out the manager itself
     manager = qcfractal.queue.QueueManager(
         client,
@@ -135,16 +140,16 @@ def main(args=None):
         max_tasks=args["max_tasks"],
         queue_tag=args["queue_tag"],
         cluster=args["cluster_name"],
-        update_frequency=args["update_frequency"])
+        update_frequency=args["update_frequency"],
+        cores_per_task=cores_per_task,
+        memory_per_task=memory_per_task)
 
     # Add exit callbacks
     for cb in exit_callbacks:
         manager.add_exit_callback(cb[0], *cb[1], **cb[2])
 
     # Either startup the manager or run until complete
-    if args["rapidfire"]:
-        manager.await_results()
-    elif args["test"]:
+    if args["test"]:
         success = manager.test()
         if success is False:
             raise ValueError("Testing was not successful, failing.")

--- a/qcfractal/cli/qcfractal_server.py
+++ b/qcfractal/cli/qcfractal_server.py
@@ -49,8 +49,7 @@ def parse_args():
     args = vars(parser.parse_args())
     if args["config_file"] is not None:
         data = cli_utils.read_config_file(args["config_file"])
-
-        args = cli_utils.argparse_config_merge(parse, args, data)
+        args = cli_utils.argparse_config_merge(parser, args, data)
 
     return args
 

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -9,7 +9,6 @@ import pytest
 
 from qcfractal import testing
 
-
 # def _run_tests()
 _options = {"coverage": True, "dump_stdout": True}
 _pwd = os.path.dirname(os.path.abspath(__file__))
@@ -41,53 +40,27 @@ def active_server(request):
 
 @testing.mark_slow
 def test_manager_local_testing_process():
-    assert testing.run_process(["qcfractal-manager", "--test", "executor"], **_options)
+    assert testing.run_process(["qcfractal-manager", "--test", "--ntasks=2"], **_options)
 
 
 @testing.mark_slow
 def test_manager_executor_manager_boot(active_server):
-    args = ["qcfractal-manager", active_server.test_uri_cli, "executor", "--nprocs=1"]
+    args = ["qcfractal-manager", active_server.test_uri_cli, "--ntasks=1"]
     assert testing.run_process(args, interupt_after=7, **_options)
 
 
 @testing.mark_slow
-@testing.using_dask
-def test_manager_dask_manager_local_boot(active_server):
-    args = ["qcfractal-manager", active_server.test_uri_cli, "dask", "--local-cluster", "--local-workers=1"]
-    assert testing.run_process(args, interupt_after=7, **_options)
-
-
-@testing.mark_slow
-@testing.using_fireworks
-def test_manager_fireworks_boot(active_server):
-    args = ["qcfractal-manager", active_server.test_uri_cli, "fireworks"]
-    assert testing.run_process(args, interupt_after=5, **_options)
-
-
-@testing.mark_slow
-@testing.using_fireworks
-def test_manager_fireworks_config_boot(active_server):
-    config_path = os.path.join(_pwd, "fw_config_boot.yaml")
-    args = [
-        "qcfractal-manager", active_server.test_uri_cli, "--rapidfire", "--config-file=" + config_path, "fireworks"
-    ]
-    assert testing.run_process(args, **_options)
-
-
-@testing.mark_slow
-@pytest.mark.parametrize("adapter", [
-    "dask",
-    "parsl",
-    # pytest.param("fireworks", marks=pytest.mark.xfail),
-    # pytest.param("executor", marks=pytest.mark.xfail)
-])
-@pytest.mark.parametrize("scheduler", [
-    "slurm",
-    "pbs",
-    "torque",
-    "lsf",
-    pytest.param("garbage", marks=pytest.mark.xfail)
-])
+@pytest.mark.parametrize(
+    "adapter",
+    [
+        "dask",
+        "parsl",
+        # pytest.param("fireworks", marks=pytest.mark.xfail),
+        # pytest.param("executor", marks=pytest.mark.xfail)
+    ])
+@pytest.mark.parametrize("scheduler",
+                         ["slurm", "pbs", "torque", "lsf",
+                          pytest.param("garbage", marks=pytest.mark.xfail)])
 def test_cli_template_generator(adapter, scheduler, tmp_path):
     if adapter == "parsl" and scheduler == "lsf":
         pytest.xfail("Parsl has no LSF implementation")

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -272,7 +272,7 @@ class FractalClient(object):
 
 ### Keywords section
 
-    def get_keywords(self, id: List[str], full_return: bool=False) -> 'List[KeywordSet]':
+    def get_keywords(self, id: List[str]=None, *, hash_index: List[str]=None, full_return: bool=False) -> 'List[KeywordSet]':
         """Obtains KeywordSets from the server using keyword ids.
 
         Parameters
@@ -287,7 +287,8 @@ class FractalClient(object):
         List[KeywordSet]
             The requested KeywordSet objects.
         """
-        body = KeywordGETBody(meta={}, data=id)
+        data = {"id": id, "hash_index": hash_index}
+        body = KeywordGETBody(meta={}, data=data)
         r = self._request("get", "keyword", data=body.json())
         r = KeywordGETResponse.parse_raw(r.text)
 

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -18,7 +18,11 @@ from .models.rest_models import (
 
 
 class FractalClient(object):
-    def __init__(self, address: Any, username: Optional[str]=None, password: Optional[str]=None, verify: bool=True):
+    def __init__(self,
+                 address: Union[str, 'FractalServer']='api.qcarchive.molssi.org:443',
+                 username: Optional[str]=None,
+                 password: Optional[str]=None,
+                 verify: bool=True):
         """Initializes a FractalClient instance from an address and verification information.
 
         Parameters

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -135,9 +135,8 @@ class Collection(abc.ABC):
             raise KeyError("Attempted to create Collection from JSON, but no `collection` field found.")
 
         if data["collection"] != class_name:
-            raise KeyError(
-                "Attempted to create Collection from JSON with class {}, but found collection type of {}.".format(
-                    class_name, data["collection"]))
+            raise KeyError("Attempted to create Collection from JSON with class {}, but found collection type of {}.".
+                           format(class_name, data["collection"]))
 
         # Attempt to build class
         # First make sure external source provides ALL keys, including "optional" ones
@@ -156,7 +155,7 @@ class Collection(abc.ABC):
         # Allow PyDantic to handle type validation
         return cls(name, client=client, **data)
 
-    def to_json(self, filename: Optional[str] = None):
+    def to_json(self, filename: Optional[str]=None):
         """
         If a filename is provided, dumps the file to disk. Otherwise returns a copy of the current data.
 
@@ -194,7 +193,7 @@ class Collection(abc.ABC):
         pass
 
     # Setters
-    def save(self, client=None, overwrite: bool = False):
+    def save(self, client=None):
         """Uploads the overall structure of the Collection (indices, options, new molecules, etc)
         to the server.
 
@@ -216,10 +215,12 @@ class Collection(abc.ABC):
                                      "instance and one was not passed in.".format(class_name))
             client = self.client
 
-        if overwrite and (self.data.id == self.data.fields['id'].default):
-            raise KeyError("Attempting to overwrite the {} class on the server, but no ID found.".format(class_name))
-
         self._pre_save_prep(client)
 
         # Add the database
-        return client.add_collection(self.data.dict(), overwrite=overwrite)
+        if (self.data.id == self.data.fields['id'].default):
+            self.data.id = client.add_collection(self.data.dict(), overwrite=False)
+        else:
+            client.add_collection(self.data.dict(), overwrite=True)
+
+        return self.data.id

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -358,7 +358,7 @@ class Dataset(Collection):
               field="return_result",
               as_array=False):
         """
-        Queries the local Portal for the requested keys and stoichiometry.
+        Queries the local Portal for the requested keys.
 
         Parameters
         ----------
@@ -426,7 +426,7 @@ class Dataset(Collection):
 
         return True
 
-    def compute(self, method, basis, driver=None, keywords=None, program=None, stoich="default", ignore_ds_type=False):
+    def compute(self, method, basis, driver=None, keywords=None, program=None, ignore_ds_type=False):
         """Executes a computational method for all reactions in the Dataset.
         Previously completed computations are not repeated.
 
@@ -438,8 +438,6 @@ class Dataset(Collection):
             The computational basis to compute (6-31G)
         driver : str, optional
             The type of computation to run (energy, gradient, etc)
-        stoich : str, optional
-            The stoichiometry of the requested compute (cp/nocp/etc)
         keywords : str, optional
             The keyword alias for the requested compute
         program : str, optional

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -232,7 +232,7 @@ class Dataset(Collection):
 
         self.data.default_program = program.lower()
 
-    def add_keywords(self, alias: str, program: str, keyword: 'KeywordSet', default: bool = False) -> bool:
+    def add_keywords(self, alias: str, program: str, keyword: 'KeywordSet', default: bool=False) -> bool:
         """
         Adds an option alias to the dataset. Not that keywords are not present
         until a save call has been completed.
@@ -260,6 +260,19 @@ class Dataset(Collection):
         if default:
             self.data.default_keywords[program] = alias
         return True
+
+    def get_keywords(self, alias: str, program: str) -> 'KeywordSet':
+
+        if self.client is None:
+            raise AttributeError("Dataset: Client was not set.")
+
+        alias = alias.lower()
+        program = program.lower()
+        if (program not in self.data.alias_keywords) or (alias not in self.data.alias_keywords[program]):
+            raise KeyError("Keywords {}: {} not found.".format(program, alias))
+
+        kwid = self.data.alias_keywords[program][alias]
+        return self.client.get_keywords([kwid])[0]
 
     def add_contributed_values(self, contrib: ContributedValues, overwrite=False) -> None:
         """Adds a ContributedValues to the database.
@@ -453,7 +466,7 @@ class Dataset(Collection):
         self._check_state()
 
         if self.client is None:
-            raise AttributeError("DataBase: Compute: Client was not set.")
+            raise AttributeError("Dataset: Compute: Client was not set.")
 
         driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -172,6 +172,9 @@ class Dataset(Collection):
         return df
 
     def _default_parameters(self, driver, keywords, program):
+        """
+        Takes raw input parsed parameters and applies defaults to them.
+        """
 
         if program is None:
             if self.data.default_program is None:
@@ -245,6 +248,7 @@ class Dataset(Collection):
         """
 
         alias = alias.lower()
+        program = program.lower()
         if program not in self.data.alias_keywords:
             self.data.alias_keywords[program] = {}
 

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -207,7 +207,7 @@ class OpenFFWorkflow(Collection):
             frag_data[name] = packet
 
         # Push collection data back to server
-        self.save(overwrite=True)
+        self.save()
 
     def _add_torsiondrive(self, packet):
         # Build out a new service

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -225,12 +225,13 @@ class ReactionDataset(Dataset):
         ds.query("B3LYP", "aug-cc-pVDZ", stoich="cp", prefix="cp-")
 
         """
-
-        driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
-        self._validate_stoich(stoich)
+        self._check_state()
 
         if not contrib and (self.client is None):
             raise AttributeError("DataBase: FractalClient was not set.")
+
+        driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
+        self._validate_stoich(stoich)
 
         # # If reaction results
         if contrib:
@@ -297,7 +298,7 @@ class ReactionDataset(Dataset):
         self._check_state()
 
         if self.client is None:
-            raise AttributeError("DataBase: Compute: Client was not set.")
+            raise AttributeError("Dataset: Compute: Client was not set.")
 
         driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
         self._validate_stoich(stoich)

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -260,6 +260,7 @@ class ResultRecord(RecordBase):
 
         # Result specific
         self.extras = data["extras"]
+        self.extras.pop("_qcfractal_tags", None)
         self.return_result = data["return_result"]
         self.properties = data["properties"]
 

--- a/qcfractal/interface/models/tests/test_hashes.py
+++ b/qcfractal/interface/models/tests/test_hashes.py
@@ -32,14 +32,14 @@ def test_molecule_water_canary_hash():
 
     frag_0 = mol.get_fragment(0, orient=True)
     frag_1 = mol.get_fragment(1, orient=True)
-    assert frag_0.get_hash() == "d8975ddd917a57f468596b54968b0dffe52c7487"
-    assert frag_1.get_hash() == "feb5c6127ca54d715b999c15ea1ea1772ada8c5d"
+    assert frag_0.get_hash() == "f701c1724e645f52c09dbf36d01fe17d9d882a8a"
+    assert frag_1.get_hash() == "4469ff05895a6375a91ce9a225f96e3f9938450b"
 
 @pytest.mark.parametrize("geom, hash_index", [
-    ([0, 0, 0, 0, 0, 0], "78c135e2e81bb84bdcbbcb9ee3f1a031b4b5501a"),
-    ([0, 0, 0, 0, 0, 0 + 1.e-12], "78c135e2e81bb84bdcbbcb9ee3f1a031b4b5501a"),
-    ([0, 0, 0, 0, 0, 0 - 1.e-12], "78c135e2e81bb84bdcbbcb9ee3f1a031b4b5501a"),
-    ([0, 0, 0, 0, 0, 0 + 1.e-7], "78c135e2e81bb84bdcbbcb9ee3f1a031b4b5501a"),
+    ([0, 0, 0, 0, 5, 0], "ba76b68bb11e042712b2444d6b42ebbf92b944fc"),
+    ([0, 0, 0, 0, 5, 0 + 1.e-12], "ba76b68bb11e042712b2444d6b42ebbf92b944fc"),
+    ([0, 0, 0, 0, 5, 0 - 1.e-12], "ba76b68bb11e042712b2444d6b42ebbf92b944fc"),
+    ([0, 0, 0, 0, 5, 0 + 1.e-7], "ba76b68bb11e042712b2444d6b42ebbf92b944fc"),
 ]) # yapf: disable
 def test_molecule_geometry_canary_hash(geom, hash_index):
 

--- a/qcfractal/interface/tests/test_molecule.py
+++ b/qcfractal/interface/tests/test_molecule.py
@@ -79,8 +79,8 @@ def test_water_minima_fragment():
 
     frag_0 = mol.get_fragment(0, orient=True)
     frag_1 = mol.get_fragment(1, orient=True)
-    assert frag_0.get_hash() == "6d253a5a66eb68b611ab6bb0f15b55bbd3f6fe91"
-    assert frag_1.get_hash() == "feb5c6127ca54d715b999c15ea1ea1772ada8c5d"
+    assert frag_0.get_hash() == "0b13814f79b8f74f17499b31fe7b76cd97b89449"
+    assert frag_1.get_hash() == "4469ff05895a6375a91ce9a225f96e3f9938450b"
 
     frag_0_1 = mol.get_fragment(0, 1)
     frag_1_0 = mol.get_fragment(1, 0)

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -42,15 +42,15 @@ class QueueManager:
     def __init__(self,
                  client: Any,
                  queue_client: Any,
-                 loop: Any = None,
-                 logger: Optional[logging.Logger] = None,
-                 max_tasks: int = 200,
-                 queue_tag: str = None,
-                 cluster: str = "unknown",
-                 update_frequency: Union[int, float] = 2,
-                 verbose: bool = True,
-                 cores_per_task: Optional[int] = None,
-                 memory_per_task: Optional[int] = None):
+                 loop: Any=None,
+                 logger: Optional[logging.Logger]=None,
+                 max_tasks: int=200,
+                 queue_tag: str=None,
+                 cluster: str="unknown",
+                 update_frequency: Union[int, float]=2,
+                 verbose: bool=True,
+                 cores_per_task: Optional[int]=None,
+                 memory_per_task: Optional[int]=None):
         """
         Parameters
         ----------
@@ -106,7 +106,6 @@ class QueueManager:
         # Pull the current loop if we need it
         self.loop = loop or tornado.ioloop.IOLoop.current()
 
-
         self.logger.info("QueueManager:")
         self.logger.info("    Version:         {}\n".format(get_information("version")))
 
@@ -121,7 +120,9 @@ class QueueManager:
 
         if self.verbose:
             self.logger.info("    QCEngine:")
-            self.logger.info("        Version:    {}\n".format(qcengine.__version__))
+            self.logger.info("        Version:     {}".format(qcengine.__version__))
+            self.logger.info("        Task Cores:  {}".format(self.cores_per_task))
+            self.logger.info("        Task Mem:    {}\n".format(self.memory_per_task))
 
         # DGAS Note: Note super happy about how this if/else turned out. Looking for alternatives.
         if self.connected():
@@ -132,7 +133,9 @@ class QueueManager:
             self.server_query_limit = self.server_info["query_limit"]
             if self.max_tasks > self.server_query_limit:
                 self.max_tasks = self.server_query_limit
-                self.logger.warning("Max tasks was larger than server query limit of {}, reducing to match query limit.".format(self.server_query_limit))
+                self.logger.warning(
+                    "Max tasks was larger than server query limit of {}, reducing to match query limit.".format(
+                        self.server_query_limit))
             self.heartbeat_frequency = self.server_info["heartbeat_frequency"]
 
             # Tell the server we are up and running
@@ -153,7 +156,6 @@ class QueueManager:
         else:
             self.logger.info("    QCFractal server information:")
             self.logger.info("        Not connected, some actions will not be available")
-
 
     def _payload_template(self):
         meta = self.name_data.copy()
@@ -242,7 +244,6 @@ class QueueManager:
 
         return self.queue_adapter.close()
 
-
 ## Queue Manager functions
 
     def heartbeat(self) -> None:
@@ -298,7 +299,7 @@ class QueueManager:
         """
         self.exit_callbacks.append((callback, args, kwargs))
 
-    def update(self, new_tasks: bool = True) -> bool:
+    def update(self, new_tasks: bool=True) -> bool:
         """Examines the queue for completed tasks and adds successful completions to the database
         while unsuccessful are logged for future inspection
 

--- a/qcfractal/tests/test_client.py
+++ b/qcfractal/tests/test_client.py
@@ -38,10 +38,10 @@ def test_client_options(test_server):
     ret = client.add_keywords([opt])
 
     # Test get
-    get_kw = client.get_keywords({'id': ret[0]})
+    get_kw = client.get_keywords([ret[0]])
     assert opt == get_kw[0]
 
-    get_kw = client.get_keywords({"hash_index": opt.hash_index})
+    get_kw = client.get_keywords(hash_index=[opt.hash_index])
     assert opt == get_kw[0]
 
 

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -130,7 +130,7 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
     ds = client.get_collection("reactiondataset", ds_name)
 
     with pytest.raises(KeyError):
-        ret = ds.compute("SCF", "STO-3G", stoich="nocp") # Should be 'default' not 'nocp'
+        ret = ds.compute("SCF", "STO-3G", stoich="nocp")  # Should be 'default' not 'nocp'
 
     # Compute SCF/sto-3g
     ret = ds.compute("SCF", "STO-3G")
@@ -183,9 +183,14 @@ def test_compute_reactiondataset_keywords(fractal_compute_server):
     assert ds.list_history(keywords="DF").shape[0] == 1
     assert ds.list_history(keywords="DIRECT").shape[0] == 1
 
+    # Check saved history
     ds = client.get_collection("reactiondataset", "dataset_options")
     assert ds.list_history().shape[0] == 2
     assert {"df", "direct"} == set(ds.list_history().reset_index()["keywords"])
+
+    # Check keywords
+    kw = ds.get_keywords("df", "psi4")
+    assert kw.values["scf_type"] == "df"
 
 
 @testing.using_torsiondrive

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -129,6 +129,9 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
     r = ds.save()
     ds = client.get_collection("reactiondataset", ds_name)
 
+    with pytest.raises(KeyError):
+        ret = ds.compute("SCF", "STO-3G", stoich="nocp") # Should be 'default' not 'nocp'
+
     # Compute SCF/sto-3g
     ret = ds.compute("SCF", "STO-3G")
     assert len(ret.submitted) == 3

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -126,7 +126,7 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
     ds.add_contributed_values(contrib)
 
     # Save the DB and overwrite the result, reacquire via client
-    r = ds.save(overwrite=True)
+    r = ds.save()
     ds = client.get_collection("reactiondataset", ds_name)
 
     # Compute SCF/sto-3g
@@ -163,6 +163,7 @@ def test_compute_reactiondataset_keywords(fractal_compute_server):
     ds.add_keywords("df", "psi4", portal.models.KeywordSet(values={"scf_type": "df"}))
 
     ds.save()
+    ds = client.get_collection("reactiondataset", "dataset_options")
 
     # Compute, should default to direct options
     r = ds.compute("SCF", "STO-3G")
@@ -178,6 +179,10 @@ def test_compute_reactiondataset_keywords(fractal_compute_server):
     assert ds.list_history().shape[0] == 2
     assert ds.list_history(keywords="DF").shape[0] == 1
     assert ds.list_history(keywords="DIRECT").shape[0] == 1
+
+    ds = client.get_collection("reactiondataset", "dataset_options")
+    assert ds.list_history().shape[0] == 2
+    assert {"df", "direct"} == set(ds.list_history().reset_index()["keywords"])
 
 
 @testing.using_torsiondrive

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ if __name__ == "__main__":
             'mongoengine',
 
             # QCArchive depends
-            'qcengine>=0.6.0',
-            'qcelemental>=0.3.0',
+            'qcengine>=0.6.2',
+            'qcelemental>=0.3.1',
 
             # Testing
             'pytest',


### PR DESCRIPTION
## Description
This PR provides a host of tweaks and bug fixes from using the code at a production level. These are:
 - FractalClient now automatically connects to `api.qcarchive.molssi.org`
 - Fixes a bug where config-file data was not respected.
 - Removed override from the `collection.save()` feature which is now automatically used correctly on updates.
 - Several hash changes due to fixes in QCElemental v0.3.1
 - `_fractal_tags` were leaking into results and are now properly removed.
 - Removes stoic from the base dataset where this is not used.
 - QueueManager CLI is now reduced to just a PoolExecutor for now.
 - Bumps ecosystem required versions.

## Status
- [ ] Changelog updated
- [x] Ready to go