### PR TITLE
Project Snowflake

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -8,6 +8,7 @@ from qcfractal import testing
 
 _pwd = os.path.abspath(os.path.dirname(__file__))
 
+
 def wait_true(wait_time, func, *args, **kwargs):
 
     periods = wait_time // 4

--- a/qcfractal/__init__.py
+++ b/qcfractal/__init__.py
@@ -9,6 +9,7 @@ from .storage_sockets import storage_socket_factory
 
 # Handle top level object imports
 from .server import FractalServer
+from .snowflake import FractalSnowflake
 from .queue import QueueManager
 
 # Handle versioneer

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -3,13 +3,16 @@ A command line interface to the qcfractal server.
 """
 
 import argparse
+import signal
 from enum import Enum
+from functools import partial
 from typing import List, Optional
 
-from pydantic import BaseSettings, BaseModel, conint, confloat
-import qcfractal
 import tornado.log
+
 import qcengine as qcng
+import qcfractal
+from pydantic import BaseModel, BaseSettings, confloat, conint
 
 from . import cli_utils
 
@@ -292,7 +295,8 @@ def main(args=None):
             raise ValueError("Testing was not successful, failing.")
     else:
 
-        cli_utils.install_signal_handlers(manager.loop, manager.stop)
+        for signame in {"SIGHUP", "SIGINT", "SIGTERM"}:
+            signal.signal(getattr(signal, signame), partial(manager.stop, signame))
 
         # Blocks until keyboard interrupt
         manager.start()

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -296,10 +296,18 @@ def main(args=None):
     else:
 
         for signame in {"SIGHUP", "SIGINT", "SIGTERM"}:
-            signal.signal(getattr(signal, signame), partial(manager.stop, signame))
 
-        # Blocks until keyboard interrupt
-        manager.start()
+            def stop(*args, **kwargs):
+                manager.stop(signame)
+                raise KeyboardInterrupt()
+
+            signal.signal(getattr(signal, signame), stop)
+
+        # Blocks until signal
+        try:
+            manager.start()
+        except KeyboardInterrupt:
+            pass
 
 
 if __name__ == '__main__':

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -90,8 +90,7 @@ class DaskQueueSettings(BaseSettings):
 
     def __init__(self, **kwargs):
         """Enforce that the keys we are going to set remain untouched"""
-        forbidden_set = {
-            "name", "ncores", "memory", "processes", "walltime", "env_extra", "qca_resource_string"}
+        forbidden_set = {"name", "ncores", "memory", "processes", "walltime", "env_extra", "qca_resource_string"}
         bad_set = set(kwargs.keys()) & forbidden_set
         if bad_set:
             raise KeyError("The following items were set as part of dask_jobqueue, however, "
@@ -152,7 +151,8 @@ def parse_args():
     # Additional args
     optional = parser.add_argument_group('Optional Settings')
     optional.add_argument("--test", action="store_true", help="Boot and run a short test suite to validate setup")
-    optional.add_argument("--ntests", type=int, help="How many tests per found program to run, does nothing without --test set")
+    optional.add_argument(
+        "--ntests", type=int, help="How many tests per found program to run, does nothing without --test set")
 
     # Move into nested namespace
     args = vars(parser.parse_args())

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -92,17 +92,30 @@ class FractalClient(object):
             self.server_name, self.address, self.username)
         return ret
 
-    def _request(self, method: str, service: str, payload: Dict[str, Any]=None, *, data: str=None,
-                 noraise: bool=False):
+    def _request(self,
+                 method: str,
+                 service: str,
+                 payload: Dict[str, Any]=None,
+                 *,
+                 data: str=None,
+                 noraise: bool=False,
+                 timeout=None):
 
         addr = self.address + service
+        kwargs = {
+            "json": payload,
+            "data": data,
+            "timeout": timeout,
+            "headers": self._headers,
+            "verify": self._verify,
+        }
         try:
             if method == "get":
-                r = requests.get(addr, json=payload, data=data, headers=self._headers, verify=self._verify)
+                r = requests.get(addr, **kwargs)
             elif method == "post":
-                r = requests.post(addr, json=payload, data=data, headers=self._headers, verify=self._verify)
+                r = requests.post(addr, **kwargs)
             elif method == "put":
-                r = requests.put(addr, json=payload, data=data, headers=self._headers, verify=self._verify)
+                r = requests.put(addr, **kwargs)
             else:
                 raise KeyError("Method not understood: '{}'".format(method))
         except requests.exceptions.SSLError as exc:

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -230,7 +230,7 @@ class FractalClient(object):
                         id: Optional[List[str]]=None,
                         molecule_hash: Optional[List[str]]=None,
                         molecular_formula: Optional[List[str]]=None,
-                        full_return: bool=False) -> 'List[Molecule]':
+                        full_return: bool=False) -> List[Molecule]:
         """Queries molecules from the database.
 
         Parameters
@@ -452,7 +452,7 @@ class FractalClient(object):
                       keywords: QueryObjectId=None,
                       status: QueryStr="COMPLETE",
                       projection: QueryProjection=None,
-                      full_return: bool=False) -> Union[List[RecordResult], Dict[str, Any]]:
+                      full_return: bool=False) -> Union[List['RecordResult'], Dict[str, Any]]:
         """Queries ResultRecords from the database.
 
         Parameters
@@ -486,7 +486,7 @@ class FractalClient(object):
             Returns a List of found RecordResult's without projection, or a
             dictionary of results with projection.
         """
-        body = ResultGETBody({
+        body = ResultGETBody(**{
             "meta": {
                 "projection": projection
             },
@@ -499,7 +499,7 @@ class FractalClient(object):
                 "method": method,
                 "basis": basis,
                 "keywords": keywords,
-                "status": stats,
+                "status": status,
             }
         })
         r = self._request("get", "result", data=body.json())

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -251,8 +251,7 @@ class OptimizationTasks(BaseTasks):
 
         qc_spec = QCSpecification(**data.meta["qc_spec"])
         if qc_spec.keywords:
-            qc_keywords = self.storage.get_add_keywords_mixed([meta["keywords"]])["data"][0]["values"]
-
+            qc_keywords = self.storage.get_add_keywords_mixed([qc_spec.keywords])["data"][0]
         else:
             qc_keywords = None
 

--- a/qcfractal/queue/executor_adapter.py
+++ b/qcfractal/queue/executor_adapter.py
@@ -46,9 +46,8 @@ class ExecutorAdapter(BaseAdapter):
         return ret
 
     def await_results(self) -> bool:
-        for future in self.queue.values():
-            while future.done() is False:
-                time.sleep(0.1)
+        from concurrent.futures import wait
+        wait(list(self.queue.values()))
 
         return True
 
@@ -72,7 +71,8 @@ class DaskAdapter(ExecutorAdapter):
         func = self.get_function(task_spec["spec"]["function"])
 
         # Watch out out for thread unsafe tasks and our own constraints
-        task = self.client.submit(func, *task_spec["spec"]["args"], **task_spec["spec"]["kwargs"], resources={"process": 1})
+        task = self.client.submit(
+            func, *task_spec["spec"]["args"], **task_spec["spec"]["kwargs"], resources={"process": 1})
         return task_spec["id"], task
 
     def await_results(self) -> bool:

--- a/qcfractal/queue/executor_adapter.py
+++ b/qcfractal/queue/executor_adapter.py
@@ -2,7 +2,6 @@
 Queue adapter for Dask
 """
 
-import time
 import traceback
 from typing import Any, Dict, Hashable, List, Tuple
 

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -223,10 +223,7 @@ class QueueManager:
         self.scheduler.enter(0, 1, scheduler_update)
         self.scheduler.enter(0, 2, scheduler_heartbeat)
 
-        try:
-            self.scheduler.run()
-        except KeyboardInterrupt:
-            self.stop(signame="Interrupt")
+        self.scheduler.run()
 
     def stop(self, signame="Not provided", signum=None, stack=None) -> None:
         """
@@ -290,7 +287,7 @@ class QueueManager:
         payload = self._payload_template()
         payload["data"]["operation"] = "shutdown"
         put_body = QueueManagerPUTBody(**payload)
-        r = self.client._request("put", "queue_manager", data=put_body.json(), noraise=True)
+        r = self.client._request("put", "queue_manager", data=put_body.json(), noraise=True, timeout=2)
 
         if r.status_code != 200:
             # TODO something as we didnt successfully add the data

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -218,7 +218,6 @@ class QueueManager:
             self.heartbeat()
             self.scheduler.enter(heartbeat_time, 1, scheduler_heartbeat)
 
-
         self.logger.info("QueueManager successfully started.\n")
 
         self.scheduler.enter(0, 1, scheduler_update)
@@ -235,8 +234,10 @@ class QueueManager:
         """
         self.logger.info("QueueManager recieved shutdown signal: {}.\n".format(signame))
 
-        for event in self.scheduler.queue:
-            self.scheduler.cancel(event)
+        # Cancel all events
+        if self.scheduler is not None:
+            for event in self.scheduler.queue:
+                self.scheduler.cancel(event)
 
         # Push data back to the server
         self.shutdown()

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -5,19 +5,20 @@ Queue backend abstraction manager.
 import asyncio
 import json
 import logging
+import sched
 import socket
+import time
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import tornado.ioloop
+import qcengine as qcng
 from qcfractal.extras import get_information
 
-import qcengine as qcng
-
-from ..interface.data import get_molecule
-from ..interface.models.rest_models import (QueueManagerMeta, QueueManagerGETBody, QueueManagerGETResponse, QueueManagerPOSTBody,
-                                            QueueManagerPOSTResponse, QueueManagerPUTBody, QueueManagerPUTResponse)
 from .adapters import build_queue_adapter
+from ..interface.data import get_molecule
+from ..interface.models.rest_models import (QueueManagerGETBody, QueueManagerGETResponse, QueueManagerMeta,
+                                            QueueManagerPOSTBody, QueueManagerPOSTResponse, QueueManagerPUTBody,
+                                            QueueManagerPUTResponse)
 
 __all__ = ["QueueManager"]
 
@@ -42,11 +43,10 @@ class QueueManager:
     def __init__(self,
                  client: Any,
                  queue_client: Any,
-                 loop: Any=None,
                  logger: Optional[logging.Logger]=None,
                  max_tasks: int=200,
                  queue_tag: str=None,
-                 manager_name: str= "unlabled",
+                 manager_name: str="unlabled",
                  update_frequency: Union[int, float]=2,
                  verbose: bool=True,
                  cores_per_task: Optional[int]=None,
@@ -60,8 +60,6 @@ class QueueManager:
             The DBAdapter class for queue abstraction
         storage_socket : DBSocket
             A socket for the backend database
-        loop : IOLoop
-            The running Tornado IOLoop
         logger : logging.Logger, Optional. Default: None
             A logger for the QueueManager
         max_tasks : int
@@ -98,6 +96,7 @@ class QueueManager:
         self.queue_tag = queue_tag
         self.verbose = verbose
 
+        self.scheduler = None
         self.update_frequency = update_frequency
         self.periodic = {}
         self.active = 0
@@ -106,9 +105,6 @@ class QueueManager:
         # QCEngine data
         self.available_programs = qcng.list_available_programs()
         self.available_procedures = qcng.list_available_procedures()
-
-        # Pull the current loop if we need it
-        self.loop = loop or tornado.ioloop.IOLoop.current()
 
         self.logger.info("QueueManager:")
         self.logger.info("    Version:         {}\n".format(get_information("version")))
@@ -164,7 +160,8 @@ class QueueManager:
             self.logger.info("        Not connected, some actions will not be available")
 
     def _payload_template(self):
-        meta = QueueManagerMeta(**self.name_data.copy(),
+        meta = QueueManagerMeta(
+            **self.name_data.copy(),
 
             # Version info
             qcengine_version=qcng.__version__,
@@ -176,8 +173,7 @@ class QueueManager:
             # Pull info
             programs=self.available_programs,
             procedures=self.available_procedures,
-            tag=self.queue_tag,
-            )
+            tag=self.queue_tag, )
 
         return {"meta": meta, "data": {}}
 
@@ -211,27 +207,36 @@ class QueueManager:
 
         self.assert_connected()
 
-        self.logger.info("QueueManager successfully started. Starting IOLoop.\n")
+        self.scheduler = sched.scheduler(time.time, time.sleep)
+        heartbeat_time = int(0.8 * self.heartbeat_frequency)
 
-        # Add services callback, cb freq is given in milliseconds
-        update = tornado.ioloop.PeriodicCallback(self.update, 1000 * self.update_frequency)
-        update.start()
-        self.periodic["update"] = update
+        def scheduler_update():
+            self.update()
+            self.scheduler.enter(self.update_frequency, 1, scheduler_update)
 
-        # Add heartbeat
-        heartbeat_frequency = int(0.8 * 1000 * self.heartbeat_frequency)  # Beat at 80% of cutoff time
-        heartbeat = tornado.ioloop.PeriodicCallback(self.heartbeat, heartbeat_frequency)
-        heartbeat.start()
-        self.periodic["heartbeat"] = heartbeat
+        def scheduler_heartbeat():
+            self.heartbeat()
+            self.scheduler.enter(heartbeat_time, 1, scheduler_heartbeat)
 
-        # Soft quit with a keyboard interrupt
-        self.running = True
-        self.loop.start()
 
-    def stop(self) -> None:
+        self.logger.info("QueueManager successfully started.\n")
+
+        self.scheduler.enter(0, 1, scheduler_update)
+        self.scheduler.enter(0, 2, scheduler_heartbeat)
+
+        try:
+            self.scheduler.run()
+        except KeyboardInterrupt:
+            self.stop(signame="Interrupt")
+
+    def stop(self, signame="Not provided", signum=None, stack=None) -> None:
         """
         Shuts down all IOLoops and periodic updates
         """
+        self.logger.info("QueueManager recieved shutdown signal: {}.\n".format(signame))
+
+        for event in self.scheduler.queue:
+            self.scheduler.cancel(event)
 
         # Push data back to the server
         self.shutdown()
@@ -239,20 +244,11 @@ class QueueManager:
         # Close down the adapter
         self.close_adapter()
 
-        # Stop callbacks
-        for cb in self.periodic.values():
-            cb.stop()
-
         # Call exit callbacks
         for func, args, kwargs in self.exit_callbacks:
             func(*args, **kwargs)
 
-        # Stop loop
-        if not asyncio.get_event_loop().is_running():  # Only works on Py3
-            self.loop.stop()
-
-        self.loop.close(all_fds=True)
-        self.logger.info("QueueManager stopping gracefully. Stopped IOLoop.\n")
+        self.logger.info("QueueManager stopping gracefully.\n")
 
     def close_adapter(self) -> bool:
         """
@@ -280,7 +276,6 @@ class QueueManager:
         else:
             self.logger.info("Heartbeat was successful.")
 
-
         _ = QueueManagerPUTResponse.parse_raw(r.text)  # Validate
 
     def shutdown(self) -> Dict[str, Any]:
@@ -288,6 +283,8 @@ class QueueManager:
         Shutdown the manager and returns tasks to queue.
         """
         self.assert_connected()
+
+        self.update(new_tasks=False)
 
         payload = self._payload_template()
         payload["data"]["operation"] = "shutdown"
@@ -325,7 +322,6 @@ class QueueManager:
 
         """
 
-        self.logger.info("Starting update.")
         self.assert_connected()
 
         results = self.queue_adapter.acquire_complete()
@@ -341,9 +337,10 @@ class QueueManager:
                 self.logger.warning("Post complete tasks was not successful. Data may be lost.")
 
             _ = QueueManagerPOSTResponse.parse_raw(r.text)  # Ensure validation from server
-            self.logger.info("Pushed {} complete tasks to the server.".format(len(results)))
 
             self.active -= len(results)
+
+        self.logger.info("Pushed {} complete tasks to the server.".format(len(results)))
 
         open_slots = max(0, self.max_tasks - self.active)
 
@@ -461,7 +458,6 @@ class QueueManager:
 
         results = self.queue_adapter.acquire_complete()
         self.logger.info("Testing results acquired.")
-
 
         missing_programs = results.keys() - set(found_programs)
         if len(missing_programs):

--- a/qcfractal/queue/parsl_adapter.py
+++ b/qcfractal/queue/parsl_adapter.py
@@ -87,7 +87,7 @@ class ParslAdapter(BaseAdapter):
         return ret
 
     def await_results(self) -> bool:
-        for future in self.queue.values():
+        for future in list(self.queue.values()):
             while future.done() is False:
                 time.sleep(0.1)
 

--- a/qcfractal/snowflake.py
+++ b/qcfractal/snowflake.py
@@ -1,3 +1,4 @@
+import asyncio
 import atexit
 import shutil
 import socket
@@ -11,8 +12,6 @@ from tornado.ioloop import IOLoop
 from typing import Optional
 
 from .server import FractalServer
-from .interface import FractalClient
-from .queue import QueueManager
 
 
 def _find_port() -> int:
@@ -77,6 +76,8 @@ class FractalSnowflake(FractalServer):
             self.queue_socket = ProcessPoolExecutor(max_workers=max_workers)
 
         # Add the loop to a background thread and init the server
+        self.aioloop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.aioloop)
         IOLoop.clear_instance()
         IOLoop.clear_current()
         loop = IOLoop()
@@ -94,7 +95,7 @@ class FractalSnowflake(FractalServer):
             ssl_options=False,
             max_active_services=max_active_services,
             queue_socket=self.queue_socket,
-            # logfile_prefix=self.logfile.name,
+            logfile_prefix=self.logfile.name,
             query_limit=int(1.e6))
 
         if self._mongod_proc:

--- a/qcfractal/snowflake.py
+++ b/qcfractal/snowflake.py
@@ -120,6 +120,7 @@ class FractalSnowflake(FractalServer):
 
         super().stop(stop_loop=False)
         self.loop.add_callback(self.loop.stop)
+        self.loop_future.result()
 
         self.loop_thread.shutdown()
 

--- a/qcfractal/snowflake.py
+++ b/qcfractal/snowflake.py
@@ -94,7 +94,7 @@ class FractalSnowflake(FractalServer):
             ssl_options=False,
             max_active_services=max_active_services,
             queue_socket=self.queue_socket,
-            logfile_prefix=self.logfile.name,
+            # logfile_prefix=self.logfile.name,
             query_limit=int(1.e6))
 
         if self._mongod_proc:

--- a/qcfractal/snowflake.py
+++ b/qcfractal/snowflake.py
@@ -1,0 +1,106 @@
+import atexit
+import shutil
+import socket
+import sys
+import subprocess
+import tempfile
+
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from tornado.ioloop import IOLoop
+
+from typing import Optional
+
+from .server import FractalServer
+
+
+def _find_port() -> int:
+    sock = socket.socket()
+    sock.bind(('', 0))
+    host, port = sock.getsockname()
+    return port
+
+
+def _background_process(args, **kwargs):
+
+    if sys.platform.startswith('win'):
+        # Allow using CTRL_C_EVENT / CTRL_BREAK_EVENT
+        kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+    kwargs['stdout'] = subprocess.PIPE
+    kwargs['stderr'] = subprocess.PIPE
+    proc = subprocess.Popen(args, **kwargs)
+
+    return proc
+
+
+class FractalSnowflake(FractalServer):
+    def __init__(self, max_workers: Optional[int]=1, max_active_services: int=20):
+        """A temporary FractalServer that can be used to run complex workflows or try
+
+
+        ! Warning ! All data is lost when the server is shutdown
+
+        Parameters
+        ----------
+        max_workers : Optional[int], optional
+            The maximum number of ProcessPoolExecutor to spin up.
+        max_active_services : int, optional
+            Description
+        """
+        # Startup a MongoDB in background thread and in custom folder.
+        mongod_port = _find_port()
+        self._mongod_tmpdir = tempfile.TemporaryDirectory()
+        self._mongod_proc = _background_process(
+            [shutil.which("mongod"), f"--port={mongod_port}", f"--dbpath={self._mongod_tmpdir.name}"])
+
+        queue_socket = None
+        if max_workers:
+            queue_socket = ProcessPoolExecutor(max_workers=max_workers)
+
+        self.loop = IOLoop()
+        self.loop_thread = ThreadPoolExecutor(max_workers=1)
+        self.loop_future = self.loop_thread.submit(self.loop.start)
+
+        super().__init__(
+            name="QCFractal Snowflake Instance",
+            port=_find_port(),
+            loop=self.loop,
+            storage_uri=f"mongodb://localhost:{mongod_port}",
+            storage_project_name="temporary_snowflake",
+            max_active_services=max_active_services,
+            queue_socket=queue_socket,
+            query_limit=int(1.e6))
+
+        self.start(start_loop=False)
+
+        self._active = True
+
+        # We need to call before threadings cleanup
+        atexit.register(self.stop)
+
+    def stop(self) -> None:
+        """
+        Shuts down the Snowflake instance. This instance is not recoverable after a stop call.
+        """
+
+        if not self._active:
+            return
+
+        super().stop(stop_loop=False)
+        self.loop.add_callback(self.loop.stop)
+        self.loop_thread.shutdown()
+
+        if self._mongod_proc is not None:
+            self._mongod_proc.kill()
+            self._mongod_proc = None
+
+        # Closed down
+        self._active = False
+        atexit.unregister(self.stop)
+
+    def __del__(self):
+        """
+        Cleans up the Snowflake instance on delete.
+        """
+
+        self.stop()

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -312,14 +312,13 @@ def test_server(request):
 
     storage_name = "qcf_local_server_test"
 
-    with loop_in_thread() as loop:
-
-        # Build server, manually handle IOLoop (no start/stop needed)
-        server = FractalServer(port=find_open_port(), storage_project_name=storage_name, loop=loop, ssl_options=False)
+    # with loop_in_thread() as loop:
+    with FractalSnowflake(
+            max_workers=0, storage_project_name=storage_name, storage_uri="mongodb://localhost:27017",
+            start_server=False) as server:
 
         # Clean and re-init the database
         reset_server_database(server)
-
         yield server
 
 
@@ -362,6 +361,9 @@ def build_managed_compute_server(mtype):
 
     storage_name = "qcf_compute_server_test"
     adapter_client = build_adapter_clients(mtype, storage_name=storage_name)
+
+    # Build a server with the thread in a outer context loop
+    # Not all adapters play well with internal loops
     with loop_in_thread() as loop:
         server = FractalServer(
             port=find_open_port(),

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -35,6 +35,8 @@ def _plugin_import(plug):
 
 _import_message = "Not detecting module {}. Install package if necessary and add to envvar PYTHONPATH"
 
+_adapter_testing = ["pool", "dask", "fireworks", "parsl"]
+
 # Figure out what is imported
 _programs = {
     "fireworks": _plugin_import("fireworks"),
@@ -316,9 +318,12 @@ def test_server(request):
     with FractalSnowflake(
             max_workers=0, storage_project_name=storage_name, storage_uri="mongodb://localhost:27017",
             start_server=False) as server:
+        print(server)
 
         # Clean and re-init the database
+        print("Resetting")
         reset_server_database(server)
+        print("Yielding")
         yield server
 
 
@@ -386,9 +391,10 @@ def build_managed_compute_server(mtype):
 
         # Close down and clean the adapter
         manager.close_adapter()
+        manager.stop()
 
 
-@pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
+@pytest.fixture(scope="module", params=_adapter_testing)
 def adapter_client_fixture(request):
     adapter_client = build_adapter_clients(request.param)
     yield adapter_client
@@ -397,7 +403,7 @@ def adapter_client_fixture(request):
     build_queue_adapter(adapter_client).close()
 
 
-@pytest.fixture(scope="module", params=["pool", "dask", "fireworks", "parsl"])
+@pytest.fixture(scope="module", params=_adapter_testing)
 def managed_compute_server(request):
     """
     A FractalServer with compute associated parametrize for all managers

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -19,6 +19,7 @@ from tornado.ioloop import IOLoop
 
 from .queue import build_queue_adapter
 from .server import FractalServer
+from .snowflake import FractalSnowflake
 from .storage_sockets import storage_socket_factory
 
 ### Addon testing capabilities
@@ -412,24 +413,15 @@ def fractal_compute_server(request):
     # Check mongo
     check_active_mongo_server()
 
-    # Basic boot and loop information
+    # Storage name
     storage_name = "qcf_compute_server_test"
-    from concurrent.futures import ProcessPoolExecutor
 
-    with ProcessPoolExecutor(max_workers=2) as adapter_client:
-        with loop_in_thread() as loop:
-            server = FractalServer(
-                port=find_open_port(),
-                storage_project_name=storage_name,
-                loop=loop,
-                queue_socket=adapter_client,
-                ssl_options=False)
+    with FractalSnowflake(
+            max_workers=2, storage_project_name=storage_name, storage_uri="mongodb://localhost:27017",
+            start_server=False) as server:
 
-            # Clean and re-init the databse
-            reset_server_database(server)
-
-            # Yield the server instance
-            yield server
+        reset_server_database(server)
+        yield server
 
 
 def build_socket_fixture(stype):

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -266,12 +266,7 @@ class ResultHandler(APIHandler):
 
         body = ResultGETBody.parse_raw(self.request.body)
         proj = body.meta.projection
-        if 'id' in body.data:
-            ret = storage.get_results(id=body.data['id'], projection=proj)
-        elif 'task_id' in body.data:
-            ret = storage.get_results(task_id=body.data['task_id'], projection=proj)
-        else:
-            ret = storage.get_results(**body.data, projection=proj)
+        ret = storage.get_results(**body.data.dict(), projection=proj)
         result = ResultGETResponse(**ret)
         self.logger.info("GET: Results - {} pulls.".format(len(result.data)))
         self.write(result.json())

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -242,9 +242,7 @@ class CollectionHandler(APIHandler):
         storage = self.objects["storage_socket"]
 
         body = CollectionPOSTBody.parse_raw(self.request.body)
-        ret = storage.add_collection(
-            body.data.dict(),
-            overwrite=body.meta.overwrite)
+        ret = storage.add_collection(body.data.dict(), overwrite=body.meta.overwrite)
 
         response = CollectionPOSTResponse(**ret)
 


### PR DESCRIPTION
## Description
Adds in project snowflake, or a server instance that is temporary and does not required a database instance to be running. This mostly involved lots of little changes making sure all of the Asyncio calls cascaded correctly. To this end several other changes were made:
- [x] Snowflake is now implemented and allows users to spin up instances within python scripts. Closes #148.
- [x] `qcfractal-manager` no longer relies on Tornado/Asyncio and instead uses the `scheduler` module. This greatly simplifies the code where Asyncio was not needed.
- [x] Testing now relies on Snowflake where applicable, we may want to consider allowing `pytest` to use two threads to reduce overall time.
- [x] Managers now push back tasks on shutdown, a chance to return a very small number of jobs.

A quick example:
```py
server = FractalSnowflake()

client = ptl.FractalClient(server)
mol = ptl.Molecule(symbols=["H", "H"], geometry=[0, 0, 0, 0, 5, 0], connectivity=[(0, 1, 1)])
ret = client.add_compute("psi4", "HF", "sto-3g", "energy", None, [mol])

server.await_results()
print(client.query_results(id=ret.ids))
```

As a note MongoDB is particularly nice as the process shuts down if it cannot access the data folder which is cleaned up by Python. The current implementation seems very robust against accidental dangling processes during odd shutdowns.

## Status
- [ ] Changelog updated
- [ ] Ready to go