### PR TITLE
Queue Manager now reads Config File

### DIFF
--- a/docs/qcfractal/source/setup_compute.rst
+++ b/docs/qcfractal/source/setup_compute.rst
@@ -101,7 +101,7 @@ To setup a Dask with the SLURM queue manager the following command can be run:
 
     # Fractal Settings
     # Location of the Fractal Server you are connecting to
-    FRACTAL_ADDRESS = "localhost:7777"
+    FRACTAL_URI = "localhost:7777"
     ...
 
 The generated script has a small tutorial on how to correct fill in the

--- a/qcfractal/cli/cli_utils.py
+++ b/qcfractal/cli/cli_utils.py
@@ -10,12 +10,14 @@ import signal
 import yaml
 
 
-def import_module(module):
+def import_module(module, package=None):
     """Protected import of a module
     """
     try:
-        ret = importlib.import_module(module)
+        ret = importlib.import_module(module, package=package)
     except ImportError:
+        if package is not None:
+            raise ImportError("Requested module/package '{}/{}' not found.".format(module, package))
         raise ImportError("Requested module '{}' not found.".format(module))
 
     return ret
@@ -44,13 +46,14 @@ def argparse_config_merge(parser, parsed_options, config_options, parser_default
     ----------
     parser : ArgumentParser
     config_options : dict
-    parser_default : None, optional
+    parser_default : List, Optional
     """
     config_options = copy.deepcopy(config_options)
 
     default_options = vars(parser.parse_args(args=parser_default))
     diff = config_options.keys() - default_options.keys()
     if diff:
+        import argparse
         raise argparse.ArgumentError(None,
                                      "Unknown arguments found in configuration file: {}.".format(", ".join(diff)))
 

--- a/qcfractal/cli/cli_utils.py
+++ b/qcfractal/cli/cli_utils.py
@@ -33,13 +33,16 @@ def read_config_file(fname):
     else:
         raise TypeError("Did not understand file type {}.".format(fname))
 
-    with open(fname, "r") as handle:
-        ret = rfunc(handle)
+    try:
+        with open(fname, "r") as handle:
+            ret = rfunc(handle)
+    except FileNotFoundError:
+        raise FileNotFoundError("No config file found at {}.".format(config_file))
 
     return ret
 
 
-def argparse_config_merge(parser, parsed_options, config_options, parser_default=None):
+def argparse_config_merge(parser, parsed_options, config_options, parser_default=None, check=True):
     """Merges options between a configuration file and a parser
 
     Parameters
@@ -50,11 +53,12 @@ def argparse_config_merge(parser, parsed_options, config_options, parser_default
     """
     config_options = copy.deepcopy(config_options)
 
-    default_options = vars(parser.parse_args(args=parser_default))
-    diff = config_options.keys() - default_options.keys()
-    if diff:
-        raise argparse.ArgumentError(None,
-                                     "Unknown arguments found in configuration file: {}.".format(", ".join(diff)))
+    if check:
+        default_options = vars(parser.parse_args(args=parser_default))
+        diff = config_options.keys() - default_options.keys()
+        if diff:
+            raise argparse.ArgumentError(None,
+                                         "Unknown arguments found in configuration file: {}.".format(", ".join(diff)))
 
     # Add in parsed options
     for k, v in parsed_options.items():

--- a/qcfractal/cli/cli_utils.py
+++ b/qcfractal/cli/cli_utils.py
@@ -2,6 +2,7 @@
 Utilities for CLI programs
 """
 
+import argparse
 import copy
 import importlib
 import json
@@ -15,11 +16,10 @@ def import_module(module, package=None):
     """
     try:
         ret = importlib.import_module(module, package=package)
-    except ImportError:
+    except ModuleNotFoundError:
         if package is not None:
-            raise ImportError("Requested module/package '{}/{}' not found.".format(module, package))
-        raise ImportError("Requested module '{}' not found.".format(module))
-
+            raise ModuleNotFoundError("Requested module/package '{}/{}' not found.".format(module, package))
+        raise ModuleNotFoundError("Requested module '{}' not found.".format(module))
     return ret
 
 
@@ -53,7 +53,6 @@ def argparse_config_merge(parser, parsed_options, config_options, parser_default
     default_options = vars(parser.parse_args(args=parser_default))
     diff = config_options.keys() - default_options.keys()
     if diff:
-        import argparse
         raise argparse.ArgumentError(None,
                                      "Unknown arguments found in configuration file: {}.".format(", ".join(diff)))
 

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -64,6 +64,8 @@ class SchedulerEnum(str, Enum):
     slurm = "slurm"
     torque = "torque"
     pbs = "pbs"
+    sge = "sge"
+    moab = "moab"
 
 
 class ClusterSettings(BaseSettings):
@@ -75,10 +77,11 @@ class ClusterSettings(BaseSettings):
     walltime: str = "00:10:00"
 
     @validator("scheduler")
-    def remap_pbs_to_torque(cls, v):
-        if v == "pbs":
-            print('Remapping `scheduler` option "pbs" to "torque"')
-            v = 'torque'
+    def remap_torque_to_pbs(cls, v):
+        if v == "torque":
+            print('WARING: Remapping `scheduler` option "torque" to "pbs" as Dask does not have a Torque scheduler but '
+                  'may be close enough to work. Compatibility not assured.')
+            v = 'pbs'
         return v
 
     class Config(SettingsCommonConfig):
@@ -239,7 +242,8 @@ def main(args=None):
         if settings.cluster.node_exclusivity and "--exclusive" not in scheduler_opts:
             scheduler_opts.append("--exclusive")
 
-        _cluster_loaders = {"slurm": "SLURMCluster", "pbs": "PBSCluster", "torque": "PBSCluster"}
+        _cluster_loaders = {"slurm": "SLURMCluster", "pbs": "PBSCluster", "torque": "PBSCluster", "moab": "MoabCluster",
+                            "sge": "SGECluster"}
 
         # Create one construct to quickly merge dicts with a final check
         dask_construct = dict(

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -3,7 +3,6 @@ A command line interface to the qcfractal server.
 """
 
 import argparse
-from collections import defaultdict
 from enum import Enum
 from typing import List
 import os
@@ -18,6 +17,7 @@ from . import cli_utils
 __all__ = ["main"]
 
 QCA_RESOURCE_STRING = '--resources process=1'
+MANAGER_CONFIG_NAME = "qcf_manager_config.yaml"
 
 
 class SettingsCommonConfig:
@@ -129,9 +129,6 @@ class ManagerSettings(BaseModel):
     server: FractalServerSettings = FractalServerSettings()
     cluster: ClusterSettings = ClusterSettings()
     dask_jobqueue: DaskJobQueueSettings = DaskJobQueueSettings()
-
-
-MANAGER_CONFIG_NAME = "qcf_manager_config.yaml"
 
 
 def parse_args():

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -3,7 +3,12 @@ A command line interface to the qcfractal server.
 """
 
 import argparse
+from collections import defaultdict
+from enum import Enum
+from typing import List
+import os
 
+from pydantic import BaseSettings, validator, BaseModel, conint, confloat
 import qcfractal
 import tornado.log
 import qcengine as qcng
@@ -12,16 +17,138 @@ from . import cli_utils
 
 __all__ = ["main"]
 
+QCA_RESOURCE_STRING = '--resources process=1'
+
+
+class SettingsCommonConfig:
+    env_prefix = "QCA_"
+    case_insensitive = True
+
+
+class AdapterEnum(str, Enum):
+    dask = "dask"
+    pool = "pool"
+
+
+class CommonManagerSettings(BaseSettings):
+    ntasks: int = 1
+    cores: int = qcng.config.get_global("ncores")
+    memory: confloat(gt=0) = qcng.config.get_global("memory")
+    max_tasks: conint(gt=0) = 200
+    manager_name: str = "unknown"
+    update_frequency: float = 30
+    test: bool = False
+    adapter: AdapterEnum = AdapterEnum.pool
+    log_file_prefix: str = None
+    queue_tag: str = None
+
+    class Config(SettingsCommonConfig):
+        pass
+
+
+class FractalServerSettings(BaseSettings):
+    file: str = None
+    address: str = None
+    username: str = None
+    password: str = None
+    verify: bool = None
+
+    class Config(SettingsCommonConfig):
+        pass
+
+    @validator("file")
+    def file_stands_alone(cls, v, values, **kwargs):
+        if any(other is not None for other in values):
+            raise ValueError("Either specify a Fractal Server config `file` location or manually set the "
+                             "(address, username, password), but not both!")
+        return v
+
+    @property
+    def specified(self):
+        """Helper function to determine if something was set manually"""
+        return any(x is not None for x in [self.address, self.username, self.password, self.verify])
+
+
+class SchedulerEnum(str, Enum):
+    slurm = "slurm"
+    torque = "torque"
+    pbs = "pbs"
+
+
+class ClusterSettings(BaseSettings):
+    max_nodes: conint(gt=0) = 1
+    node_exclusivity: bool = True
+    scheduler: SchedulerEnum = None
+    scheduler_options: List[str] = []
+    task_startup_commands: List[str] = []
+    walltime: str = "00:10:00"
+
+    @validator("scheduler")
+    def remap_pbs_to_torque(cls, v):
+        if v == "pbs":
+            print('Remapping `scheduler` option "pbs" to "torque"')
+            v = 'torque'
+        return v
+
+    class Config(SettingsCommonConfig):
+        pass
+
+
+class _DaskJobQueueSettingsNoCheck(BaseSettings):
+    interface: str = None
+    extra: List[str] = None
+
+    class Config(SettingsCommonConfig):
+        extra = "allow"
+
+
+class DaskJobQueueSettings(_DaskJobQueueSettingsNoCheck):
+    """Pass through options beyond interface are permitted"""
+
+    def __init__(self, **kwargs):
+        """Enforce that the keys we are going to set remain untouched"""
+        bad_set = set(kwargs.keys()) - {"name",
+                                        "cores",
+                                        "memory",
+                                        "queue",
+                                        "processes",
+                                        "walltime",
+                                        "env_extra",
+                                        "qca_resource_string"
+                                        }
+
+        if bad_set:
+            raise KeyError("The following items were set as part of dask_jobqueue, however, "
+                           "there are other config items which control these in more generic "
+                           "settings locations: {}".format(bad_set))
+        super().__init__(**kwargs)
+
+
+class ManagerSettings(BaseModel):
+    common: CommonManagerSettings = CommonManagerSettings()
+    server: FractalServerSettings = FractalServerSettings()
+    cluster: ClusterSettings = ClusterSettings()
+    dask_jobqueue: DaskJobQueueSettings = DaskJobQueueSettings()
+
+
+MANAGER_CONFIG_NAME = "qcf_manager_config.yaml"
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description='A CLI for a QCFractal QueueManager with a ProcessPoolExecutor backend.')
+        description='A CLI for a QCFractal QueueManager with a ProcessPoolExecutor or a Dask backend. '
+                    'The Dask backend *requires* a config file due to the complexity of its setup. If a config '
+                    'file is specified, the remaining options serve as CLI overwrites of the config.'
+                    'Config files are searched for in working directory and ~/.qca/ for "{}"'
+                    ''.format(MANAGER_CONFIG_NAME))
 
+    parser.add_argument("config_file", nargs="?", type=str,
+                        default=[os.path.join(os.path.realpath("."), MANAGER_CONFIG_NAME),
+                                 os.path.join(os.path.expanduser("~"), ".qca", MANAGER_CONFIG_NAME)])
     # Keywords for ProcessPoolExecutor
     executor = parser.add_argument_group('Executor settings')
     executor.add_argument(
         "--ntasks",
-        required=True,
         type=int,
         help="The number of simultaneous tasks for the executor to run, resources will be divided evenly.")
     executor.add_argument("--cores", type=int, help="The number of process for the executor")
@@ -30,31 +157,29 @@ def parse_args():
     # FractalClient options
     server = parser.add_argument_group('FractalServer connection settings')
     server.add_argument(
-        "--fractal-uri", type=str, default="localhost:7777", help="FractalServer location to pull from")
+        "--fractal-address", type=str, help="FractalServer location to pull from")
     server.add_argument("-u", "--username", type=str, help="FractalServer username")
     server.add_argument("-p", "--password", type=str, help="FractalServer password")
-    server.add_argument("--noverify", action="store_true", default=True, help="The logfile prefix to use")
+    server.add_argument("--no-verify", action="store_true", help="Don't verify the SSL certificate")
+    server.add_argument("--server-config-file", type=str,
+                        help="A Fractal Server configuration file to use")
 
     # QueueManager options
     manager = parser.add_argument_group("QueueManager settings")
     manager.add_argument(
-        "--max-tasks", type=int, default=1000, help="Maximum number of tasks to hold at any given time.")
+        "--max-tasks", type=int, help="Maximum number of tasks to hold at any given time.")
     manager.add_argument(
-        "--cluster-name", type=str, default="unknown", help="The name of the compute cluster to start")
+        "--manager-name", type=str, help="The name of the manager to start")
     manager.add_argument("--queue-tag", type=str, help="The queue tag to pull from")
-    manager.add_argument("--logfile-prefix", type=str, default=None, help="The prefix of the logfile to write to.")
+    manager.add_argument("--log-file-prefix", type=str, help="The path prefix of the logfile to write to.")
     manager.add_argument(
-        "--update-frequency", type=int, default=15, help="The frequency in seconds to check for complete tasks.")
+        "--update-frequency", type=int, help="The frequency in seconds to check for complete tasks.")
 
     # Additional args
     optional = parser.add_argument_group('Optional Settings')
     optional.add_argument("--test", action="store_true", help="Boot and run a short test suite to validate setup")
-    optional.add_argument("--config-file", type=str, default=None, help="A configuration file to use")
 
     args = vars(parser.parse_args())
-    if args["config_file"] is not None:
-        data = cli_utils.read_config_file(args["config_file"])
-        args = cli_utils.argparse_config_merge(parser, args, data, parser_default=[args["adapter_type"]])
 
     return args
 
@@ -64,83 +189,148 @@ def main(args=None):
     # Grab CLI args if not present
     if args is None:
         args = parse_args()
-
     exit_callbacks = []
-    args["adapter_type"] = "executor"
 
-    # Handle Dask adapters
-    # if args["adapter_type"] == "dask":
-    #     dd = cli_utils.import_module("distributed")
+    # Try to read a config file first
+    config_file = args["config_file"]
+    if type(config_file) is str:  # Cast to unified code for same list
+        config_file = [config_file]
+    data = {}
+    fail_count = 0
+    for path in config_file:  # Multiple searchable paths if defaults
+        try:
+            data = cli_utils.read_config_file(path)
+            print("Found config file at {}".format(path))
+            break  # Found a config file, stop trying
+        except FileNotFoundError:
+            fail_count += 1
+    if fail_count == len(config_file):
+        print("No config file found at {}, relying on CLI input only.\n"
+              "This can only create Pool Executors with limited options".format(config_file))
+    elif data == {} or data is None:
+        print("Found a config file found at {}, but it appeared empty. Relying on CLI input only.\n"
+              "This can only create Pool Executors with limited options".format(config_file))
+        data = {}  # Ensures data is a dict in case empty yaml, which returns None
 
-    #     if args["local_cluster"]:
-    #         # Build localcluster and exit callbacks
-    #         queue_client = dd.Client(threads_per_worker=1, n_workers=args["local_workers"])
-    #     else:
-    #         if args["dask_uri"] is None:
-    #             raise KeyError("A 'dask-uri' must be specified.")
-    #         queue_client = dd.Client(args["dask_uri"])
+    # Handle CLI/args mappings
+    # Handle the Manager settings
+    if "common" not in data:
+        data["common"] = {}
+    for arg in ["cores", "memory", "ntasks", "max_tasks", "manager_name", "update_frequency", "queue_tag",
+                "log_file_prefix", "test"]:
+        # Overwrite the args from the config file
+        if arg in args and args[arg] is not None:
+            data["common"][arg] = args[arg]
+    # Handle Fractal Server (have to map the CLI onto the Pydantic)
+    if "server" not in data:
+        data["server"] = {}
+    for arg, var in [("fractal-address", "address"),
+                     ("username", "username"),
+                     ("password", "password"),
+                     ("server_config_file", "file"),
+                     ("no_verify", "verify")]:
+        if arg in args and args[arg] is not None:
+            v = args[arg]
+            if arg.startswith("no_"):  # Negation
+                v = not v
+            data["server"][var] = v
 
-    # # Handle Fireworks adapters
-    # elif args["adapter_type"] == "fireworks":
+    # Construct object
+    settings = ManagerSettings(**data)
 
-    #     # Check option conflicts
-    #     num_options = sum(args[x] is not None for x in ["fw_config", "fw_uri"])
-    #     if num_options == 0:
-    #         args["fw_uri"] = "mongodb://localhost:27017"
-    #     elif num_options != 1:
-    #         raise KeyError("Can only provide a single URI or config_file for Fireworks.")
+    if settings.common.log_file_prefix is not None:
+        tornado.options.options['log_file_prefix'] = settings.common.log_file_prefix
+    tornado.log.enable_pretty_logging()
 
-    #     fireworks = cli_utils.import_module("fireworks")
+    if settings.common.test:
+        # Test, nothing needed
+        client = None
+    elif settings.server.file is not None:
+        # Gave a file? Neat!
+        client = qcfractal.interface.FractalClient.from_file(settings.server.file)
+    elif settings.server.specified:
+        # Specified something? Okay!
+        client = qcfractal.interface.FractalClient(settings.server.dict(exclude={"file"}, skip_defaults=True))
+    else:
+        # Finally, fall back and assume the user has a config file in the default path
+        # somewhere that FractalClient knows about!
+        client = qcfractal.interface.FractalClient()
 
-    #     if args["fw_uri"] is not None:
-    #         queue_client = fireworks.LaunchPad(args["fw_uri"], name=args["fw_name"])
-    #     elif args["fw_config"] is not None:
-    #         queue_client = fireworks.LaunchPad.from_file(args["fw_config"])
-    #     else:
-    #         raise KeyError("A URI or config_file must be specified.")
+    # Figure out per-task data
+    cores_per_task = settings.common.cores // settings.common.ntasks
+    memory_per_task = settings.common.memory / settings.common.ntasks
+    if cores_per_task < 1:
+        raise ValueError("Cores per task must be larger than one!")
 
-    if args["cores"] is None:
-        args["cores"] = qcng.config.get_global("ncores")
-
-    if args["memory"] is None:
-        args["memory"] = qcng.config.get_global("memory")
-
-    if args["adapter_type"] == "executor":
-
+    if settings.common.adapter == "pool":
         from concurrent.futures import ProcessPoolExecutor
 
         queue_client = ProcessPoolExecutor(max_workers=args["ntasks"])
 
+    elif settings.common.adapter == "dask":
+
+        dask_settings = settings.dask_jobqueue.dict(skip_defaults=True)
+        # Checks
+        if "extra" not in dask_settings:
+            dask_settings["extra"] = []
+        if QCA_RESOURCE_STRING not in dask_settings["extra"]:
+            dask_settings["extra"].append(QCA_RESOURCE_STRING)
+        # Scheduler opts
+        scheduler_opts = settings.cluster.scheduler_options.copy()
+        if settings.cluster.node_exclusivity and "--exclusive" not in scheduler_opts:
+            scheduler_opts.append("--exclusive")
+
+        _cluster_loaders = {"slurm": "SLURMCluster",
+                            "pbs": "PBSCluster",
+                            "torque": "PBSCluster"}
+
+        # Create one construct to quickly merge dicts with a final check
+        dask_construct = _DaskJobQueueSettingsNoCheck(
+            name="QCFractal_Dask_Compute_Executor",
+            cores=settings.common.cores,
+            memory=str(settings.common.memory) + "GB",
+            processes=settings.common.ntasks,
+            walltime=settings.cluster.walltime,
+            job_extra=scheduler_opts,
+            env_exta=settings.cluster.task_startup_commands,
+            **dask_settings
+        )
+
+        # Import the dask things we need
+        from dask.distributed import Client
+        cluster_class = cli_utils.import_module("dask_jobqueue", package=_cluster_loaders[settings.cluster.scheduler])
+
+        cluster = cluster_class(**dask_construct.dict())
+
+        # Setup up adaption
+        # Workers are distributed down to the cores through the sub-divided processes
+        # Optimization may be needed
+        cluster.adapt(minimum=0, maximum=settings.cluster.max_nodes)
+
+        queue_client = Client(cluster)
+
+        # Make sure tempdir gets assigned correctly
+
+        # Dragonstooth has the low priority queue
+
     else:
         raise KeyError(
-            "Unknown adapter type '{}', available options: 'fireworks', 'dask', .".format(args["adapter_type"]))
-
-    # Quick logging
-    if args["logfile_prefix"] is not None:
-        tornado.options.options['log_file_prefix'] = logfile_prefix
-    tornado.log.enable_pretty_logging()
-
-    # Build the client
-    if args["test"]:
-        client = None
-    else:
-        client = qcfractal.interface.FractalClient(
-            args["fractal_uri"], username=args["username"], password=args["password"], verify=(not args["noverify"]))
-
-    # Figure out per-task data
-    cores_per_task = args["cores"] // args["ntasks"]
-    memory_per_task = args["memory"] / args["ntasks"]
-    if cores_per_task < 1:
-        raise ValueError("Cores per task must be larger than one!")
+            "Unknown adapter type '{}', available options: {}.\n"
+            "This code should also be unreachable with pydantic Validation, so if "
+            "you see this message, please report it to the QCFractal GitHub".format(
+                settings.common.adapter,
+                [getattr(AdapterEnum, v).value for v in AdapterEnum]
+            )
+        )
 
     # Build out the manager itself
     manager = qcfractal.queue.QueueManager(
         client,
         queue_client,
-        max_tasks=args["max_tasks"],
-        queue_tag=args["queue_tag"],
-        cluster=args["cluster_name"],
-        update_frequency=args["update_frequency"],
+        max_tasks=settings.common.max_tasks,
+        queue_tag=settings.common.queue_tag,
+        manager_name=settings.common.manager_name,
+        update_frequency=settings.common.update_frequency,
         cores_per_task=cores_per_task,
         memory_per_task=memory_per_task)
 
@@ -149,7 +339,7 @@ def main(args=None):
         manager.add_exit_callback(cb[0], *cb[1], **cb[2])
 
     # Either startup the manager or run until complete
-    if args["test"]:
+    if settings.common.test:
         success = manager.test()
         if success is False:
             raise ValueError("Testing was not successful, failing.")
@@ -157,7 +347,7 @@ def main(args=None):
 
         cli_utils.install_signal_handlers(manager.loop, manager.stop)
 
-        # Blocks until keyboard interupt
+        # Blocks until keyboard interrupt
         manager.start()
 
 

--- a/qcfractal/cli/qcfractal_template_generator.py
+++ b/qcfractal/cli/qcfractal_template_generator.py
@@ -24,11 +24,19 @@ For additional information about the {MANAGER_URL_TITLE}, please visit this site
 
 # Fractal Settings
 # Location of the Fractal Server you are connecting to
-FRACTAL_ADDRESS = "localhost:7777"
+FRACTAL_ADDRESS = "localhost:7777"  # QCArchive is at: api.qcarchive.molssi.org:443
+# Authentication with the Fractal Server
+USERNAME = None
+PASSWORD = None
+VERIFY_SSL = False
+
 
 # Queue Manager Settings
 # Set whether or not we are just testing the Queue Manger (no Fractal Client needed)
 TEST_RUN = {TEST_RUN}
+# Tell the manager to only pull jobs with this tag
+QUEUE_TAG = None
+
 
 
 # How many cores per node you want your jobs to have access to
@@ -90,14 +98,18 @@ if MEMORY_PER_NODE <= 0:
 if TEST_RUN:
     fractal_client = None
 else:
-    fractal_client = portal.FractalClient(FRACTAL_ADDRESS, verify=False)
+    fractal_client = portal.FractalClient(FRACTAL_ADDRESS, 
+                                          username=USERNAME,
+                                          password=PASSWORD,
+                                          verify=VERIFY_SSL)
 
 
 
 # Build a manager
 manager = qcfractal.queue.QueueManager(fractal_client, {MANAGER_CLIENT}, update_frequency=0.5,
                                        cores_per_task=CORES_PER_NODE // MAX_TASKS_PER_NODE,
-                                       memory_per_task=MEMORY_PER_NODE // MAX_TASKS_PER_NODE)
+                                       memory_per_task=MEMORY_PER_NODE // MAX_TASKS_PER_NODE,
+                                       queue_tag=QUEUE_TAG)
 
 # Important for a calm shutdown
 from qcfractal.cli.cli_utils import install_signal_handlers

--- a/qcfractal/cli/qcfractal_template_generator.py
+++ b/qcfractal/cli/qcfractal_template_generator.py
@@ -24,7 +24,7 @@ For additional information about the {MANAGER_URL_TITLE}, please visit this site
 
 # Fractal Settings
 # Location of the Fractal Server you are connecting to
-FRACTAL_ADDRESS = "localhost:7777"  # QCArchive is at: api.qcarchive.molssi.org:443
+FRACTAL_URI = "localhost:7777"  # QCArchive is at: api.qcarchive.molssi.org:443
 # Authentication with the Fractal Server
 USERNAME = None
 PASSWORD = None
@@ -98,7 +98,7 @@ if MEMORY_PER_NODE <= 0:
 if TEST_RUN:
     fractal_client = None
 else:
-    fractal_client = portal.FractalClient(FRACTAL_ADDRESS, 
+    fractal_client = portal.FractalClient(FRACTAL_URI, 
                                           username=USERNAME,
                                           password=PASSWORD,
                                           verify=VERIFY_SSL)

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -34,7 +34,7 @@ def active_server(request):
     with testing.popen(args, **_options) as server:
         time.sleep(2)
 
-        server.test_uri_cli = "--fractal-address=localhost:" + port
+        server.test_uri_cli = "--fractal-uri=localhost:" + port
         yield server
 
 
@@ -45,7 +45,7 @@ def test_manager_local_testing_process():
 
 @testing.mark_slow
 def test_manager_executor_manager_boot(active_server):
-    args = ["qcfractal-manager", active_server.test_uri_cli, "--ntasks=1"]
+    args = ["qcfractal-manager", active_server.test_uri_cli, "--ntasks=1", "--no-verify"]
     assert testing.run_process(args, interupt_after=7, **_options)
 
 

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -40,12 +40,33 @@ def active_server(request):
 
 @testing.mark_slow
 def test_manager_local_testing_process():
-    assert testing.run_process(["qcfractal-manager", "--test", "--ntasks=2"], **_options)
+    assert testing.run_process(["qcfractal-manager", "--adapter=pool", "--test", "--ntasks=2"], **_options)
 
 
 @testing.mark_slow
 def test_manager_executor_manager_boot(active_server):
-    args = ["qcfractal-manager", active_server.test_uri_cli, "--ntasks=1", "--no-verify"]
+    args = ["qcfractal-manager", active_server.test_uri_cli, "--adapter=pool", "--ntasks=1", "--verify=False"]
+    assert testing.run_process(args, interupt_after=7, **_options)
+
+
+@testing.mark_slow
+def test_manager_executor_manager_boot_from_file(active_server, tmp_path):
+
+    yaml_file = """
+    common:
+        adapter: pool
+        ntasks: 4
+        cores: 4
+    server:
+        fractal_uri: {}
+        verify: False
+    """.format(active_server.test_uri_cli.split("=")[1])
+    print(yaml_file)
+
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml_file)
+
+    args = ["qcfractal-manager", "--config-file={}".format(p)]
     assert testing.run_process(args, interupt_after=7, **_options)
 
 

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -34,7 +34,7 @@ def active_server(request):
     with testing.popen(args, **_options) as server:
         time.sleep(2)
 
-        server.test_uri_cli = "--fractal-uri=localhost:" + port
+        server.test_uri_cli = "--fractal-address=localhost:" + port
         yield server
 
 

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -46,7 +46,7 @@ class QueueManager:
                  logger: Optional[logging.Logger]=None,
                  max_tasks: int=200,
                  queue_tag: str=None,
-                 manager_name: str= "unknown",
+                 manager_name: str= "unlabled",
                  update_frequency: Union[int, float]=2,
                  verbose: bool=True,
                  cores_per_task: Optional[int]=None,

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -46,11 +46,11 @@ class QueueManager:
                  logger: Optional[logging.Logger]=None,
                  max_tasks: int=200,
                  queue_tag: str=None,
-                 cluster: str="unknown",
+                 manager_name: str= "unknown",
                  update_frequency: Union[int, float]=2,
                  verbose: bool=True,
                  cores_per_task: Optional[int]=None,
-                 memory_per_task: Optional[int]=None):
+                 memory_per_task: Optional[Union[int, float]]=None):
         """
         Parameters
         ----------
@@ -68,7 +68,7 @@ class QueueManager:
             The maximum number of tasks to hold at any given time
         queue_tag : str
             Allows managers to pull from specific tags
-        cluster : str
+        manager_name : str
             The cluster the manager belongs to
         update_frequency : int
             The frequency to check for new tasks in seconds
@@ -86,7 +86,7 @@ class QueueManager:
         else:
             self.logger = logging.getLogger('QueueManager')
 
-        self.name_data = {"cluster": cluster, "hostname": socket.gethostname(), "uuid": str(uuid.uuid4())}
+        self.name_data = {"cluster": manager_name, "hostname": socket.gethostname(), "uuid": str(uuid.uuid4())}
         self._name = self.name_data["cluster"] + "-" + self.name_data["hostname"] + "-" + self.name_data["uuid"]
 
         self.client = client

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -270,7 +270,7 @@ class FractalServer:
         # Add the socket to passed args
         client = FractalClient(self._address, verify=self.client_verify)
         self.objects["queue_manager"] = QueueManager(
-            client, self.queue_socket, loop=self.loop, logger=self.logger, cluster="FractalServer", verbose=False)
+            client, self.queue_socket, loop=self.loop, logger=self.logger, manager_name="FractalServer", verbose=False)
 
     def start(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
             'pymongo>=3.0',
             'requests',
             'tornado',
+            'pyyaml',
 
             # Database
             'mongoengine',


### PR DESCRIPTION
## Description
Added manager config files to the CLI, ~looks in `./qcf_manager_config.yaml` and `~/.qca/qcf_manager_config.yaml`~ falling back to the defaults in the pydantic models, but individual options can be overwritten through the CLI.

Individual options are also searched through environment variables looking for `QCA_XXXXX` where `XXXXXX` is the variable name.

Some of CLI variables have been changed, as have their defaults. Some names have been changed in kwargs to be more clear what they do, namely I have renamed the `QueueManager`'s `cluster` kwarg to `manager_name`.

Dask JobQueue can now be set up through the config file + cli. If no config file is found (or an insufficient number of environment variables are set), then only the `ProcessPoolExecutor` can be run.

Ready for feature and function/design review, but still needs more work on new unit tests and testing in a live environment.

This also fixes #205 while I was in there

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Fix all tests
  - [x] Figure out how to test the Dask distributed (edit: will do this in post, Pool works)

## Status
- [x] Changelog updated (edit: due to #212, changelog edits in PRs before that are unsafe, will do before next release)
- [x] Ready to go

### Edits:
* See individual edit notes above
* No automatic queue manager template can be found now, it MUST be specified or only use CLI (in which case its Pool only)