### PR TITLE
Remove lower cast from query calls

### DIFF
--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -241,11 +241,11 @@ class ReactionDataset(Dataset):
             return True
 
         query_keys = {
-            "method": method.lower(),
-            "basis": basis.lower(),
-            "driver": driver.lower(),
+            "method": method,
+            "basis": basis,
+            "driver": driver,
             "keywords": keywords,
-            "program": program.lower(),
+            "program": program,
         }
 
         if (not ignore_ds_type) and (self.data.ds_type.lower() == "ie"):


### PR DESCRIPTION
Removes the `.lower()` call to the query keys as we handle it better
elsewhere. This fixes a bug when feeding `None` into any of the options
which then does not have a `.lower()` method.

## Status
- [ ] Changelog updated
- [x] Ready to go