### PR TITLE
TorsionDrive Dataset Visualization

### DIFF
--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -716,7 +716,7 @@ class Dataset(Collection):
 
         Returns
         -------
-        success : bool
+        success : str
             The name of the queried column
 
         Examples

--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -199,14 +199,14 @@ class TorsionDriveDataset(Collection):
             The specification name to query
         """
         # Try to get the specification, will throw if not found.
-        self.get_specification(specification)
+        spec = self.get_specification(specification)
 
-        specification = specification.lower()
+        spec_name = specification.lower()
         query_ids = []
         mapper = {}
         for rec in self.data.records.values():
             try:
-                td_id = rec.torsiondrives[specification]
+                td_id = rec.torsiondrives[spec_name]
                 query_ids.append(td_id)
                 mapper[td_id] = rec.name
             except KeyError:
@@ -218,10 +218,32 @@ class TorsionDriveDataset(Collection):
         for td in torsiondrives:
             data.append([mapper[td.id], td])
 
-        df = pd.DataFrame(data, columns=["index", specification])
+        df = pd.DataFrame(data, columns=["index", spec.name])
         df.set_index("index", inplace=True)
 
-        self.df[specification] = df[specification]
+        self.df[spec.name] = df[spec.name]
+
+    def status(self, collapse: bool=True) -> 'DataFrame':
+        """Returns the current status of all current specifications.
+
+        Parameters
+        ----------
+        collapse : bool, optional
+            Collapse the status into summaries per specification or not.
+            Description
+
+        Returns
+        -------
+        DataFrame
+            A DataFrame of all known statuses
+        """
+
+        df = self.df.apply(lambda x: x.apply(lambda y: y.status.value))
+
+        if collapse:
+            return df.apply(lambda x: x.value_counts())
+        else:
+            return df
 
 
 register_collection(TorsionDriveDataset)

--- a/qcfractal/interface/tests/test_visualization.py
+++ b/qcfractal/interface/tests/test_visualization.py
@@ -29,7 +29,7 @@ def S22Fixture():
 
 @using_plotly
 @pytest.mark.parametrize("kind", ["violin", "bar"])
-def test_dataset_plot(S22Fixture, kind):
+def test_plot_dataset(S22Fixture, kind):
 
     client, S22 = S22Fixture
 
@@ -45,7 +45,7 @@ def test_dataset_plot(S22Fixture, kind):
 @using_plotly
 @pytest.mark.parametrize("kind", ["violin", "bar"])
 @pytest.mark.parametrize("groupby", ["method", "basis"])
-def test_dataset_groupby_plot(S22Fixture, kind, groupby):
+def test_plot_dataset_groupby(S22Fixture, kind, groupby):
 
     client, S22 = S22Fixture
 
@@ -73,22 +73,16 @@ def TDDSFixture():
 
 
 @using_plotly
-@pytest.mark.parametrize("measured", [True, False])
-def test_torsiondrive_dataset_visualize(TDDSFixture, measured):
-
+def test_plot_torsiondrive_dataset(TDDSFixture):
     client, ds = TDDSFixture
 
-    client = portal.FractalClient()
-    ds = client.get_collection("TorsionDriveDataset", "OpenFF Fragmenter Phenyl Benchmark")
+    ds.visualize("c1ccc(cc1)N-[3, 5, 6, 12]", ["b3lyp", "uff"], units="kJ / mol", return_figure=True)
+    ds.visualize(
+        ["c1ccc(cc1)N-[3, 5, 6, 12]", "CCCNc1ccc(cc1)Cl-[1, 4, 9, 8]"], "uff", relative=False, return_figure=True)
 
-    ds.visualize(
-        "c1ccc(cc1)N-[3, 5, 6, 12]", ["b3lyp", "uff"],
-        units="kJ / mol",
-        use_measured_angle=measured,
-        return_figure=True)
-    ds.visualize(
-        ["c1ccc(cc1)N-[3, 5, 6, 12]", "CCCNc1ccc(cc1)Cl-[1, 4, 9, 8]"],
-        "uff",
-        use_measured_angle=measured,
-        relative=False,
-        return_figure=True)
+
+@using_plotly
+def test_plot_torsiondrive_dataset_measured(TDDSFixture):
+    client, ds = TDDSFixture
+
+    ds.visualize("c1ccc(cc1)N-[3, 5, 6, 12]", "b3lyp", units="kJ / mol", use_measured_angle=True, return_figure=True)

--- a/qcfractal/interface/tests/test_visualization.py
+++ b/qcfractal/interface/tests/test_visualization.py
@@ -59,12 +59,36 @@ def test_dataset_groupby_plot(S22Fixture, kind, groupby):
     assert "S22" in fig["layout"]["title"]["text"]
 
 
+### Test TorsionDriveDataset scans
+
+
+@pytest.fixture
+def TDDSFixture():
+
+    # Connect to the primary database
+    client = portal.FractalClient()
+    TDDs = client.get_collection("TorsionDriveDataset", "OpenFF Fragmenter Phenyl Benchmark")
+
+    return (client, TDDs)
+
+
 @using_plotly
-def test_torsiondrive_dataset_visualize():
+@pytest.mark.parametrize("measured", [True, False])
+def test_torsiondrive_dataset_visualize(TDDSFixture, measured):
+
+    client, ds = TDDSFixture
 
     client = portal.FractalClient()
     ds = client.get_collection("TorsionDriveDataset", "OpenFF Fragmenter Phenyl Benchmark")
 
-    ds.visualize("c1ccc(cc1)N-[3, 5, 6, 12]", ["b3lyp", "uff"], units="kJ / mol", return_figure=True)
     ds.visualize(
-        ["c1ccc(cc1)N-[3, 5, 6, 12]", "CCCNc1ccc(cc1)Cl-[1, 4, 9, 8]"], "uff", relative=False, return_figure=True)
+        "c1ccc(cc1)N-[3, 5, 6, 12]", ["b3lyp", "uff"],
+        units="kJ / mol",
+        use_measured_angle=measured,
+        return_figure=True)
+    ds.visualize(
+        ["c1ccc(cc1)N-[3, 5, 6, 12]", "CCCNc1ccc(cc1)Cl-[1, 4, 9, 8]"],
+        "uff",
+        use_measured_angle=measured,
+        relative=False,
+        return_figure=True)

--- a/qcfractal/interface/tests/test_visualization.py
+++ b/qcfractal/interface/tests/test_visualization.py
@@ -57,3 +57,14 @@ def test_dataset_groupby_plot(S22Fixture, kind, groupby):
         kind=kind,
         groupby=groupby).to_dict()
     assert "S22" in fig["layout"]["title"]["text"]
+
+
+@using_plotly
+def test_torsiondrive_dataset_visualize():
+
+    client = portal.FractalClient()
+    ds = client.get_collection("TorsionDriveDataset", "OpenFF Fragmenter Phenyl Benchmark")
+
+    ds.visualize("c1ccc(cc1)N-[3, 5, 6, 12]", ["b3lyp", "uff"], units="kJ / mol", return_figure=True)
+    ds.visualize(
+        ["c1ccc(cc1)N-[3, 5, 6, 12]", "CCCNc1ccc(cc1)Cl-[1, 4, 9, 8]"], "uff", relative=False, return_figure=True)

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -2,6 +2,8 @@
 Visualization using the plotly library.
 """
 
+from typing import Any, Dict, List
+
 
 def _isnotebook():
     """
@@ -36,13 +38,26 @@ def check_plotly():
     Checks if plotly is found and auto inits the offline notebook
     """
     if _plotly_found is False:
-        raise ModuleNotFoundError("Plotly is required for this function. Please 'conda install plotly' or 'pip isntall plotly'.")
+        raise ModuleNotFoundError(
+            "Plotly is required for this function. Please 'conda install plotly' or 'pip isntall plotly'.")
 
     global _ipycheck
     if _ipycheck:
         import plotly
         plotly.offline.init_notebook_mode(connected=True)
         _ipycheck = True
+
+
+def _configure_return(figure, filename, return_figure):
+    import plotly
+
+    if return_figure is None:
+        return_figure = not _ipycheck
+
+    if return_figure:
+        return figure
+    else:
+        return plotly.offline.iplot(figure, filename=filename)
 
 
 def bar_plot(traces: 'List[Series]', title=None, ylabel=None, return_figure=True) -> 'plotly.Figure':
@@ -69,7 +84,6 @@ def bar_plot(traces: 'List[Series]', title=None, ylabel=None, return_figure=True
 
     check_plotly()
     import plotly.graph_objs as go
-    import plotly
 
     data = [go.Bar(x=trace.index, y=trace, name=trace.name) for trace in traces]
 
@@ -81,13 +95,7 @@ def bar_plot(traces: 'List[Series]', title=None, ylabel=None, return_figure=True
     layout = go.Layout(layout)
     figure = go.Figure(data=data, layout=layout)
 
-    if return_figure is None:
-        return_figure = not _ipycheck
-
-    if return_figure:
-        return figure
-    else:
-        return plotly.offline.iplot(figure, filename='qcportal-bar')
+    return _configure_return(figure, "qcportal-bar", return_figure)
 
 
 def violin_plot(traces: 'DataFrame',
@@ -110,6 +118,7 @@ def violin_plot(traces: 'DataFrame',
         Show points or not, this option is not available for comparison violin plots.
     ylabel : None, optional
         The y axis label
+    return_figure : bool, optional
         Returns the raw plotly figure or not
 
     Returns
@@ -119,7 +128,6 @@ def violin_plot(traces: 'DataFrame',
     """
     check_plotly()
     import plotly.graph_objs as go
-    import plotly
 
     data = []
     if negative is not None:
@@ -141,10 +149,58 @@ def violin_plot(traces: 'DataFrame',
     layout = go.Layout({"title": title, "yaxis": {"title": ylabel}})
     figure = go.Figure(data=data, layout=layout)
 
-    if return_figure is None:
-        return_figure = not _ipycheck
+    return _configure_return(figure, "qcportal-violin", return_figure)
 
-    if return_figure:
-        return figure
+
+def scatter_plot(traces: List[Dict[str, Any]],
+                 mode='lines+markers',
+                 title=None,
+                 ylabel=None,
+                 xlabel=None,
+                 xline=True,
+                 yline=True,
+                 custom_layout=None,
+                 return_figure=True) -> 'plotly.Figure':
+    """Renders a plotly violin plot
+
+    Parameters
+    ----------
+    traces : List[Dict[str, Any]]
+        A List of traces to plot, require x and y values
+    mode : str, optional
+        The mode of lines, will not override mode in the traces dictionary
+    title : None, optional
+        The title of the graph
+    ylabel : None, optional
+        The y axis label
+    xlabel : None, optional
+        The x axis label
+    xline : bool, optional
+        Show the x-zeroline
+    yline : bool, optional
+        Show the y-zeroline
+    custom_layout : None, optional
+        Overrides all other layout options
+    return_figure : bool, optional
+        Returns the raw plotly figure or not
+
+    Returns
+    -------
+    plotly.Figure
+        The requested scatter plot.
+
+    """
+    check_plotly()
+    import plotly.graph_objs as go
+
+    data = []
+    for trace in traces:
+        data.append(go.Scatter(**trace))
+
+    if custom_layout is None:
+        layout = go.Layout({"title": title, "yaxis": {"title": ylabel, "zeroline": yline}, "xaxis": {"title": xlabel, "zeroline": xline}})
     else:
-        return plotly.offline.iplot(figure, filename='qcportal-violin')
+        layout = go.Layout(**custom_layout)
+    figure = go.Figure(data=data, layout=layout)
+
+    return _configure_return(figure, "qcportal-violin", return_figure)

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -45,7 +45,6 @@ def check_plotly():
     if _ipycheck:
         import plotly
         plotly.offline.init_notebook_mode(connected=True)
-        _ipycheck = True
 
 
 def _configure_return(figure, filename, return_figure):

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -32,7 +32,8 @@ def test_dataset_compute_gradient(fractal_compute_server):
     client = ptl.FractalClient(fractal_compute_server)
 
     # Build a dataset
-    ds = ptl.collections.Dataset("ds_gradient", client, default_program="psi4", default_driver="gradient", default_units="hartree")
+    ds = ptl.collections.Dataset(
+        "ds_gradient", client, default_program="psi4", default_driver="gradient", default_units="hartree")
 
     ds.add_entry("He1", ptl.Molecule.from_data("He -1 0 0\n--\nHe 0 0 1"))
     ds.add_entry("He2", ptl.Molecule.from_data("He -1.1 0 0\n--\nHe 0 0 1.1"))
@@ -179,7 +180,6 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
 
     ds.units = "eV"
     assert pytest.approx(0.00010614635, 1.e-5) == ds.statistics("MURE", "SCF/sto-3g", floor=10)
-
 
 
 @testing.using_psi4
@@ -429,3 +429,6 @@ def test_torsiondrive_dataset(fractal_compute_server):
     for row in ["hooh1", "hooh2"]:
         for spec in ["spec1", "spec2"]:
             assert pytest.approx(ds.df.loc["hooh1", "spec2"].final_energies(90), 1.e-5) == 0.00015655375994799847
+
+    assert ds.status().loc["COMPLETE", "spec1"] == 2
+    assert ds.status(collapse=False).loc["hooh1", "spec1"] == "COMPLETE"

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -432,3 +432,6 @@ def test_torsiondrive_dataset(fractal_compute_server):
 
     assert ds.status().loc["COMPLETE", "spec1"] == 2
     assert ds.status(collapse=False).loc["hooh1", "spec1"] == "COMPLETE"
+
+    assert ds.counts("hooh1").loc["hooh1", "spec1"] > 5
+    assert ds.counts("hooh1", specs="spec1", count_gradients=True).loc["hooh1", "spec1"] > 30

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -11,6 +11,7 @@ from qcfractal.testing import fractal_compute_server, reset_server_database, usi
 bad_id1 = "000000000000000000000000"
 bad_id2 = "000000000000000000000001"
 
+
 @pytest.mark.parametrize("data", [
     pytest.param(("psi4", "HF", "sto-3g"), id="psi4", marks=using_psi4),
     pytest.param(("rdkit", "UFF", None), id="rdkit", marks=using_rdkit)
@@ -64,6 +65,12 @@ def test_task_error(fractal_compute_server):
     assert results[0].status == "ERROR"
 
     assert "connectivity" in results[0].get_error().error_message
+
+    # Check manager
+    m = fractal_compute_server.storage.get_managers(status="ACTIVE")["data"]
+    assert len(m) == 1
+    assert m[0]["failures"] > 0
+    assert m[0]["completed"] > 0
 
 
 @testing.using_rdkit
@@ -255,6 +262,7 @@ def test_queue_bad_procedure_method(fractal_compute_server):
     assert 'not avail' in str(exc.value)
     assert 'badqc' in str(exc.value)
 
+
 def test_queue_ordering_time(fractal_compute_server):
     reset_server_database(fractal_compute_server)
 
@@ -273,6 +281,7 @@ def test_queue_ordering_time(fractal_compute_server):
 
     assert queue_id1 == ret1
     assert queue_id2 == ret2
+
 
 def test_queue_ordering_priority(fractal_compute_server):
     reset_server_database(fractal_compute_server)
@@ -294,6 +303,7 @@ def test_queue_ordering_priority(fractal_compute_server):
     assert queue_id1 == ret2
     assert queue_id2 == ret3
     assert queue_id3 == ret1
+
 
 def test_queue_order_procedure_priority(fractal_compute_server):
     reset_server_database(fractal_compute_server)
@@ -323,9 +333,12 @@ def test_queue_order_procedure_priority(fractal_compute_server):
     assert len(fractal_compute_server.storage.queue_get_next("manager", ["rdkit"], ["geom"], limit=1)) == 0
     assert len(fractal_compute_server.storage.queue_get_next("manager", ["prog1"], ["geometric"], limit=1)) == 0
 
-    queue_id1 = fractal_compute_server.storage.queue_get_next("manager", ["rdkit"], ["geometric"], limit=1)[0].base_result.id
-    queue_id2 = fractal_compute_server.storage.queue_get_next("manager", ["RDKIT"], ["geometric"], limit=1)[0].base_result.id
-    queue_id3 = fractal_compute_server.storage.queue_get_next("manager", ["rdkit"], ["GEOMETRIC"], limit=1)[0].base_result.id
+    queue_id1 = fractal_compute_server.storage.queue_get_next(
+        "manager", ["rdkit"], ["geometric"], limit=1)[0].base_result.id
+    queue_id2 = fractal_compute_server.storage.queue_get_next(
+        "manager", ["RDKIT"], ["geometric"], limit=1)[0].base_result.id
+    queue_id3 = fractal_compute_server.storage.queue_get_next(
+        "manager", ["rdkit"], ["GEOMETRIC"], limit=1)[0].base_result.id
 
     assert queue_id1 == ret2
     assert queue_id2 == ret3

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -67,7 +67,7 @@ def test_task_error(fractal_compute_server):
     assert "connectivity" in results[0].get_error().error_message
 
     # Check manager
-    m = fractal_compute_server.storage.get_managers(status="ACTIVE")["data"]
+    m = fractal_compute_server.storage.get_managers()["data"]
     assert len(m) == 1
     assert m[0]["failures"] > 0
     assert m[0]["completed"] > 0


### PR DESCRIPTION
## Description
Add visualization to the torsion drive dataset for 1D scans. In addition:
 - [x] Adds a count function to find the number of total optimization/gradient evaluations.
 - [x] Adds a status function to provide details on completed torsion scans.
 - [x] Allows the visualization to measure the actual angle of the final molecule rather than trusting the constraint.

@ChayaSt

<img width="1038" alt="Screen Shot 2019-03-24 at 5 52 59 PM" src="https://user-images.githubusercontent.com/1769841/54886370-c1b06a00-4e5d-11e9-8997-3705f06d5eae.png">

## Status
- [ ] Changelog updated
- [x] Ready to go