### PR TITLE
Visualization Pass

### DIFF
--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -14,6 +14,7 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
 
 # Test depends
   - pytest

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -14,6 +14,7 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
 
 # Test depends
   - pytest

--- a/devtools/conda-envs/dev_head.yaml
+++ b/devtools/conda-envs/dev_head.yaml
@@ -14,6 +14,7 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
 
 # Test depends
   - pytest

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -25,6 +25,7 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
 
 # Test depends
   - pytest

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -15,6 +15,7 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
 
 # Test depends
   - pytest

--- a/examples/local_dataset/query_database.py
+++ b/examples/local_dataset/query_database.py
@@ -7,7 +7,7 @@ p = portal.FractalClient("localhost:7777", verify=False)
 ds = portal.collections.ReactionDataset.from_server(p, "Water")
 
 # Submit computations
-r = ds.query("SCF", "STO-3G", stoich="cp", scale="kcal/mol", program="psi4")
+r = ds.query("SCF", "STO-3G", stoich="cp", program="psi4")
 
 # Print the Pandas DataFrame
 print(ds.df)

--- a/examples/local_dataset/query_database.py
+++ b/examples/local_dataset/query_database.py
@@ -7,7 +7,7 @@ p = portal.FractalClient("localhost:7777", verify=False)
 ds = portal.collections.ReactionDataset.from_server(p, "Water")
 
 # Submit computations
-r = ds.query("SCF", "STO-3G", stoich="cp", program="psi4")
+r = ds.query("SCF", "sto-3g", stoich="cp", program="psi4")
 
 # Print the Pandas DataFrame
 print(ds.df)
@@ -15,7 +15,7 @@ print(ds.df)
 # Tests to ensure the correct results are returned
 # Safe to comment out
 import pytest
-assert pytest.approx(ds.df.loc["Water Dimer", "SCF/STO-3G"], 1.e-3) == -1.392710
-assert pytest.approx(ds.df.loc["Water Dimer Stretch", "SCF/STO-3G"], 1.e-3) ==  0.037144
-assert pytest.approx(ds.df.loc["Helium Dimer", "SCF/STO-3G"], 1.e-3) == -0.003148
+assert pytest.approx(ds.df.loc["Water Dimer", "cp-SCF/sto-3g-Psi4"], 1.e-3) == -1.392710
+assert pytest.approx(ds.df.loc["Water Dimer Stretch", "cp-SCF/sto-3g-Psi4"], 1.e-3) ==  0.037144
+assert pytest.approx(ds.df.loc["Helium Dimer", "cp-SCF/sto-3g-Psi4"], 1.e-3) == -0.003148
 

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -110,6 +110,9 @@ class ManagerSettings(BaseModel):
     cluster: Optional[ClusterSettings] = None
     dask: Optional[DaskQueueSettings] = None
 
+    class Config:
+        extra = "forbid"
+
 
 def parse_args():
     parser = argparse.ArgumentParser(

--- a/qcfractal/cli/qcfractal_server.py
+++ b/qcfractal/cli/qcfractal_server.py
@@ -44,6 +44,7 @@ def parse_args():
     general.add_argument("--port", type=int, default=7777, help="The server port")
     general.add_argument("--compress-response", type=bool, default=True, help="Compress the response or not")
     general.add_argument("--config-file", type=str, default=None, help="A configuration file to use")
+    general.add_argument("--start-periodics", type=bool, default=True, help="Start the periodic calls or not, always recommended unless running fractal-server behind a proxy")
 
     parser._action_groups.reverse()
 
@@ -120,7 +121,7 @@ def main(args=None):
     cli_utils.install_signal_handlers(server.loop, server.stop)
 
     # Blocks until keyboard interupt
-    server.start()
+    server.start(start_periodics=args["start_periodics"])
 
 
 if __name__ == '__main__':

--- a/qcfractal/extras.py
+++ b/qcfractal/extras.py
@@ -2,6 +2,8 @@
 Misc information and runtime information.
 """
 
+from importlib.util import find_spec
+
 from . import _version
 
 __all__ = ["get_information"]
@@ -28,6 +30,10 @@ def _isnotebook():
 
 
 __info["isnotebook"] = _isnotebook()
+
+
+def find_module(name):
+    return find_spec(name)
 
 
 def get_information(key):

--- a/qcfractal/extras.py
+++ b/qcfractal/extras.py
@@ -11,6 +11,25 @@ versions = _version.get_versions()
 __info = {"version": versions['version'], "git_revision": versions['full-revisionid']}
 
 
+def _isnotebook():
+    """
+    Checks if we are inside a jupyter notebook or not.
+    """
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell in ['ZMQInteractiveShell', 'google.colab._shell']:
+            return True
+        elif shell == 'TerminalInteractiveShell':
+            return False
+        else:
+            return False
+    except NameError:
+        return False
+
+
+__info["isnotebook"] = _isnotebook()
+
+
 def get_information(key):
     """
     Obtains a variety of runtime information about QCFractal.
@@ -27,4 +46,8 @@ def provenance_stamp(routine):
    generating routine's name is passed in through `routine`.
 
    """
-    return {'creator': 'QCFractal', 'version': get_information('version'), 'routine': routine}
+    return {
+        'creator': 'QCFractal',
+        'version': get_information('version'),
+        'routine': routine,
+    }

--- a/qcfractal/interface/collections/collection_utils.py
+++ b/qcfractal/interface/collections/collection_utils.py
@@ -39,8 +39,8 @@ def register_collection(collection: 'Collection') -> None:
     """
 
     class_name = collection.__name__.lower()
-    if class_name in __registered_collections:
-        raise KeyError("Collection type '{}' already registered".format(class_name))
+    # if class_name in __registered_collections:
+    #     raise KeyError("Collection type '{}' already registered".format(class_name))
     __registered_collections[class_name] = collection
 
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -534,7 +534,7 @@ class Dataset(Collection):
         return [x.name for x in self.data.records]
 
     # Statistical quantities
-    def statistics(self, stype: str, value: str, bench: str="Benchmark"):
+    def statistics(self, stype: str, value: str, bench: str="Benchmark", **kwargs: Dict[str, Any]):
         """Summary
 
         Parameters
@@ -545,13 +545,16 @@ class Dataset(Collection):
             The method string to compare
         bench : str, optional
             The benchmark method for the comparison
+        kwargs: Dict[str, Any]
+            Additional kwargs to pass to the statistics functions
+
 
         Returns
         -------
         ret : pd.DataFrame, pd.Series, float
             Returns a DataFrame, Series, or float with the requested statistics depending on input.
         """
-        return wrap_statistics(stype, self.df, value, bench)
+        return wrap_statistics(stype.upper(), self.df, value, bench, **kwargs)
 
     # Getters
     def __getitem__(self, args: str) -> 'Series':

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -134,6 +134,7 @@ class Dataset(Collection):
 
         self.data.history.add(tuple(new_history))
 
+
     def list_history(self, **search: Dict[str, Optional[str]]) -> 'DataFrame':
         """
         Lists the history of computations completed.
@@ -166,20 +167,21 @@ class Dataset(Collection):
         df.sort_index(inplace=True)
         return df
 
-    def _default_parameters(self, driver: str, keywords: Optional[str], program: str) -> Tuple[str, str, str, str]:
+    def _default_parameters(self, keywords: Optional[str], program: str, stoich=None) -> Tuple[str, str, str, str]:
         """
         Takes raw input parsed parameters and applies defaults to them.
         """
 
+        default_name = {}
         if program is None:
             if self.data.default_program is None:
                 raise KeyError("No default program was set and none was provided.")
             program = self.data.default_program
         else:
             program = program.lower()
+            default_name["program"] = program.title()
 
-        if driver is None:
-            driver = self.data.default_driver
+        driver = self.data.default_driver
 
         keywords_alias = keywords
         if keywords is None:
@@ -409,7 +411,6 @@ class Dataset(Collection):
               method,
               basis=None,
               *,
-              driver=None,
               keywords=None,
               program=None,
               contrib=False,
@@ -424,8 +425,6 @@ class Dataset(Collection):
             The computational method to query on (B3LYP)
         basis : str
             The computational basis query on (6-31G)
-        driver : str, optional
-            Search within energy, gradient, etc computations
         keywords : str, optional
             The option token desired
         program : str, optional
@@ -448,7 +447,7 @@ class Dataset(Collection):
         >>> ds.query("B3LYP", "aug-cc-pVDZ", stoich="cp", prefix="cp-")
         """
 
-        driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
+        driver, keywords, keywords_alias, program = self._default_parameters(keywords, program)
 
         if not contrib and (self.client is None):
             raise AttributeError("DataBase: FractalClient was not set.")
@@ -482,7 +481,6 @@ class Dataset(Collection):
                 method: str,
                 basis: Optional[str]=None,
                 *,
-                driver: Optional[str]=None,
                 keywords: Optional[str]=None,
                 program: Optional[str]=None,
                 tag: Optional[str]=None,
@@ -496,8 +494,6 @@ class Dataset(Collection):
             The computational method to compute (B3LYP)
         basis : Optional[str], optional
             The computational basis to compute (6-31G)
-        driver : Optional[str], optional
-            The type of computation to run (energy, gradient, etc)
         keywords : Optional[str], optional
             The keyword alias for the requested compute
         program : Optional[str], optional
@@ -518,7 +514,7 @@ class Dataset(Collection):
         if self.client is None:
             raise AttributeError("Dataset: Compute: Client was not set.")
 
-        driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
+        driver, keywords, keywords_alias, program = self._default_parameters(keywords, program)
 
         molecule_idx = [e.molecule_id for e in self.data.records]
         umols, uidx = np.unique(molecule_idx, return_index=True)

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -233,24 +233,15 @@ class Dataset(Collection):
             A DataFrame of the queried parameters
         """
 
-        pop_method = False
-        if method is None:
-            method = "something"
-            pop_method = True
+        # Get default program/keywords
+        name, dbkeys, history = self._default_parameters(program, "nan", "nan", keywords)
 
-        pop_basis = False
-        if basis is None:
-            basis = "something"
-            pop_basis = True
+        for k, v in [("method", method), ("basis", basis)]:
 
-
-        name, dbkeys, history = self._default_parameters(program, method, basis, keywords)
-
-        if pop_method:
-            history.pop("method")
-
-        if pop_basis:
-            history.pop("basis")
+            if v is not None:
+                history[k] = v
+            else:
+                history.pop(k, None)
 
         return self._get_history(**history)
 
@@ -273,6 +264,8 @@ class Dataset(Collection):
 
         title = f"Dataset {self.data.name} Statistics"
 
+        if len(queries) == 0:
+            raise KeyError("No query matches, nothing to visualize!")
         series = self.statistics(metric, list(queries["name"]), bench=bench)
         series.sort_index(inplace=True)
 
@@ -287,7 +280,7 @@ class Dataset(Collection):
                   bench=None):
 
         query = {"method": method, "basis": basis, "keywords": keywords, "program": program}
-        query = {k:v for k, v in query.items() if v is not None}
+        query = {k: v for k, v in query.items() if v is not None}
 
         return self._visualize(metric, bench, query=query)
 

--- a/qcfractal/interface/collections/openffworkflow.py
+++ b/qcfractal/interface/collections/openffworkflow.py
@@ -149,7 +149,7 @@ class OpenFFWorkflow(Collection):
         """
         return list(self.data.fragments)
 
-    def add_fragment(self, fragment_id, data, provenance=None, tag=None, priority=None):
+    def add_fragment(self, fragment_id, data, tag=None, priority=None):
         """
         Adds a new fragment to the workflow along with the associated input required.
 
@@ -161,9 +161,6 @@ class OpenFFWorkflow(Collection):
         data : dict
             A dictionary of label : {type, intial_molecule, grid_spacing, dihedrals} for torsiondrive type and
             label : {type, initial_molecule, contraints} for an optimization type
-
-        provenance : dict, optional
-            The provenance of the fragments creation
 
         Example
         -------
@@ -178,8 +175,6 @@ class OpenFFWorkflow(Collection):
         }
         wf.add_fragment("CCCC", data=)
         """
-        if provenance is None:
-            provenance = {}
 
         if fragment_id not in self.data.fragments:
             self.data.fragments[fragment_id] = {}

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -177,7 +177,6 @@ class ReactionDataset(Dataset):
               prefix: str="",
               postfix: str="",
               contrib: bool=False,
-              scale: str="kcal/mol",
               field: str="return_result",
               ignore_ds_type: bool=False):
         """
@@ -236,7 +235,7 @@ class ReactionDataset(Dataset):
 
         # # If reaction results
         if contrib:
-            tmp_idx = self.get_contributed_values_column(method, scale=scale)
+            tmp_idx = self.get_contributed_values_column(method)
 
             self.df[prefix + method + postfix] = tmp_idx
             return True
@@ -263,7 +262,7 @@ class ReactionDataset(Dataset):
 
         # scale
         tmp_idx = tmp_idx.apply(lambda x: pd.to_numeric(x, errors='ignore'))
-        tmp_idx[tmp_idx.select_dtypes(include=['number']).columns] *= constants.conversion_factor('hartree', scale)
+        tmp_idx[tmp_idx.select_dtypes(include=['number']).columns] *= constants.conversion_factor('hartree', self.units)
 
         # Apply to df
         self.df[tmp_idx.columns] = tmp_idx

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -194,7 +194,24 @@ class ReactionDataset(Dataset):
         """
 
         self._validate_stoich(stoich)
-        name, dbkeys, history = self._default_parameters(program, "something", basis, keywords, stoich=stoich)
+
+        pop_method = False
+        if method is None:
+            method = "something"
+            pop_method = True
+
+        pop_basis = False
+        if basis is None:
+            basis = "something"
+            pop_basis = True
+
+        name, dbkeys, history = self._default_parameters(program, method, basis, keywords, stoich=stoich)
+
+        if pop_method:
+            history.pop("method")
+        if pop_basis:
+            history.pop("basis")
+
         return self._get_history(**history)
 
     def query(self,
@@ -371,7 +388,7 @@ class ReactionDataset(Dataset):
             priority=priority)
 
         # Update the record that this was computed
-        self._add_history(**history, stoichiometry=stoich)
+        self._add_history(**history)
         self.save()
 
         return ret

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -73,9 +73,6 @@ class ReactionDataset(Dataset):
         self.valid_stoich = None
         self._form_index()
 
-        for cv in self.data.contributed_values.keys():
-            self.query(cv, contrib=True)
-
     class DataModel(Dataset.DataModel):
 
         ds_type: _ReactionTypeEnum = _ReactionTypeEnum.rxn
@@ -259,7 +256,6 @@ class ReactionDataset(Dataset):
               keywords: Optional[str]=None,
               program: Optional[str]=None,
               stoich: str="default",
-              contrib: bool=False,
               field: Optional[str]=None,
               ignore_ds_type: bool=False,
               force: bool=False) -> str:
@@ -278,8 +274,6 @@ class ReactionDataset(Dataset):
             The program to query on
         stoich : str, optional
             The given stoichiometry to compute.
-        contrib : bool, optional
-            Toggles a search between the Mongo Pages and the Databases's ContributedValues field.
         field : Optional[str], optional
             The result field to query on
         ignore_ds_type : bool, optional
@@ -302,7 +296,7 @@ class ReactionDataset(Dataset):
         """
         self._check_state()
 
-        if not contrib and (self.client is None):
+        if self.client is None:
             raise AttributeError("DataBase: FractalClient was not set.")
 
         self._validate_stoich(stoich)
@@ -317,12 +311,6 @@ class ReactionDataset(Dataset):
             return name
 
         # # If reaction results
-        if contrib:
-            tmp_idx = self.get_contributed_values_column(method)
-
-            self.df[tmp_idx.columns[0]] = tmp_idx
-            return tmp_idx.columns[0]
-
         if (not ignore_ds_type) and (self.data.ds_type.lower() == "ie"):
             monomer_stoich = ''.join([x for x in stoich if not x.isdigit()]) + '1'
             tmp_idx_complex = self._unroll_query(dbkeys, stoich, field=field)

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -170,7 +170,6 @@ class ReactionDataset(Dataset):
               method,
               basis: Optional[str]=None,
               *,
-              driver: Optional[str]=None,
               keywords: Optional[str]=None,
               program: Optional[str]=None,
               stoich: str="default",
@@ -188,8 +187,6 @@ class ReactionDataset(Dataset):
             The computational method to query on (B3LYP)
         basis : Optional[str], optional
             The computational basis query on (6-31G)
-        driver : Optional[str], optional
-            Search within energy, gradient, etc computations
         keywords : Optional[str], optional
             The option token desired
         program : Optional[str], optional
@@ -230,7 +227,7 @@ class ReactionDataset(Dataset):
         if not contrib and (self.client is None):
             raise AttributeError("DataBase: FractalClient was not set.")
 
-        driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
+        driver, keywords, keywords_alias, program = self._default_parameters(keywords, program)
         self._validate_stoich(stoich)
 
         # # If reaction results
@@ -273,7 +270,6 @@ class ReactionDataset(Dataset):
                 method: Optional[str],
                 basis: Optional[str]=None,
                 *,
-                driver: Optional[str]=None,
                 keywords: Optional[str]=None,
                 program: Optional[str]=None,
                 stoich: str="default",
@@ -289,8 +285,6 @@ class ReactionDataset(Dataset):
             The computational method to compute (B3LYP)
         basis : Optional[str], optional
             The computational basis to compute (6-31G)
-        driver : Optional[str], optional
-            The type of computation to run (energy, gradient, etc)
         keywords : Optional[str], optional
             The keyword alias for the requested compute
         program : Optional[str], optional
@@ -319,7 +313,7 @@ class ReactionDataset(Dataset):
         if self.client is None:
             raise AttributeError("Dataset: Compute: Client was not set.")
 
-        driver, keywords, keywords_alias, program = self._default_parameters(driver, keywords, program)
+        driver, keywords, keywords_alias, program = self._default_parameters(keywords, program)
         self._validate_stoich(stoich)
 
         # Figure out molecules that we need

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -176,7 +176,7 @@ class ReactionDataset(Dataset):
               contrib: bool=False,
               field: Optional[str]=None,
               ignore_ds_type: bool=False,
-              force: bool=False):
+              force: bool=False) -> str:
         """
         Queries the local Portal for the requested keys and stoichiometry.
 
@@ -203,15 +203,14 @@ class ReactionDataset(Dataset):
 
         Returns
         -------
-        success : bool
-            Returns True if the requested query was successful or not.
+        str
+            The name of the queried column
 
 
         Examples
         --------
 
         ds.query("B3LYP", "aug-cc-pVDZ", stoich="cp", prefix="cp-")
-
 
 
         """
@@ -229,14 +228,14 @@ class ReactionDataset(Dataset):
             name = "{}-{}".format(name, field)
 
         if (name in self.df) and (force is False):
-            return True
+            return name
 
         # # If reaction results
         if contrib:
             tmp_idx = self.get_contributed_values_column(method)
 
             self.df[tmp_idx.columns[0]] = tmp_idx
-            return True
+            return tmp_idx.columns[0]
 
         if (not ignore_ds_type) and (self.data.ds_type.lower() == "ie"):
             monomer_stoich = ''.join([x for x in stoich if not x.isdigit()]) + '1'
@@ -258,7 +257,7 @@ class ReactionDataset(Dataset):
         # Apply to df
         self.df[name] = tmp_idx
 
-        return True
+        return name
 
     def compute(self,
                 method: Optional[str],

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -68,14 +68,13 @@ class ReactionDataset(Dataset):
 
         # Internal data
         self.rxn_index = pd.DataFrame()
-        self.df = pd.DataFrame()
-
-        # Initialize internal data frames
-        self.df = pd.DataFrame(index=self.get_index())
 
         self.rxn_index = None
         self.valid_stoich = None
         self._form_index()
+
+        for cv in self.data.contributed_values.keys():
+            self.query(cv, contrib=True)
 
     class DataModel(Dataset.DataModel):
 
@@ -165,6 +164,38 @@ class ReactionDataset(Dataset):
         tmp_idx[null_mask] = np.nan
 
         return tmp_idx
+
+    def get_history(self,
+                    method: Optional[str]=None,
+                    basis: Optional[str]=None,
+                    keywords: Optional[str]=None,
+                    program: Optional[str]=None,
+                    stoich: str="default") -> 'DataFrame':
+        """ Queries known history from the search paramaters provided. Defaults to the standard
+        programs and keywords if not provided.
+
+        Parameters
+        ----------
+        method : Optional[str]
+            The computational method to compute (B3LYP)
+        basis : Optional[str], optional
+            The computational basis to compute (6-31G)
+        keywords : Optional[str], optional
+            The keyword alias for the requested compute
+        program : Optional[str], optional
+            The underlying QC program
+        stoich : str, optional
+            The given stoichiometry to compute.
+
+        Returns
+        -------
+        DataFrame
+            A DataFrame of the queried parameters
+        """
+
+        self._validate_stoich(stoich)
+        name, dbkeys, history = self._default_parameters(program, "something", basis, keywords, stoich=stoich)
+        return self._get_history(**history)
 
     def query(self,
               method,

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -195,22 +195,14 @@ class ReactionDataset(Dataset):
 
         self._validate_stoich(stoich)
 
-        pop_method = False
-        if method is None:
-            method = "something"
-            pop_method = True
+        name, dbkeys, history = self._default_parameters(program, "nan", "nan", keywords, stoich=stoich)
 
-        pop_basis = False
-        if basis is None:
-            basis = "something"
-            pop_basis = True
+        for k, v in [("method", method), ("basis", basis)]:
 
-        name, dbkeys, history = self._default_parameters(program, method, basis, keywords, stoich=stoich)
-
-        if pop_method:
-            history.pop("method")
-        if pop_basis:
-            history.pop("basis")
+            if v is not None:
+                history[k] = v
+            else:
+                history.pop(k, None)
 
         return self._get_history(**history)
 

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -206,6 +206,52 @@ class ReactionDataset(Dataset):
 
         return self._get_history(**history)
 
+    def visualize(self,
+                  method: Optional[str]=None,
+                  basis: Optional[str]=None,
+                  keywords: Optional[str]=None,
+                  program: Optional[str]=None,
+                  stoich: Optional[str]=None,
+                  groupby: Optional[str]=None,
+                  metric: str="UE",
+                  bench: Optional[str]=None,
+                  kind: str="bar",
+                  return_figure: Optional[bool]=None) -> 'plotly.Figure':
+        """
+        Parameters
+        ----------
+        method : Optional[str], optional
+            Methods to query
+        basis : Optional[str], optional
+            Bases to query
+        keywords : Optional[str], optional
+            Keyword aliases to query
+        program : Optional[str], optional
+            Programs aliases to query
+        stoich : Optional[str], optional
+            Stoichiometry to query
+        groupby : Optional[str], optional
+            Groups the plot by this index.
+        metric : str, optional
+            The metric to use either UE (unsigned error) or URE (unsigned relative error)
+        bench : Optional[str], optional
+            The benchmark level of theory to use
+        kind : str, optional
+            The kind of chart to produce, either 'bar' or 'violin'
+        return_figure : Optional[bool], optional
+            If True, return the raw plotly figure. If False, returns a hosted iPlot. If None, return a iPlot display in Jupyter notebook and a raw plotly figure in all other circumstances.
+        
+        Returns
+        -------
+        plotly.Figure
+            The requested figure.
+        """
+
+        query = {"method": method, "basis": basis, "keywords": keywords, "program": program, "stoich": stoich}
+        query = {k: v for k, v in query.items() if v is not None}
+
+        return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind)
+
     def query(self,
               method,
               basis: Optional[str]=None,

--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -49,7 +49,7 @@ class TorsionDriveDataset(Collection):
 
     def _get_index(self):
 
-        return list(self.data.records)
+        return [x.name for x in self.data.records.values()]
 
     def add_specification(self,
                           name: str,
@@ -209,7 +209,7 @@ class TorsionDriveDataset(Collection):
         df = pd.DataFrame(data, columns=["index", specification])
         df.set_index("index", inplace=True)
 
-        self.df[specification] = df
+        self.df[specification] = df[specification]
 
 
 register_collection(TorsionDriveDataset)

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -79,6 +79,7 @@ class TorsionDriveRecord(RecordBase):
 
     # Output data
     final_energy_dict: Dict[str, float]
+
     optimization_history: Dict[str, List[ObjectId]]
     minimum_positions: Dict[str, int]
 

--- a/qcfractal/interface/statistics.py
+++ b/qcfractal/interface/statistics.py
@@ -5,52 +5,49 @@ import pandas as pd
 
 # Need to use specifically with the fitting_database class
 
-# def signed_error(value, bench):
-#     return value - bench
 
-# def unsigned_error(value, bench):
-#     return np.abs(value - bench)
+def signed_error(value, bench, **kwargs):
+    return value - bench
 
 
-def mean_signed_error(value, bench):
+def unsigned_error(value, bench, **kwargs):
+    return np.abs(value - bench)
+
+
+def mean_signed_error(value, bench, **kwargs):
     return np.mean(value - bench)
 
 
-def mean_unsigned_error(value, bench):
+def mean_unsigned_error(value, bench, **kwargs):
     return np.mean(np.abs(value - bench))
 
 
-# def unsigned_relative_error(value, bench):
-#     return np.abs((value - bench) / bench) * 100
+def unsigned_relative_error(value, bench, **kwargs):
+    min_div = kwargs.get("floor", None)
+    divisor = bench.copy()
+    if min_div:
+        divisor[np.abs(divisor) < min_div] = np.abs(min_div)
+    return np.abs((value - bench) / divisor) * 100
 
 
-def mean_unsigned_relative_error(value, bench):
-    return np.mean(np.abs((value - bench) / bench)) * 100
+def mean_unsigned_relative_error(value, bench, **kwargs):
+    ure = unsigned_relative_error(value, bench, **kwargs)
+    return np.mean(ure)
 
-
-# def weighted_unsigned_relative_error(value, bench, weight):
-#     return np.abs((value - bench) / weight) * 100
-
-# def weighted_mean_unsigned_relative_error(value, bench, weight):
-#     return np.mean(np.abs((value - bench) / weight)) * 100
 
 # Stats wrapped in a dictionary:
 _stats_dict = {}
-# _stats_dict['E'] = signed_error
+_stats_dict['E'] = signed_error
 _stats_dict['ME'] = mean_signed_error
-# _stats_dict['UE'] = unsigned_error
+_stats_dict['UE'] = unsigned_error
 _stats_dict['MUE'] = mean_unsigned_error
-# _stats_dict['URE'] = unsigned_relative_error
+_stats_dict['URE'] = unsigned_relative_error
 _stats_dict['MURE'] = mean_unsigned_relative_error
-# _stats_dict['WURE'] = weighted_unsigned_relative_error
-# _stats_dict['WMURE'] = weighted_mean_unsigned_relative_error
 
 _return_series = ['ME', 'MUE', 'MURE', 'WMURE']
 
-# _needs_weight = ["WURE", "WMURE"]
 
-
-def wrap_statistics(description, df, value, bench):
+def wrap_statistics(description, df, value, bench, **kwargs):
 
     # Get benchmark
     if isinstance(bench, str):
@@ -64,14 +61,14 @@ def wrap_statistics(description, df, value, bench):
 
     if isinstance(value, str):
         rvalue = df[value]
-        return _stats_dict[description](rvalue, rbench)
+        return _stats_dict[description](rvalue, rbench, **kwargs)
 
     elif isinstance(value, pd.Series):
         rvalue = value
-        return _stats_dict[description](rvalue, rbench)
+        return _stats_dict[description](rvalue, rbench, **kwargs)
 
     elif isinstance(value, pd.DataFrame):
-        return value.apply(lambda x: _stats_dict[description](x, rbench))
+        return value.apply(lambda x: _stats_dict[description](x, rbench, **kwargs))
 
     elif isinstance(value, (list, tuple)):
         if description in _return_series:
@@ -81,7 +78,7 @@ def wrap_statistics(description, df, value, bench):
 
         method = _stats_dict[description]
         for col in value:
-            ret[col] = method(df[col], rbench)
+            ret[col] = method(df[col], rbench, **kwargs)
         return ret
 
     else:

--- a/qcfractal/interface/tests/test_visualization.py
+++ b/qcfractal/interface/tests/test_visualization.py
@@ -1,0 +1,59 @@
+"""
+Tests for visualization code
+"""
+
+import pytest
+
+from . import portal
+
+try:
+    import plotly
+    _has_ploty = True
+except ModuleNotFoundError:
+    _has_ploty = False
+
+using_plotly = pytest.mark.skipif(
+    _has_ploty is False, reason="Not detecting module 'plotly'. Install package if necessary to enable tests.")
+
+
+@pytest.fixture
+def S22Fixture():
+
+    # Connect to the primary database
+    client = portal.FractalClient()
+
+    S22 = client.get_collection("ReactionDataset", "S22")
+
+    return (client, S22)
+
+
+@using_plotly
+@pytest.mark.parametrize("kind", ["violin", "bar"])
+def test_dataset_plot(S22Fixture, kind):
+
+    client, S22 = S22Fixture
+
+    fig = S22.visualize(
+        method=["b2plyp", "b3lyp", "pbe"],
+        basis=["def2-svp", "def2-TZVP"],
+        return_figure=True,
+        bench="S22a",
+        kind=kind).to_dict()
+    assert "S22" in fig["layout"]["title"]["text"]
+
+
+@using_plotly
+@pytest.mark.parametrize("kind", ["violin", "bar"])
+@pytest.mark.parametrize("groupby", ["method", "basis"])
+def test_dataset_groupby_plot(S22Fixture, kind, groupby):
+
+    client, S22 = S22Fixture
+
+    fig = S22.visualize(
+        method=["b2plyp", "b3lyp"],
+        basis=["def2-svp", "def2-TZVP"],
+        return_figure=True,
+        bench="S22a",
+        kind=kind,
+        groupby=groupby).to_dict()
+    assert "S22" in fig["layout"]["title"]["text"]

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -1,0 +1,55 @@
+"""
+Visualization using the plotly library.
+"""
+
+
+def _isnotebook():
+    """
+    Checks if we are inside a jupyter notebook or not.
+    """
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell in ['ZMQInteractiveShell', 'google.colab._shell']:
+            return True
+        elif shell == 'TerminalInteractiveShell':
+            return False
+        else:
+            return False
+    except NameError:
+        return False
+
+
+# Plotly is an optional library
+from importlib.util import find_spec
+spec = find_spec('plotly')
+if spec is None:
+    _plotly_found = False
+else:
+    _plotly_found = True
+del spec, find_spec
+
+_ipycheck = False
+
+
+def check_plotly():
+    """
+    Checks if plotly is found and auto inits the offline notebook
+    """
+    if _plotly_found is False:
+        raise ModuleNotFoundError("Plotly is required for this function. Please ")
+
+    if _ipycheck is False:
+        import plotly
+        plotly.offline.init_notebook_mode(connected=True)
+        _ipycheck = True
+
+
+import plotly.plotly as py
+import plotly.graph_objs as go
+
+
+def bar():
+
+    check_plotly()
+
+    plotly.offline.plot

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -44,12 +44,83 @@ def check_plotly():
         _ipycheck = True
 
 
-import plotly.plotly as py
-import plotly.graph_objs as go
+def bar_plot(traces: 'List[Series]', title=None, ylabel=None, dtype="bar") -> 'plotly.Figure':
+    """Renders a plotly bar plot
 
+    Parameters
+    ----------
+    traces : List[Series]
+        A list of bar plots to show, if more than one series the resulting graph will be grouped.
+    title : None, optional
+        The title of the graph
+    ylabel : None, optional
+        The y axis label
 
-def bar():
+    Returns
+    -------
+    plotly.Figure
+        The requested bar plot.
+    """
 
     check_plotly()
+    import plotly.graph_objs as go
 
-    plotly.offline.plot
+    data = [go.Bar(x=trace.index, y=trace, name=trace.name) for trace in traces]
+
+    layout = {}
+    if title:
+        layout["title"] = title
+    if ylabel:
+        layout["yaxis"] = {"title": ylabel}
+    layout = go.Layout(layout)
+    figure = go.Figure(data=data, layout=layout)
+
+    return figure
+
+
+def violin_plot(traces: 'DataFrame', negative: 'DataFrame'=None, title=None, points=False,
+                ylabel=None) -> 'plotly.Figure':
+    """Renders a plotly violin plot
+
+    Parameters
+    ----------
+    traces : DataFrame
+        Pandas DataFrame of points to plot, will create a violin plot of each column.
+    negative : DataFrame, optional
+        A comparison violin plot, these columns will present the right hand side.
+    title : None, optional
+        The title of the graph
+    points : None, optional
+        Show points or not, this option is not available for comparison violin plots.
+    ylabel : None, optional
+        The y axis label
+
+    Returns
+    -------
+    plotly.Figure
+        The requested violin plot.
+    """
+    check_plotly()
+    import plotly.graph_objs as go
+
+    data = []
+    if negative is not None:
+
+        for trace, side in zip([traces, negative], ["positive", "negative"]):
+            p = {"name": trace.name, "type": "violin", "box": {"visible": True}}
+            p["y"] = trace.stack()
+            p["x"] = trace.stack().reset_index().level_1
+            p["side"] = side
+
+            data.append(p)
+    else:
+        for name, series in traces.items():
+            p = {"name": name, "type": "violin", "box": {"visible": True}}
+            p["y"] = series
+
+            data.append(p)
+
+    layout = go.Layout({"title": title, "yaxis": {"title": ylabel}})
+    figure = go.Figure(data=data, layout=layout)
+
+    return figure

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -28,7 +28,7 @@ else:
     _plotly_found = True
 del spec, find_spec
 
-_ipycheck = False
+_ipycheck = _isnotebook()
 
 
 def check_plotly():
@@ -36,10 +36,10 @@ def check_plotly():
     Checks if plotly is found and auto inits the offline notebook
     """
     if _plotly_found is False:
-        raise ModuleNotFoundError("Plotly is required for this function. Please ")
+        raise ModuleNotFoundError("Plotly is required for this function. Please 'conda install plotly' or 'pip isntall plotly'.")
 
     global _ipycheck
-    if _ipycheck is False:
+    if _ipycheck:
         import plotly
         plotly.offline.init_notebook_mode(connected=True)
         _ipycheck = True

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -45,7 +45,7 @@ def check_plotly():
         _ipycheck = True
 
 
-def bar_plot(traces: 'List[Series]', title=None, ylabel=None, dtype="bar", return_figure=True) -> 'plotly.Figure':
+def bar_plot(traces: 'List[Series]', title=None, ylabel=None, return_figure=True) -> 'plotly.Figure':
     """Renders a plotly bar plot
 
     Parameters
@@ -56,6 +56,10 @@ def bar_plot(traces: 'List[Series]', title=None, ylabel=None, dtype="bar", retur
         The title of the graph
     ylabel : None, optional
         The y axis label
+    dtype : str, optional
+        Description
+    return_figure : bool, optional
+        Returns the raw plotly figure or not
 
     Returns
     -------
@@ -77,14 +81,21 @@ def bar_plot(traces: 'List[Series]', title=None, ylabel=None, dtype="bar", retur
     layout = go.Layout(layout)
     figure = go.Figure(data=data, layout=layout)
 
+    if return_figure is None:
+        return_figure = not _ipycheck
+
     if return_figure:
         return figure
     else:
         return plotly.offline.iplot(figure, filename='qcportal-bar')
 
 
-def violin_plot(traces: 'DataFrame', negative: 'DataFrame'=None, title=None, points=False,
-                ylabel=None) -> 'plotly.Figure':
+def violin_plot(traces: 'DataFrame',
+                negative: 'DataFrame'=None,
+                title=None,
+                points=False,
+                ylabel=None,
+                return_figure=True) -> 'plotly.Figure':
     """Renders a plotly violin plot
 
     Parameters
@@ -99,6 +110,7 @@ def violin_plot(traces: 'DataFrame', negative: 'DataFrame'=None, title=None, poi
         Show points or not, this option is not available for comparison violin plots.
     ylabel : None, optional
         The y axis label
+        Returns the raw plotly figure or not
 
     Returns
     -------
@@ -107,6 +119,7 @@ def violin_plot(traces: 'DataFrame', negative: 'DataFrame'=None, title=None, poi
     """
     check_plotly()
     import plotly.graph_objs as go
+    import plotly
 
     data = []
     if negative is not None:
@@ -128,4 +141,10 @@ def violin_plot(traces: 'DataFrame', negative: 'DataFrame'=None, title=None, poi
     layout = go.Layout({"title": title, "yaxis": {"title": ylabel}})
     figure = go.Figure(data=data, layout=layout)
 
-    return figure
+    if return_figure is None:
+        return_figure = not _ipycheck
+
+    if return_figure:
+        return figure
+    else:
+        return plotly.offline.iplot(figure, filename='qcportal-violin')

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -45,7 +45,7 @@ def check_plotly():
         _ipycheck = True
 
 
-def bar_plot(traces: 'List[Series]', title=None, ylabel=None, dtype="bar") -> 'plotly.Figure':
+def bar_plot(traces: 'List[Series]', title=None, ylabel=None, dtype="bar", return_figure=True) -> 'plotly.Figure':
     """Renders a plotly bar plot
 
     Parameters
@@ -65,6 +65,7 @@ def bar_plot(traces: 'List[Series]', title=None, ylabel=None, dtype="bar") -> 'p
 
     check_plotly()
     import plotly.graph_objs as go
+    import plotly
 
     data = [go.Bar(x=trace.index, y=trace, name=trace.name) for trace in traces]
 
@@ -76,7 +77,10 @@ def bar_plot(traces: 'List[Series]', title=None, ylabel=None, dtype="bar") -> 'p
     layout = go.Layout(layout)
     figure = go.Figure(data=data, layout=layout)
 
-    return figure
+    if return_figure:
+        return figure
+    else:
+        return plotly.offline.iplot(figure, filename='qcportal-bar')
 
 
 def violin_plot(traces: 'DataFrame', negative: 'DataFrame'=None, title=None, points=False,

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -38,6 +38,7 @@ def check_plotly():
     if _plotly_found is False:
         raise ModuleNotFoundError("Plotly is required for this function. Please ")
 
+    global _ipycheck
     if _ipycheck is False:
         import plotly
         plotly.offline.init_notebook_mode(connected=True)

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -363,7 +363,7 @@ class FractalServer:
 
         # Shut down queue manager
         if "queue_manager" in self.objects:
-            fut = self._run_in_thread(self.objects["queue_manager"].stop)
+            self._run_in_thread(self.objects["queue_manager"].stop)
 
         # Close down periodics
         for cb in self.periodic.values():

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -10,19 +10,16 @@ import numpy as np
 
 from .service_util import BaseService, TaskManager
 from ..interface.models import TorsionDriveRecord, json_encoders
+from ..extras import find_module
 
-try:
-    import torsiondrive
-    from torsiondrive import td_api
-except ImportError:
-    td_api = None
 
 __all__ = ["TorsionDriveService"]
 
+__td_api = find_module("torsiondrive")
 
 def _check_td():
-    if td_api is None:
-        raise ImportError("Unable to find TorsionDriveRecord which must be installed to use the TorsionDriveService")
+    if __td_api is None:
+        raise ModuleNotFoundError("Unable to find TorsionDriveRecord which must be installed to use the TorsionDriveService")
 
 
 class TorsionDriveService(BaseService):
@@ -54,6 +51,8 @@ class TorsionDriveService(BaseService):
     @classmethod
     def initialize_from_api(cls, storage_socket, logger, service_input, tag=None, priority=None):
         _check_td()
+        import torsiondrive
+        from torsiondrive import td_api
 
         # Build the record
         output = TorsionDriveRecord(
@@ -112,6 +111,9 @@ class TorsionDriveService(BaseService):
         return cls(**meta, storage_socket=storage_socket, logger=logger)
 
     def iterate(self):
+        _check_td()
+        from torsiondrive import td_api
+
 
         self.status = "RUNNING"
 
@@ -157,6 +159,8 @@ class TorsionDriveService(BaseService):
         return False
 
     def submit_optimization_tasks(self, task_dict):
+        _check_td()
+        from torsiondrive import td_api
 
         new_tasks = {}
         task_map = {}
@@ -192,6 +196,8 @@ class TorsionDriveService(BaseService):
         """
         Finishes adding data to the TorsionDriveRecord object
         """
+        _check_td()
+        from torsiondrive import td_api
 
         # # Get lowest energies and positions
         min_positions = {}

--- a/qcfractal/snowflake.py
+++ b/qcfractal/snowflake.py
@@ -42,8 +42,7 @@ class FractalSnowflake(FractalServer):
                  max_active_services: int=20,
                  logging: Union[bool, str]=False,
                  start_server: bool=True):
-        """A temporary FractalServer that can be used to run complex workflows or try
-
+        """A temporary FractalServer that can be used to run complex workflows or try new computations.
 
         ! Warning ! All data is lost when the server is shutdown.
 

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -1487,7 +1487,8 @@ class MongoengineSocket:
 
         # Update results and procedures if reset_error
         if reset_error:
-            task_ids = TaskQueueORM.objects(manager=manager, status="ERROR").only('id')
+            task_objs = TaskQueueORM.objects(manager=manager, status="ERROR").only('id')
+            task_ids = [x.id for x in task_objs]
             ResultORM.objects(task_id__in=task_ids).update(status='INCOMPLETE', modified_on=dt.utcnow())
             ProcedureORM.objects(task_id__in=task_ids).update(status='INCOMPLETE', modified_on=dt.utcnow())
 

--- a/qcfractal/storage_sockets/mongoengine_socket.py
+++ b/qcfractal/storage_sockets/mongoengine_socket.py
@@ -54,7 +54,8 @@ def _str_to_indices_with_errors(ids: List[Union[str, ObjectId]]):
 _null_keys = {"basis", "keywords"}
 _id_keys = {"id", "molecule", "keywords", "procedure_id"}
 _lower_func = lambda x: x.lower()
-_prepare_keys = {"program": _lower_func, "basis": prepare_basis, "method": _lower_func, "procedure": _lower_func}
+_upper_func = lambda x: x.upper()
+_prepare_keys = {"program": _lower_func, "basis": prepare_basis, "method": _lower_func, "procedure": _lower_func, "status": _upper_func}
 
 
 def format_query(**query: Dict[str, Union[str, List[str]]]) -> Dict[str, Union[str, List[str]]]:

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -208,7 +208,7 @@ def test_compute_reactiondataset_keywords(fractal_compute_server):
 
     r = ds.compute("SCF", "sto-3g", keywords="df")
     fractal_compute_server.await_results()
-    assert ds.query("SCF", "sto-3g", keywords="df",)
+    assert ds.query("SCF", "sto-3g", keywords="df") == "SCF/sto-3g-df"
     assert pytest.approx(0.38748602675524185, 1.e-5) == ds.df.loc["He2", "SCF/sto-3g-df"]
 
     assert ds.list_history().shape[0] == 2

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -38,7 +38,7 @@ def test_dataset_compute_gradient(fractal_compute_server):
     ds.add_entry("He2", ptl.Molecule.from_data("He -1.1 0 0\n--\nHe 0 0 1.1"))
 
     contrib = {
-        "name": "gradient",
+        "name": "Gradient",
         "theory_level": "pseudo-random values",
         "values": {
             "He1": [0.03, 0, 0.02, -0.02, 0, -0.03],
@@ -57,10 +57,10 @@ def test_dataset_compute_gradient(fractal_compute_server):
     ds.query("gradient", None, contrib=True, as_array=True)
 
     # Test out some statistics
-    stats = ds.statistics("MUE", "HF/sto-3g", "gradient")
+    stats = ds.statistics("MUE", "HF/sto-3g", "Gradient")
     assert pytest.approx(stats.mean(), 1.e-5) == 0.00984176986312362
 
-    stats = ds.statistics("UE", "HF/sto-3g", "gradient")
+    stats = ds.statistics("UE", "HF/sto-3g", "Gradient")
     assert pytest.approx(stats.loc["He1"].mean(), 1.e-5) == 0.01635020639
     assert pytest.approx(stats.loc["He2"].mean(), 1.e-5) == 0.00333333333
 
@@ -163,22 +163,22 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
 
     # Query computed results
     assert ds.query("SCF", "STO-3G")
-    assert pytest.approx(0.6024530476, 1.e-5) == ds.df.loc["He1", "SCF/STO-3G"]
-    assert pytest.approx(-0.0068950359, 1.e-5) == ds.df.loc["He2", "SCF/STO-3G"]
+    assert pytest.approx(0.6024530476, 1.e-5) == ds.df.loc["He1", "SCF/sto-3g"]
+    assert pytest.approx(-0.0068950359, 1.e-5) == ds.df.loc["He2", "SCF/sto-3g"]
 
     # Check results
     assert ds.query("Benchmark", contrib=True)
-    assert pytest.approx(0.00024477933196125805, 1.e-5) == ds.statistics("MUE", "SCF/STO-3G")
+    assert pytest.approx(0.00024477933196125805, 1.e-5) == ds.statistics("MUE", "SCF/sto-3g")
 
-    assert pytest.approx([0.081193, 7.9533e-05], 1.e-4) == list(ds.statistics("URE", "SCF/STO-3G"))
-    assert pytest.approx(0.0406367, 1.e-5) == ds.statistics("MURE", "SCF/STO-3G")
-    assert pytest.approx(0.002447793, 1.e-5) == ds.statistics("MURE", "SCF/STO-3G", floor=10)
+    assert pytest.approx([0.081193, 7.9533e-05], 1.e-4) == list(ds.statistics("URE", "SCF/sto-3g"))
+    assert pytest.approx(0.0406367, 1.e-5) == ds.statistics("MURE", "SCF/sto-3g")
+    assert pytest.approx(0.002447793, 1.e-5) == ds.statistics("MURE", "SCF/sto-3g", floor=10)
 
     assert isinstance(ds.to_json(), dict)
     assert ds.list_history(keywords=None).shape[0] == 1
 
     ds.units = "eV"
-    assert pytest.approx(0.00010614635, 1.e-5) == ds.statistics("MURE", "SCF/STO-3G", floor=10)
+    assert pytest.approx(0.00010614635, 1.e-5) == ds.statistics("MURE", "SCF/sto-3g", floor=10)
 
 
 
@@ -204,12 +204,12 @@ def test_compute_reactiondataset_keywords(fractal_compute_server):
     r = ds.compute("SCF", "STO-3G")
     fractal_compute_server.await_results()
     assert ds.query("SCF", "STO-3G")
-    assert pytest.approx(0.39323818102293856, 1.e-5) == ds.df.loc["He2", "SCF/STO-3G"]
+    assert pytest.approx(0.39323818102293856, 1.e-5) == ds.df.loc["He2", "SCF/sto-3g"]
 
-    r = ds.compute("SCF", "STO-3G", keywords="df")
+    r = ds.compute("SCF", "sto-3g", keywords="df")
     fractal_compute_server.await_results()
-    assert ds.query("SCF", "STO-3G", keywords="df", prefix="df-")
-    assert pytest.approx(0.38748602675524185, 1.e-5) == ds.df.loc["He2", "df-SCF/STO-3G"]
+    assert ds.query("SCF", "sto-3g", keywords="df",)
+    assert pytest.approx(0.38748602675524185, 1.e-5) == ds.df.loc["He2", "SCF/sto-3g-df"]
 
     assert ds.list_history().shape[0] == 2
     assert ds.list_history(keywords="DF").shape[0] == 1

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -32,7 +32,7 @@ def test_dataset_compute_gradient(fractal_compute_server):
     client = ptl.FractalClient(fractal_compute_server)
 
     # Build a dataset
-    ds = ptl.collections.Dataset("ds_energy", client, default_program="psi4", default_driver="gradient")
+    ds = ptl.collections.Dataset("ds_energy", client, default_program="psi4", default_driver="gradient", default_units="hartree")
 
     ds.add_entry("He1", ptl.Molecule.from_data("He -1 0 0\n--\nHe 0 0 1"))
     ds.add_entry("He2", ptl.Molecule.from_data("He -1.1 0 0\n--\nHe 0 0 1.1"))
@@ -176,6 +176,10 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
 
     assert isinstance(ds.to_json(), dict)
     assert ds.list_history(keywords=None).shape[0] == 1
+
+    ds.units = "eV"
+    assert pytest.approx(0.00010614635, 1.e-5) == ds.statistics("MURE", "SCF/STO-3G", floor=10)
+
 
 
 @testing.using_psi4

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -404,7 +404,8 @@ def test_torsiondrive_dataset(fractal_compute_server):
 
     ds.add_specification("spec1", optimization_spec, qc_spec, description="This is a really cool spec")
 
-    ds.compute("spec1")
+    ncompute = ds.compute("spec1")
+    assert ncompute == 2
 
     ds.save()
 
@@ -415,7 +416,13 @@ def test_torsiondrive_dataset(fractal_compute_server):
 
     # Add another fake set, should instantly return
     ds.add_specification("spec2", optimization_spec, qc_spec, description="This is a really cool spec")
-    ds.compute("spec2")
+
+    # Test subsets
+    ncompute = ds.compute("spec2", subset=set())
+    assert ncompute == 0
+
+    ncompute = ds.compute("spec2")
+    assert ncompute == 2
     ds.query("spec2")
 
     # We effectively computed the same thing twice with two duplicate specs

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -56,8 +56,13 @@ def test_dataset_compute_gradient(fractal_compute_server):
     ds.query("HF", "sto-3g", as_array=True)
     ds.query("gradient", None, contrib=True, as_array=True)
 
+    # Test out some statistics
     stats = ds.statistics("MUE", "HF/sto-3g", "gradient")
-    assert pytest.approx(stats.mean()) == 0.00984176986312362
+    assert pytest.approx(stats.mean(), 1.e-5) == 0.00984176986312362
+
+    stats = ds.statistics("UE", "HF/sto-3g", "gradient")
+    assert pytest.approx(stats.loc["He1"].mean(), 1.e-5) == 0.01635020639
+    assert pytest.approx(stats.loc["He2"].mean(), 1.e-5) == 0.00333333333
 
     assert ds.list_history().shape[0] == 1
 
@@ -158,12 +163,16 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
 
     # Query computed results
     assert ds.query("SCF", "STO-3G")
-    assert pytest.approx(0.6024530476071095, 1.e-5) == ds.df.loc["He1", "SCF/STO-3G"]
-    assert pytest.approx(-0.006895035942673289, 1.e-5) == ds.df.loc["He2", "SCF/STO-3G"]
+    assert pytest.approx(0.6024530476, 1.e-5) == ds.df.loc["He1", "SCF/STO-3G"]
+    assert pytest.approx(-0.0068950359, 1.e-5) == ds.df.loc["He2", "SCF/STO-3G"]
 
     # Check results
     assert ds.query("Benchmark", contrib=True)
     assert pytest.approx(0.00024477933196125805, 1.e-5) == ds.statistics("MUE", "SCF/STO-3G")
+
+    assert pytest.approx([0.081193, 7.9533e-05], 1.e-4) == list(ds.statistics("URE", "SCF/STO-3G"))
+    assert pytest.approx(0.0406367, 1.e-5) == ds.statistics("MURE", "SCF/STO-3G")
+    assert pytest.approx(0.002447793, 1.e-5) == ds.statistics("MURE", "SCF/STO-3G", floor=10)
 
     assert isinstance(ds.to_json(), dict)
     assert ds.list_history(keywords=None).shape[0] == 1
@@ -409,4 +418,3 @@ def test_torsiondrive_service(fractal_compute_server):
     for row in ["hooh1", "hooh2"]:
         for spec in ["spec1", "spec2"]:
             assert pytest.approx(ds.df.loc["hooh1", "spec2"].final_energies(90), 1.e-5) == 0.00015655375994799847
-

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -376,7 +376,7 @@ def test_missing_collection(fractal_compute_server):
 @testing.using_torsiondrive
 @testing.using_geometric
 @testing.using_rdkit
-def test_torsiondrive_service(fractal_compute_server):
+def test_torsiondrive_dataset(fractal_compute_server):
 
     client = ptl.FractalClient(fractal_compute_server)
 


### PR DESCRIPTION
## Description
This is a first pass at Dataset visualization which to plot statistics in Juypter notebooks. We picked the Plotly graph library because it both produce nice interactive graphs and also has the Dash library built on top which will easily allow us to build exploration web apps with the same code.

Bar plot example:
![image](https://user-images.githubusercontent.com/1769841/54873362-0f1fcf00-4dab-11e9-9d52-fa6826cc438c.png)

Violin plot example:
![image (1)](https://user-images.githubusercontent.com/1769841/54873365-13e48300-4dab-11e9-8dd1-ec29d74cfbb7.png)

Other items:
 - [x] `Dataset.get_history()` will not automatically perform a variety of queries to pull down all matching data.
- [x] Canonicalizes Dataset internal data frames names with a canonical function.

Random bits:
 - [x] `qcfractal-manager` config top level now long accepts additional arguments.
 - [x] Minor fixes to the server and includes a `start-periodic` flag as an optional arg.
 - [x] Fixes a TorsionDriveDataset query index issues (@ChayaSt).
 - [x] Provides the ability to filter submission in TorsionDriveDataset.
 - [x] Datasets now have a canonical unit, can be show by `Dataset.units`. `Dataset.units="eV"` would change all internal units to electron volts for example, fixes #208.
 - [x] Removes OpenFF provenance information until we have a clear use case, will bring it back then. Fixes #126.

## Status
- [ ] Changelog updated
- [x] Ready to go