### PR TITLE
REST Interface Validation

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -5,7 +5,6 @@ A command line interface to the qcfractal server.
 import argparse
 import signal
 from enum import Enum
-from functools import partial
 from typing import List, Optional
 
 import tornado.log

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -131,7 +131,12 @@ class FractalClient(object):
 
         return r
 
-    def _automodel_request(self, name: str, rest: str, payload: Dict[str, Any], full_return: bool=False) -> Any:
+    def _automodel_request(self,
+                           name: str,
+                           rest: str,
+                           payload: Dict[str, Any],
+                           full_return: bool=False,
+                           timeout: int=None) -> Any:
         """Automatic model request profiling and creation using rest_models
 
         Parameters
@@ -144,9 +149,8 @@ class FractalClient(object):
             The input dictionary
         full_return : bool, optional
             Returns the full server response if True that contains additional metadata.
-        noraise : bool, optional
-            Optionally do not raise error if
-            Description
+        timeout : int, optional
+            Timeout time
 
         Returns
         -------
@@ -157,6 +161,12 @@ class FractalClient(object):
         ------
         TypeError
             Description
+
+        Deleted Parameters
+        ------------------
+        noraise : bool, optional
+            Optionally do not raise error if
+            Description
         """
         body_model, response_model = rest_model(name, rest)
 
@@ -166,7 +176,7 @@ class FractalClient(object):
         except ValidationError as exc:
             raise TypeError(str(exc))
 
-        r = self._request(rest, name, data=payload.json())
+        r = self._request(rest, name, data=payload.json(), timeout=timeout)
         response = response_model.parse_raw(r.text)
 
         if full_return:

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -144,11 +144,19 @@ class FractalClient(object):
             The input dictionary
         full_return : bool, optional
             Returns the full server response if True that contains additional metadata.
+        noraise : bool, optional
+            Optionally do not raise error if
+            Description
 
         Returns
         -------
         Any
             The REST response object
+
+        Raises
+        ------
+        TypeError
+            Description
         """
         body_model, response_model = rest_model(name, rest)
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -5,12 +5,13 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
+
 from pydantic import BaseModel
 from qcelemental import constants
 
-from ..statistics import wrap_statistics
 from .collection import Collection
 from .collection_utils import register_collection
+from ..statistics import wrap_statistics
 
 
 class MoleculeRecord(BaseModel):
@@ -44,7 +45,7 @@ class Dataset(Collection):
         The underlying dataframe for the Dataset object
     """
 
-    def __init__(self, name, client=None, **kwargs):
+    def __init__(self, name: str, client: Optional['FractalClient']=None, **kwargs: Dict[str, Any]):
         """
         Initializer for the Dataset object. If no Portal is supplied or the database name
         is not present on the server that the Portal is connected to a blank database will be
@@ -54,8 +55,10 @@ class Dataset(Collection):
         ----------
         name : str
             The name of the Dataset
-        client : client.FractalClient, optional
+        client : Opational['FractalClient'], optional
             A Portal client to connected to a server
+        **kwargs : Dict[str, Any]
+            Additional kwargs to pass to the collection
         """
         super().__init__(name, client=client, **kwargs)
 
@@ -171,7 +174,7 @@ class Dataset(Collection):
         df.sort_index(inplace=True)
         return df
 
-    def _default_parameters(self, driver, keywords, program):
+    def _default_parameters(self, driver: str, keywords: Optional[str], program: str) -> Tuple[str, str, str, str]:
         """
         Takes raw input parsed parameters and applies defaults to them.
         """
@@ -200,9 +203,25 @@ class Dataset(Collection):
 
         return driver, keywords, keywords_alias, program
 
-    def _query(self, indexer, query, field="return_result", scale=None):
+    def _query(self, indexer: str, query: Dict[str, Any], field: str="return_result", scale: str=None) -> 'Series':
         """
         Runs a query based on an indexer which is index : molecule_id
+
+        Parameters
+        ----------
+        indexer : str
+            The primary index of the query
+        query : Dict[str, Any]
+            A results query
+        field : str, optional
+            The field to pull from the ResultRecords
+        scale : str, optional
+            The scale of the computation
+
+        Returns
+        -------
+        Series
+            A Series of the data results
         """
         self._check_state()
 
@@ -228,6 +247,11 @@ class Dataset(Collection):
     def set_default_program(self, program: str) -> bool:
         """
         Sets the default program.
+
+        Parameters
+        ----------
+        program : str
+            The program to default to.
         """
 
         self.data.default_program = program.lower()
@@ -241,10 +265,13 @@ class Dataset(Collection):
         ----------
         alias : str
             The alias of the option
+        program : str
+            The compute program the alias is for
         keyword : KeywordSet
             The Keywords object to use.
-        default : bool
+        default : bool, optional
             Sets this option as the default for the program
+
         """
 
         alias = alias.lower()
@@ -262,7 +289,21 @@ class Dataset(Collection):
         return True
 
     def get_keywords(self, alias: str, program: str) -> 'KeywordSet':
+        """Pulls the keywords alias from the server for inspection.s
 
+        Parameters
+        ----------
+        alias : str
+            The keywords alias.
+        program : str
+            The program the keywords correspond to.
+
+        Returns
+        -------
+        KeywordSet
+            The requested KeywordSet
+
+        """
         if self.client is None:
             raise AttributeError("Dataset: Client was not set.")
 
@@ -282,8 +323,7 @@ class Dataset(Collection):
         contrib : ContributedValues
             The ContributedValues to add.
         overwrite : bool, optional
-            Forces
-
+            Overwrites pre-existing values
         """
 
         # Convert and validate
@@ -304,6 +344,11 @@ class Dataset(Collection):
     def list_contributed_values(self) -> List[str]:
         """
         Lists the known keys for all contributed values.
+
+        Returns
+        -------
+        List[str]
+            A list of all known contributed values.
         """
 
         return list(self.data.contributed_values)
@@ -392,21 +437,15 @@ class Dataset(Collection):
         field : str, optional
             The result field to query on
 
-
         Returns
         -------
         success : bool
             Returns True if the requested query was successful or not.
 
-        Notes
-        -----
-
-
         Examples
         --------
 
-        ds.query("B3LYP", "aug-cc-pVDZ", stoich="cp", prefix="cp-")
-
+        >>> ds.query("B3LYP", "aug-cc-pVDZ", stoich="cp", prefix="cp-")
         """
 
         driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
@@ -493,19 +532,19 @@ class Dataset(Collection):
 
         return ret
 
-    def get_index(self):
+    def get_index(self) -> List[str]:
         """
         Returns the current index of the database.
 
         Returns
         -------
-        ret : list of str
+        ret : List[str]
             The names of all reactions in the database
         """
         return [x.name for x in self.data.records]
 
     # Statistical quantities
-    def statistics(self, stype, value, bench="Benchmark"):
+    def statistics(self, stype: str, value: str, bench: str="Benchmark"):
         """Summary
 
         Parameters
@@ -525,7 +564,7 @@ class Dataset(Collection):
         return wrap_statistics(stype, self.df, value, bench)
 
     # Getters
-    def __getitem__(self, args):
+    def __getitem__(self, args: str) -> 'Series':
         """A wrapped to the underlying pd.DataFrame to access columnar data
 
         Parameters

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -289,7 +289,7 @@ class Dataset(Collection):
         return True
 
     def get_keywords(self, alias: str, program: str) -> 'KeywordSet':
-        """Pulls the keywords alias from the server for inspection.s
+        """Pulls the keywords alias from the server for inspection.
 
         Parameters
         ----------

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -251,7 +251,7 @@ class OpenFFWorkflow(Collection):
             lookup = list(set(lookup) - self._torsiondrive_cache.keys())
 
         # Grab the data and update cache
-        data = self.client.query_procedures({"id": lookup})
+        data = self.client.query_procedures(id=lookup)
         self._torsiondrive_cache.update({x.id: x for x in data})
 
     def list_final_energies(self, fragments=None, refresh_cache=False):

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -3,17 +3,18 @@ QCPortal Database ODM
 """
 import itertools as it
 from enum import Enum
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
+
 from pydantic import BaseModel
 from qcelemental import constants
 
-from ..dict_utils import replace_dict_keys
-from ..models import Molecule
 from .collection_utils import nCr, register_collection
 from .dataset import Dataset
+from ..dict_utils import replace_dict_keys
+from ..models import Molecule
 
 
 class _ReactionTypeEnum(str, Enum):
@@ -38,8 +39,8 @@ class ReactionDataset(Dataset):
     ----------
     client : client.FractalClient
         A optional server portal to connect the database
-    data : dict
-        JSON representation of the database backbone
+    data : DataModel
+        A Model representation of the database backbone
     df : pd.DataFrame
         The underlying dataframe for the Dataset object
     rxn_index : pd.Index
@@ -117,12 +118,12 @@ class ReactionDataset(Dataset):
 
         self._form_index()
 
-    def _unroll_query(self, keys, stoich, field="return_result"):
+    def _unroll_query(self, keys: Dict[str, Any], stoich: str, field: str="return_result") -> 'Series':
         """Unrolls a complex query into a "flat" query for the server object
 
         Parameters
         ----------
-        keys : dict
+        keys : Dict[str, Any]
             Server query fields
         stoich : str
             The stoichiometry to access for the query (default/cp/cp3/etc)
@@ -131,7 +132,7 @@ class ReactionDataset(Dataset):
 
         Returns
         -------
-        ret : pd.DataFrame
+        ret : Series
             A DataFrame representation of the unrolled query
         """
         self._check_state()
@@ -167,18 +168,18 @@ class ReactionDataset(Dataset):
 
     def query(self,
               method,
-              basis=None,
+              basis: Optional[str]=None,
               *,
-              driver=None,
-              keywords=None,
-              program=None,
-              stoich="default",
-              prefix="",
-              postfix="",
-              contrib=False,
-              scale="kcal/mol",
-              field="return_result",
-              ignore_ds_type=False):
+              driver: Optional[str]=None,
+              keywords: Optional[str]=None,
+              program: Optional[str]=None,
+              stoich: str="default",
+              prefix: str="",
+              postfix: str="",
+              contrib: bool=False,
+              scale: str="kcal/mol",
+              field: str="return_result",
+              ignore_ds_type: bool=False):
         """
         Queries the local Portal for the requested keys and stoichiometry.
 
@@ -186,27 +187,27 @@ class ReactionDataset(Dataset):
         ----------
         method : str
             The computational method to query on (B3LYP)
-        basis : str
+        basis : Optional[str], optional
             The computational basis query on (6-31G)
-        driver : str, optional
+        driver : Optional[str], optional
             Search within energy, gradient, etc computations
-        keywords : str, optional
+        keywords : Optional[str], optional
             The option token desired
-        program : str, optional
+        program : Optional[str], optional
             The program to query on
-        stoich : str
+        stoich : str, optional
             The given stoichiometry to compute.
-        prefix : str
+        prefix : str, optional
             A prefix given to the resulting column names.
-        postfix : str
+        postfix : str, optional
             A postfix given to the resulting column names.
-        contrib : bool
+        contrib : bool, optional
             Toggles a search between the Mongo Pages and the Databases's ContributedValues field.
-        scale : str, double
+        scale : str, optional
             All units are based in Hartree, the default scaling is to kcal/mol.
         field : str, optional
             The result field to query on
-        ignore_ds_type : bool
+        ignore_ds_type : bool, optional
             Override of "ie" for "rxn" db types.
 
 
@@ -359,7 +360,7 @@ class ReactionDataset(Dataset):
 
         return ret
 
-    def get_rxn(self, name):
+    def get_rxn(self, name: str) -> ReactionRecord:
         """
         Returns the JSON object of a specific reaction.
 

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -598,6 +598,9 @@ class QueueManagerGETResponse(BaseModel):
     data: List[Dict[str, Any]]
 
 
+register_model("queue_manager", "GET", QueueManagerGETBody, QueueManagerGETResponse)
+
+
 class QueueManagerPOSTBody(BaseModel):
     meta: QueueManagerMeta
     data: Dict[str, Any]
@@ -609,6 +612,9 @@ class QueueManagerPOSTBody(BaseModel):
 class QueueManagerPOSTResponse(BaseModel):
     meta: ResponsePOSTMeta
     data: bool
+
+
+register_model("queue_manager", "POST", QueueManagerPOSTBody, QueueManagerPOSTResponse)
 
 
 class QueueManagerPUTBody(BaseModel):
@@ -625,3 +631,6 @@ class QueueManagerPUTResponse(BaseModel):
     # Python can resolve dict -> bool since it passes a `is` test. Will not cast bool -> dict[str, int], so make Dict[]
     # check first
     data: Union[Dict[str, int], bool]
+
+
+register_model("queue_manager", "PUT", QueueManagerPUTBody, QueueManagerPUTResponse)

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -137,6 +137,15 @@ class QueryMeta(BaseModel):
         pass
 
 
+class ComputeResponse(BaseModel):
+    ids: List[Optional[str]]
+    submitted: List[str]
+    existing: List[str]
+
+    class Config(RESTConfig):
+        pass
+
+
 ### KVStore
 
 
@@ -431,12 +440,6 @@ class ProcedureGETResponse(BaseModel):
     meta: ResponseGETMeta
     data: List[Dict[str, Any]]
 
-    @validator("data", whole=True, pre=True)
-    def ensure_list_of_dict(cls, v):
-        if isinstance(v, dict):
-            return [v]
-        return v
-
     class Config(RESTConfig):
         pass
 
@@ -453,6 +456,9 @@ class TaskQueueGETBody(BaseModel):
         program: QueryStr = None
         status: QueryStr = None
 
+        class Config(RESTConfig):
+            pass
+
     meta: QueryMeta
     data: Data
 
@@ -461,40 +467,41 @@ class TaskQueueGETResponse(BaseModel):
     meta: ResponseGETMeta
     data: Union[List[TaskRecord], List[Dict[str, Any]]]
 
-    @validator("data", whole=True, pre=True)
-    def ensure_list_of_dict(cls, v):
-        if isinstance(v, dict):
-            return [v]
-        return v
+    class Config(RESTConfig):
+        pass
+
 
 register_model("task_queue", "GET", TaskQueueGETBody, TaskQueueGETResponse)
 
+
 class TaskQueuePOSTBody(BaseModel):
+    class Data(BaseModel):
+        procedure: str
+        program: str
+
+        tag: Optional[str] = None
+        priority: Union[str, int, None] = None
+
+        class Config(RESTConfig):
+            allow_extra = "allow"
 
     meta: Dict[str, Any]
-    data: List[Union[str, Molecule]]
+    data: List[Union[ObjectId, Molecule]]
 
-    class Config:
-        json_encoders = json_encoders
-
-    @validator("data", whole=True, pre=True)
-    def ensure_list_of_dict(cls, v):
-        if not isinstance(v, list):
-            return [v]
-        return v
+    class Config(RESTConfig):
+        pass
 
 
 class TaskQueuePOSTResponse(BaseModel):
-    class Data(BaseModel):
-        ids: List[Optional[str]]
-        submitted: List[str]
-        existing: List[str]
 
     meta: ResponsePOSTMeta
-    data: Data
+    data: ComputeResponse
+
+    class Config(RESTConfig):
+        pass
+
 
 register_model("task_queue", "POST", TaskQueuePOSTBody, TaskQueuePOSTResponse)
-
 
 ### Service Queue
 
@@ -509,22 +516,28 @@ class ServiceQueueGETBody(BaseModel):
     meta: QueryMeta
     data: Data
 
+    class Config(RESTConfig):
+        pass
+
 
 class ServiceQueueGETResponse(BaseModel):
     meta: ResponseGETMeta
     data: List[Dict[str, Any]]
 
-    @validator("data", whole=True, pre=True)
-    def ensure_list_of_dict(cls, v):
-        if isinstance(v, dict):
-            return [v]
-        return v
+    class Config(RESTConfig):
+        pass
+
+
+register_model("service_queue", "GET", ServiceQueueGETBody, ServiceQueueGETResponse)
 
 
 class ServiceQueuePOSTBody(BaseModel):
     class Meta(BaseModel):
         tag: Optional[str] = None
         priority: Union[str, int, None] = None
+
+        class Config(RESTConfig):
+            pass
 
     meta: Meta
     data: List[Union[TorsionDriveInput, GridOptimizationInput]]
@@ -534,17 +547,15 @@ class ServiceQueuePOSTBody(BaseModel):
 
 
 class ServiceQueuePOSTResponse(BaseModel):
-    class Data(BaseModel):
-        ids: List[Optional[str]]
-        submitted: List[str]
-        existing: List[str]
 
     meta: ResponsePOSTMeta
-    data: Data
+    data: ComputeResponse
 
     class Config(RESTConfig):
         pass
 
+
+register_model("service_queue", "POST", ServiceQueuePOSTBody, ServiceQueuePOSTResponse)
 
 ### Queue Manager
 
@@ -585,12 +596,6 @@ class QueueManagerGETBody(BaseModel):
 class QueueManagerGETResponse(BaseModel):
     meta: ResponseGETMeta
     data: List[Dict[str, Any]]
-
-    @validator("data", whole=True, pre=True)
-    def ensure_list_of_dict(cls, v):
-        if isinstance(v, dict):
-            return [v]
-        return v
 
 
 class QueueManagerPOSTBody(BaseModel):

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -394,18 +394,40 @@ class ResultGETResponse(BaseModel):
     class Config(RESTConfig):
         pass
 
-register_model("result", "GET", ResultGETBody, ResultGETResponse)
 
+register_model("result", "GET", ResultGETBody, ResultGETResponse)
 
 ### Procedures
 
 
 class ProcedureGETBody(BaseModel):
-    meta: Dict[str, Any] = {}
-    data: Dict[str, Any]
+    class Data(BaseModel):
+        id: QueryObjectId = None
+        task_id: QueryObjectId = None
+
+        procedure: QueryStr = None
+        program: QueryStr = None
+        hash_index: QueryStr = None
+
+        status: QueryStr = "COMPLETE"
+
+        class Config(RESTConfig):
+            pass
+
+    class Meta(BaseModel):
+        projection: Dict[str, Any] = None
+
+        class Config(RESTConfig):
+            pass
+
+    meta: Meta = Meta()
+    data: Data
+
+    class Config(RESTConfig):
+        pass
 
 
-class ProcedureGETReponse(BaseModel):
+class ProcedureGETResponse(BaseModel):
     meta: ResponseGETMeta
     data: List[Dict[str, Any]]
 
@@ -415,6 +437,11 @@ class ProcedureGETReponse(BaseModel):
             return [v]
         return v
 
+    class Config(RESTConfig):
+        pass
+
+
+register_model("procedure", "GET", ProcedureGETBody, ProcedureGETResponse)
 
 ### Task Queue
 
@@ -440,6 +467,7 @@ class TaskQueueGETResponse(BaseModel):
             return [v]
         return v
 
+register_model("task_queue", "GET", TaskQueueGETBody, TaskQueueGETResponse)
 
 class TaskQueuePOSTBody(BaseModel):
 
@@ -464,6 +492,8 @@ class TaskQueuePOSTResponse(BaseModel):
 
     meta: ResponsePOSTMeta
     data: Data
+
+register_model("task_queue", "POST", TaskQueuePOSTBody, TaskQueuePOSTResponse)
 
 
 ### Service Queue

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -18,7 +18,7 @@ __all__ = [
     "KeywordGETBody", "KeywordGETResponse", "KeywordPOSTBody", "KeywordPOSTResponse",
     "CollectionGETBody", "CollectionGETResponse", "CollectionPOSTBody", "CollectionPOSTResponse",
     "ResultGETBody", "ResultGETResponse",
-    "ProcedureGETBody", "ProcedureGETReponse",
+    "ProcedureGETBody", "ProcedureGETResponse",
     "TaskQueueGETBody", "TaskQueueGETResponse", "TaskQueuePOSTBody", "TaskQueuePOSTResponse",
     "ServiceQueueGETBody", "ServiceQueueGETResponse", "ServiceQueuePOSTBody", "ServiceQueuePOSTResponse",
     "QueueManagerGETBody", "QueueManagerGETResponse", "QueueManagerPOSTBody", "QueueManagerPOSTResponse",

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -8,9 +8,9 @@ from pydantic import BaseConfig, BaseModel, constr, validator
 from .common_models import KeywordSet, Molecule, ObjectId
 from .gridoptimization import GridOptimizationInput
 from .model_utils import json_encoders
+from .records import ResultRecord
 from .task_models import TaskRecord
 from .torsiondrive import TorsionDriveInput
-from .records import ResultRecord
 
 __all__ = [
     "ResponseGETMeta",
@@ -227,7 +227,7 @@ class KeywordGETBody(BaseModel):
             pass
 
     meta: EmptyMeta = {}
-    data: Dict[str, Any]
+    data: Data
 
     class Config(RESTConfig):
         pass

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -29,7 +29,8 @@ __all__ = [
 
 __rest_models = {}
 
-def register_model(name:str, rest:str, body: 'BaseModel', response: 'BaseModel') -> None:
+
+def register_model(name: str, rest: str, body: 'BaseModel', response: 'BaseModel') -> None:
     """
     Register a REST model.
 
@@ -57,7 +58,8 @@ def register_model(name:str, rest:str, body: 'BaseModel', response: 'BaseModel')
 
     __rest_models[name][rest] = (body, response)
 
-def rest_model(name:str, rest:str) -> Tuple['BaseModel', 'BaseModel']:
+
+def rest_model(name: str, rest: str) -> Tuple['BaseModel', 'BaseModel']:
     """Aquires a REST Model
 
     Parameters
@@ -94,10 +96,11 @@ class RESTConfig(BaseConfig):
     json_encoders = json_encoders
     extra = "forbid"
 
-class EmptyMeta(BaseModel):
 
+class EmptyMeta(BaseModel):
     class Config(RESTConfig):
         pass
+
 
 class ResponseMeta(BaseModel):
     errors: List[Tuple[str, str]]
@@ -138,8 +141,8 @@ class QueryMeta(BaseModel):
 
 
 class KVStoreGETBody(BaseModel):
-    data: List[ObjectId]
     meta: EmptyMeta = {}
+    data: List[ObjectId]
 
     class Config(RESTConfig):
         pass
@@ -152,23 +155,23 @@ class KVStoreGETResponse(BaseModel):
     class Config(RESTConfig):
         pass
 
+
 register_model("kvstore", "GET", KVStoreGETBody, KVStoreGETResponse)
 
 ### Molecule response
 
 
 class MoleculeGETBody(BaseModel):
-    class Data:
-        id: QueryObjectId=None
-        molecule_hash: QueryStr=None
-        molecular_formula: QueryStr=None
+    class Data(BaseModel):
+        id: QueryObjectId = None
+        molecule_hash: QueryStr = None
+        molecular_formula: QueryStr = None
 
         class Config(RESTConfig):
             pass
 
-
-    data: Dict[str, Any]
-    meta: Dict[str, Any] = None
+    meta: EmptyMeta = {}
+    data: Data
 
     class Config(RESTConfig):
         pass
@@ -181,10 +184,12 @@ class MoleculeGETResponse(BaseModel):
     class Config(RESTConfig):
         pass
 
+
 register_model("molecule", "GET", MoleculeGETBody, MoleculeGETResponse)
 
+
 class MoleculePOSTBody(BaseModel):
-    meta: Dict[str, Any] = None
+    meta: EmptyMeta = {}
     data: List[Molecule]
 
     class Config(RESTConfig):
@@ -198,37 +203,55 @@ class MoleculePOSTResponse(BaseModel):
     class Config(RESTConfig):
         pass
 
-register_model("molecule", "POST", MoleculePOSTBody, MoleculePOSTResponse)
 
+register_model("molecule", "POST", MoleculePOSTBody, MoleculePOSTResponse)
 
 ### Keywords
 
 
 class KeywordGETBody(BaseModel):
-    meta: Dict[str, Any] = None
+    class Data(BaseModel):
+        id: QueryObjectId = None
+        hash_index: QueryStr = None
+
+        class Config(RESTConfig):
+            pass
+
+    meta: EmptyMeta = {}
     data: Dict[str, Any]
+
+    class Config(RESTConfig):
+        pass
 
 
 class KeywordGETResponse(BaseModel):
     meta: ResponseGETMeta
     data: List[KeywordSet]
 
+    class Config(RESTConfig):
+        pass
+
+
+register_model("keyword", "GET", KeywordGETBody, KeywordGETResponse)
+
 
 class KeywordPOSTBody(BaseModel):
-    meta: Dict[str, Any] = None
+    meta: EmptyMeta = {}
     data: List[KeywordSet]
 
-    # @validator("data", whole=True, pre=True)
-    # def ensure_list_of_dict(cls, v):
-    #     if isinstance(v, dict):
-    #         return [v]
-    #     return v
+    class Config(RESTConfig):
+        pass
 
 
 class KeywordPOSTResponse(BaseModel):
-    data: List[Optional[str]]
+    data: List[Optional[ObjectId]]
     meta: ResponsePOSTMeta
 
+    class Config(RESTConfig):
+        pass
+
+
+register_model("keyword", "POST", KeywordPOSTBody, KeywordPOSTResponse)
 
 ### Collections
 
@@ -242,11 +265,20 @@ class CollectionGETBody(BaseModel):
         def cast_to_lower(cls, v):
             return v.lower()
 
+        class Config(RESTConfig):
+            pass
+
     class Meta(BaseModel):
         projection: Dict[str, Any] = None
 
+        class Config(RESTConfig):
+            pass
+
     meta: Meta = None
     data: Data
+
+    class Config(RESTConfig):
+        pass
 
 
 class CollectionGETResponse(BaseModel):
@@ -260,10 +292,19 @@ class CollectionGETResponse(BaseModel):
                 raise ValueError("Dicts in 'data' must have both 'collection' and 'name'")
         return v
 
+    class Config(RESTConfig):
+        pass
+
+
+register_model("collection", "GET", CollectionGETBody, CollectionGETResponse)
+
 
 class CollectionPOSTBody(BaseModel):
     class Meta(BaseModel):
         overwrite: bool = False
+
+        class Config(RESTConfig):
+            pass
 
     class Data(BaseModel):
         id: str = "local"  # Auto blocks overwriting in mongoengine_socket
@@ -274,17 +315,25 @@ class CollectionPOSTBody(BaseModel):
         def cast_to_lower(cls, v):
             return v.lower()
 
-        class Config:
+        class Config(RESTConfig):
             extra = "allow"
 
     meta: Meta = Meta()
     data: Data
+
+    class Config(RESTConfig):
+        pass
 
 
 class CollectionPOSTResponse(BaseModel):
     data: Union[str, None]
     meta: ResponsePOSTMeta
 
+    class Config(RESTConfig):
+        pass
+
+
+register_model("collection", "POST", CollectionPOSTBody, CollectionPOSTResponse)
 
 ### Result
 
@@ -327,6 +376,9 @@ class ResultGETBody(BaseModel):
     meta: Meta = Meta()
     data: Data
 
+    class Config(RESTConfig):
+        pass
+
 
 class ResultGETResponse(BaseModel):
     meta: ResponseGETMeta
@@ -338,6 +390,11 @@ class ResultGETResponse(BaseModel):
         if isinstance(v, dict):
             return [v]
         return v
+
+    class Config(RESTConfig):
+        pass
+
+register_model("result", "GET", ResultGETBody, ResultGETResponse)
 
 
 ### Procedures

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -12,18 +12,7 @@ from .records import ResultRecord
 from .task_models import TaskRecord
 from .torsiondrive import TorsionDriveInput
 
-__all__ = [
-    "ResponseGETMeta",
-    "MoleculeGETBody", "MoleculeGETResponse", "MoleculePOSTBody", "MoleculePOSTResponse",
-    "KeywordGETBody", "KeywordGETResponse", "KeywordPOSTBody", "KeywordPOSTResponse",
-    "CollectionGETBody", "CollectionGETResponse", "CollectionPOSTBody", "CollectionPOSTResponse",
-    "ResultGETBody", "ResultGETResponse",
-    "ProcedureGETBody", "ProcedureGETResponse",
-    "TaskQueueGETBody", "TaskQueueGETResponse", "TaskQueuePOSTBody", "TaskQueuePOSTResponse",
-    "ServiceQueueGETBody", "ServiceQueueGETResponse", "ServiceQueuePOSTBody", "ServiceQueuePOSTResponse",
-    "QueueManagerGETBody", "QueueManagerGETResponse", "QueueManagerPOSTBody", "QueueManagerPOSTResponse",
-    "QueueManagerPUTBody", "QueueManagerPUTResponse"
-]  # yapf: disable
+__all__ = ["ComputeResponse", "rest_model", "QueryStr", "QueryObjectId", "QueryProjection"]
 
 ### Utility functions
 

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -134,7 +134,7 @@ class TorsionDriveRecord(RecordBase):
 
             # Grab procedures
             needed_ids = [x for v in self.optimization_history.values() for x in v]
-            objects = self.client.query_procedures({"id": needed_ids})
+            objects = self.client.query_procedures(id=needed_ids)
             procedures = {v.id: v for v in objects}
 
             # Move procedures into the correct order

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -52,7 +52,7 @@ class TaskQueueHandler(APIHandler):
         body = self.parse_bodymodel(body_model)
 
         tasks = self.storage.get_queue(**body.data.dict(), projection=body.meta.projection)
-        response = TaskQueueGETResponse(**tasks)
+        response = response_model(**tasks)
 
         self.logger.info("GET: TaskQueue - {} pulls.".format(len(response.data)))
         self.write(response.json())

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -236,6 +236,8 @@ class QueueManagerHandler(APIHandler):
         storage = self.objects["storage_socket"]
 
         body = QueueManagerPOSTBody.parse_raw(self.request.body)
+        name = self._get_name_from_metadata(body.meta)
+        self.logger.info("QueueManager: Recieved completed task packet from {}.".format(name))
         ret = self.insert_complete_tasks(storage, body.data, self.logger)
 
         response = QueueManagerPOSTResponse(
@@ -249,7 +251,7 @@ class QueueManagerHandler(APIHandler):
             },
             data=True)
         self.write(response.json())
-        self.logger.info("QueueManager: Acquired {} complete tasks.".format(len(body.data)))
+        self.logger.info("QueueManager: Inserted {} complete tasks.".format(len(body.data)))
 
         # Update manager logs
         name = self._get_name_from_metadata(body.meta)

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -208,7 +208,7 @@ class QueueManager:
         self.assert_connected()
 
         self.scheduler = sched.scheduler(time.time, time.sleep)
-        heartbeat_time = int(0.8 * self.heartbeat_frequency)
+        heartbeat_time = int(0.4 * self.heartbeat_frequency)
 
         def scheduler_update():
             self.update()

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -279,7 +279,7 @@ class QueueManager:
         payload = self._payload_template()
         payload["data"]["operation"] = "shutdown"
         try:
-            response = self.client._automodel_request("queue_manager", "put", payload)
+            response = self.client._automodel_request("queue_manager", "put", payload, timeout=2)
         except IOError:
             # TODO something as we didnt successfully add the data
             self.logger.warning("Shutdown was not successful. This may delay queued tasks.")

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -21,7 +21,7 @@ from .interface import FractalClient
 from .queue import QueueManager, QueueManagerHandler, ServiceQueueHandler, TaskQueueHandler
 from .services import construct_service
 from .storage_sockets import storage_socket_factory
-from .web_handlers import (CollectionHandler, InformationHandler, KVStoreHandler, MoleculeHandler, OptionHandler,
+from .web_handlers import (CollectionHandler, InformationHandler, KVStoreHandler, MoleculeHandler, KeywordHandler,
                            ProcedureHandler, ResultHandler)
 
 myFormatter = logging.Formatter('[%(asctime)s] %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
@@ -203,7 +203,7 @@ class FractalServer:
             (r"/information", InformationHandler, self.objects),
             (r"/kvstore", KVStoreHandler, self.objects),
             (r"/molecule", MoleculeHandler, self.objects),
-            (r"/keyword", OptionHandler, self.objects),
+            (r"/keyword", KeywordHandler, self.objects),
             (r"/collection", CollectionHandler, self.objects),
             (r"/result", ResultHandler, self.objects),
             (r"/procedure", ProcedureHandler, self.objects),

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -318,12 +318,9 @@ def test_server(request):
     with FractalSnowflake(
             max_workers=0, storage_project_name=storage_name, storage_uri="mongodb://localhost:27017",
             start_server=False) as server:
-        print(server)
 
         # Clean and re-init the database
-        print("Resetting")
         reset_server_database(server)
-        print("Yielding")
         yield server
 
 

--- a/qcfractal/tests/test_client.py
+++ b/qcfractal/tests/test_client.py
@@ -29,7 +29,7 @@ def test_client_molecule(test_server):
     assert water.compare(get_mol[0])
 
 
-def test_client_options(test_server):
+def test_client_keywords(test_server):
 
     client = ptl.FractalClient(test_server)
 

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -8,6 +8,8 @@ import qcfractal.interface as ptl
 from qcfractal import testing
 from qcfractal.testing import fractal_compute_server, reset_server_database, using_psi4, using_rdkit
 
+bad_id1 = "000000000000000000000000"
+bad_id2 = "000000000000000000000001"
 
 @pytest.mark.parametrize("data", [
     pytest.param(("psi4", "HF", "sto-3g"), id="psi4", marks=using_psi4),
@@ -147,7 +149,7 @@ def test_queue_compute_mixed_molecule(fractal_compute_server):
 
     mol2 = ptl.Molecule.from_data("He 0 0 0\nHe 0 0 2.2")
 
-    ret = client.add_compute("RDKIT", "UFF", "", "energy", None, [mol1, mol2, "bad_id"], full_return=True)
+    ret = client.add_compute("RDKIT", "UFF", "", "energy", None, [mol1, mol2, bad_id1], full_return=True)
     assert len(ret.data.ids) == 3
     assert ret.data.ids[2] is None
     assert len(ret.data.submitted) == 2
@@ -158,7 +160,7 @@ def test_queue_compute_mixed_molecule(fractal_compute_server):
 
     db = fractal_compute_server.objects["storage_socket"]
 
-    ret = client.add_compute("rdkit", "UFF", "", "energy", None, [mol_ret[0], "bad_id2"])
+    ret = client.add_compute("rdkit", "UFF", "", "energy", None, [mol_ret[0], bad_id2])
     assert len(ret.ids) == 2
     assert ret.ids[1] is None
     assert len(ret.submitted) == 0
@@ -185,7 +187,7 @@ def test_queue_duplicate_procedure(fractal_compute_server):
         },
     }
 
-    ret = client.add_procedure("optimization", "geometric", geometric_options, [mol_ret[0], "bad_id"])
+    ret = client.add_procedure("optimization", "geometric", geometric_options, [mol_ret[0], bad_id1])
     assert len(ret.ids) == 2
     assert ret.ids[1] is None
     assert len(ret.submitted) == 1
@@ -196,7 +198,7 @@ def test_queue_duplicate_procedure(fractal_compute_server):
 
     db = fractal_compute_server.objects["storage_socket"]
 
-    ret2 = client.add_procedure("optimization", "geometric", geometric_options, ["bad_id", hooh])
+    ret2 = client.add_procedure("optimization", "geometric", geometric_options, [bad_id1, hooh])
     assert len(ret2.ids) == 2
     assert ret2.ids[0] is None
     assert len(ret2.submitted) == 0

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -104,8 +104,8 @@ def test_procedure_optimization(fractal_compute_server):
     assert len(fractal_compute_server.list_current_tasks()) == 0
 
     # # Query result and check against out manual pul
-    results1 = client.query_procedures({"program": "geometric"})
-    results2 = client.query_procedures({"id": compute_key})
+    results1 = client.query_procedures(program="geometric")
+    results2 = client.query_procedures(id=compute_key)
 
     for results in [results1, results2]:
         assert len(results) == 1

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -77,7 +77,7 @@ def test_service_torsiondrive_single(torsiondrive_fixture):
     ret = spin_up_test()
 
     # Get a TorsionDriveORM result and check data
-    result = client.query_procedures({"id": ret.ids[0]})[0]
+    result = client.query_procedures(id=ret.ids)[0]
     assert result.status == "COMPLETE"
     assert isinstance(str(result), str)  # Check that repr runs
 
@@ -98,7 +98,7 @@ def test_service_torsiondrive_multi_single(torsiondrive_fixture):
 
     ret = spin_up_test(initial_molecule=[hooh, hooh2])
 
-    result = client.query_procedures({"id": ret.ids[0]})[0]
+    result = client.query_procedures(id=ret.ids)[0]
     assert result.status == "COMPLETE"
 
 
@@ -115,7 +115,7 @@ def test_service_torsiondrive_duplicates(torsiondrive_fixture):
     id2 = spin_up_test(keywords={"meaningless_entry_to_change_hash": "Waffles!"}).ids[0]
 
     assert id1 != id2
-    procedures = client.query_procedures({"id": [id1, id2]})
+    procedures = client.query_procedures(id=[id1, id2])
     assert len(procedures) == 2  # Make sure only 2 procedures are yielded
 
     base_run, duplicate_run = procedures
@@ -130,7 +130,7 @@ def test_service_iterate_error(torsiondrive_fixture):
     # Run the test without modifications
     ret = spin_up_test(keywords={"dihedrals": [[0, 1, 2, 50]]})
 
-    status = client.query_services(procedure_id=ret.ids[0])
+    status = client.query_services(procedure_id=ret.ids)
     assert len(status) == 1
 
     assert status[0]["status"] == "ERROR"
@@ -145,7 +145,7 @@ def test_service_torsiondrive_compute_error(torsiondrive_fixture):
     # Run the test without modifications
     ret = spin_up_test(qc_spec={"method": "waffles_crasher"})
 
-    status = client.query_services(procedure_id=ret.ids[0])
+    status = client.query_services(procedure_id=ret.ids)
     assert len(status) == 1
 
     assert status[0]["status"] == "ERROR"
@@ -200,7 +200,7 @@ def test_service_gridoptimization_single_opt(fractal_compute_server):
     fractal_compute_server.await_services()
     assert len(fractal_compute_server.list_current_tasks()) == 0
 
-    result = client.query_procedures(id=ret.ids[0])[0]
+    result = client.query_procedures(id=ret.ids)[0]
 
     assert result.status == "COMPLETE"
     assert result.starting_grid == (1, 0)
@@ -267,7 +267,7 @@ def test_service_gridoptimization_single_noopt(fractal_compute_server):
     fractal_compute_server.await_services()
     assert len(fractal_compute_server.list_current_tasks()) == 0
 
-    result = client.query_procedures(id=ret.ids[0])[0]
+    result = client.query_procedures(id=ret.ids)[0]
 
     assert result.status == "COMPLETE"
     assert result.starting_grid == (1, )

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -200,7 +200,7 @@ def test_service_gridoptimization_single_opt(fractal_compute_server):
     fractal_compute_server.await_services()
     assert len(fractal_compute_server.list_current_tasks()) == 0
 
-    result = client.query_procedures({"id": ret.ids[0]})[0]
+    result = client.query_procedures(id=ret.ids[0])[0]
 
     assert result.status == "COMPLETE"
     assert result.starting_grid == (1, 0)
@@ -218,7 +218,7 @@ def test_service_gridoptimization_single_opt(fractal_compute_server):
 
     # Check tags on individual procedures
     proc_id = list(result.grid_optimizations.values())[0]
-    opt = client.query_procedures({"id": proc_id})[0]
+    opt = client.query_procedures(id=proc_id)[0]
 
     task = client.query_tasks(id=opt.task_id)[0]
     assert task.priority == 0
@@ -267,7 +267,7 @@ def test_service_gridoptimization_single_noopt(fractal_compute_server):
     fractal_compute_server.await_services()
     assert len(fractal_compute_server.list_current_tasks()) == 0
 
-    result = client.query_procedures({"id": ret.ids[0]})[0]
+    result = client.query_procedures(id=ret.ids[0])[0]
 
     assert result.status == "COMPLETE"
     assert result.starting_grid == (1, )

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -147,7 +147,7 @@ class MoleculeHandler(APIHandler):
 
         body = MoleculeGETBody.parse_raw(self.request.body)
 
-        molecules = storage.get_molecules(**body.data)
+        molecules = storage.get_molecules(**body.data.dict())
         self.logger.info("GET: Molecule - {} pulls.".format(len(molecules["data"])))
 
         ret = MoleculeGETResponse(**molecules)

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -64,7 +64,7 @@ class APIHandler(tornado.web.RequestHandler):
         try:
             return model.parse_raw(self.request.body)
         except ValidationError as exc:
-            raise tornado.web.HTTPError(status_code=401, reason="Invalid REST Input")
+            raise tornado.web.HTTPError(status_code=401, reason="Invalid REST")
 
 
 class InformationHandler(APIHandler):

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -9,7 +9,7 @@ from .interface.models.rest_models import (MoleculeGETBody, MoleculeGETResponse,
                                            MoleculePOSTResponse, KeywordGETBody, KeywordGETResponse, KeywordPOSTBody,
                                            KeywordPOSTResponse, KVStoreGETBody, KVStoreGETResponse, CollectionGETBody,
                                            CollectionGETResponse, CollectionPOSTBody, CollectionPOSTResponse,
-                                           ResultGETBody, ResultGETResponse, ProcedureGETBody, ProcedureGETReponse)
+                                           ResultGETBody, ResultGETResponse, ProcedureGETBody, ProcedureGETResponse)
 
 
 class APIHandler(tornado.web.RequestHandler):
@@ -283,9 +283,9 @@ class ProcedureHandler(APIHandler):
 
         body = ProcedureGETBody.parse_raw(self.request.body)
 
-        ret = storage.get_procedures(**body.data)
+        ret = storage.get_procedures(**body.data.dict())
 
-        response = ProcedureGETReponse(**ret)
+        response = ProcedureGETResponse(**ret)
         self.logger.info("GET: Procedures - {} pulls.".format(len(response.data)))
 
         self.write(response.json())


### PR DESCRIPTION
## Description
Fully documents and validates the REST requests at both the server and client endpoints using BaseModels with `extra = 'forbid'`. In addition: 
- [x] Creates a wrapper around responses to serve the correct classes in a concise way.
- [x] Removes duplicate FractalClient code into a `_automodel_request` wrapper.
- [x] Adds full python docstrings and typing to the FractalClient.
- [x] Homogenizes all queries to take in 
- [x] Additional typing and docstrings for Datasets.

## Status
- [ ] Changelog updated
- [x] Ready to go