### PR TITLE
Dask fixes

### DIFF
--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -15,6 +15,15 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+0.5.? / 2019-??-??
+------------------
+
+Bug Fixes
++++++++++
+
+- (:pr:`215`) Dask Jobqueue for the ``qcfractal-manager`` is now tested and working. This resolve the outstanding issue
+  introduced in :pr:`211` and pushed in v0.5.3.
+
 0.5.3 / 2019-03-13
 ------------------
 

--- a/qcfractal/cli/cli_utils.py
+++ b/qcfractal/cli/cli_utils.py
@@ -7,6 +7,7 @@ import copy
 import importlib
 import json
 import signal
+from functools import partial
 
 import yaml
 
@@ -27,7 +28,10 @@ def read_config_file(fname):
     """Reads a JSON or YAML file.
     """
     if fname.endswith(".yaml") or fname.endswith(".yml"):
-        rfunc = yaml.load
+        try:
+            rfunc = partial(yaml.load, Loader=yaml.FullLoader)
+        except AttributeError:
+            rfunc = yaml.load
     elif fname.endswith(".json"):
         rfunc = json.load
     else:
@@ -37,7 +41,7 @@ def read_config_file(fname):
         with open(fname, "r") as handle:
             ret = rfunc(handle)
     except FileNotFoundError:
-        raise FileNotFoundError("No config file found at {}.".format(config_file))
+        raise FileNotFoundError("No config file found at {}.".format(fname))
 
     return ret
 

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -207,13 +207,6 @@ def main(args=None):
         client = None
     else:
         # Connect to a specified fractal server
-        print_string = "Attempting to connect to FractalClient at: {}".format(settings.server.fractal_uri)
-        other_data = settings.server.dict(skip_defaults=True, exclude={"fractal_uri"})
-        if "password" in other_data:
-            other_data["password"] = "{provided}"
-        if other_data:
-            print_string += "\n   With credentials: {}".format(other_data)
-        print(print_string)
         client = qcfractal.interface.FractalClient(
             address=settings.server.fractal_uri, **settings.server.dict(skip_defaults=True, exclude={"fractal_uri"}))
 


### PR DESCRIPTION
## Description

After doing some real testing and with the help of @dgasmith, this PR should get the Dask JobQueue working (tested with SLURM). We also found a non-failing infinite loop condition which was causing problems (See dask/dask-jobqueue\#249)

This also fixed a deprecation warrning from PyYaml (https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) and made it possible to create a large number of test cases for the queue manager `test()` method.

Fixes #214 and resolves the outstanding issue in #211

## Status
- [x] Changelog updated
- [x] Ready to go