### PR TITLE
TD Visualization Refactor

### DIFF
--- a/docs/qcportal/source/client-api.rst
+++ b/docs/qcportal/source/client-api.rst
@@ -37,9 +37,8 @@ New Compute Tasks
     add_compute
     add_procedure
     add_service
-    check_tasks
-    check_results
-    check_services
+    query_tasks
+    query_services
 
 Function Definitions
 --------------------
@@ -68,16 +67,14 @@ Function Definitions
 
 .. autofunction:: query_results
 
-.. autofunction:: check_results
-
 .. autofunction:: query_procedures
 
 .. autofunction:: add_compute
 
 .. autofunction:: add_procedure
 
-.. autofunction:: check_tasks
+.. autofunction:: query_tasks
 
 .. autofunction:: add_service
 
-.. autofunction:: check_services
+.. autofunction:: query_services

--- a/docs/qcportal/source/collection-torsiondrive.rst
+++ b/docs/qcportal/source/collection-torsiondrive.rst
@@ -1,0 +1,34 @@
+TorsionDrive Dataset
+====================
+
+TorsionDriveDatasets are sets of TorsionDrive computations where the primary
+index a set of starting molecules and each column is represented by a new
+TorsionDrive specification. This Dataset is a procedure-style dataset where a
+record of the :term:`ObjectId` of each TorsionDrive computation are recorded
+in the metadata.
+
+Querying
+--------
+
+Visualizing
+-----------
+
+Creating
+--------
+
+A empty TorsionDriveDataset can be constructed by choosing a dataset name.
+
+.. code-block:: python
+
+    client = ptl.FractalClient("localhost:7777")
+    ds = ptl.collections.TorsionDriveDataset("My Torsions")
+
+
+Computing
+---------
+
+API
+---
+
+.. autoclass:: qcfractal.interface.collections.TorsionDriveDataset
+    :members:

--- a/docs/qcportal/source/collections.rst
+++ b/docs/qcportal/source/collections.rst
@@ -22,7 +22,7 @@ A collection can then be pulled from the server as follows:
 .. code-block:: python
 
     >>> client.get_collection("dataset", "S22")
-    Dataset(id=`5b7f1fd57b87872d2c5d0a6d`, name=`S22`, client="localhost:8888")
+    Dataset(id=`5b7f1fd57b87872d2c5d0a6d`, name=`S22`, client="localhost:7777")
 
 Available Collections
 ---------------------
@@ -30,4 +30,5 @@ Available Collections
 Below is a complete list of collections available from QCPortal:
 
 * :doc:`collection-dataset` - A collection for running a single set of reactions under many methods.
+* :doc:`collection-torsiondrive` - A collection for running a single set of TorsionDrives under different methods.
 

--- a/docs/qcportal/source/index.rst
+++ b/docs/qcportal/source/index.rst
@@ -52,6 +52,7 @@ Collections are the primary way of viewing and generating new data.
 
    collections.rst
    collection-dataset
+   collection-torsiondrive
 
 **Model Documentation**
 

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -549,7 +549,7 @@ class FractalClient(object):
                          projection: 'QueryProjection'=None,
                          full_return: bool=False) -> Union[List['RecordBase'], Dict[str, Any]]:
         """Queries Procedures from the server.
-		
+
         Parameters
         ----------
         id : QueryObjectId, optional
@@ -677,6 +677,7 @@ class FractalClient(object):
                       tag: str=None,
                       full_return: bool=False) -> ComputeResponse:
         """Adds a "single" Procedure to the server.
+
         Parameters
         ----------
         procedure : str
@@ -729,7 +730,7 @@ class FractalClient(object):
                     program: 'QueryStr'=None,
                     status: 'QueryStr'=None,
                     projection: 'QueryProjection'=None,
-                    full_return: bool=False):
+                    full_return: bool=False) -> List[Dict[str, Any]]:
         """Checks the status of tasks in the Fractal queue.
 
         Parameters
@@ -749,14 +750,16 @@ class FractalClient(object):
 
         Returns
         -------
-        list of dict
+        List[Dict[str, Any]]
             A dictionary of each match that contains the current status
             and, if an error has occured, the error message.
 
-		Examples
-		--------
-        >>> client.check_tasks(id="5bd35af47b878715165f8225", projection={"status": True})
+        Examples
+        --------
+
+        >>> client.query_tasks(id="5bd35af47b878715165f8225", projection={"status": True})
         [{"status": "WAITING"}]
+
 
         """
 
@@ -816,7 +819,7 @@ class FractalClient(object):
                        hash_index: 'QueryStr'=None,
                        status: 'QueryStr'=None,
                        projection: 'QueryProjection'=None,
-                       full_return: bool=False):
+                       full_return: bool=False) -> List[Dict[str, Any]]:
         """Checks the status of services in the Fractal queue.
 
         Parameters
@@ -836,13 +839,13 @@ class FractalClient(object):
 
         Returns
         -------
-        list of dict
+        List[Dict[str, Any]]
             A dictionary of each match that contains the current status
             and, if an error has occurred, the error message.
 
         Examples
         --------
-        >>> client.check_services(id="5bd35af47b878715165f8225", projection={"status": True})
+        >>> client.query_services(id="5bd35af47b878715165f8225", projection={"status": True})
         [{"status": "RUNNING"}]
 
         """

--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -432,7 +432,7 @@ class TorsionDriveDataset(Collection):
                 y = []
                 for k, v in td.get_final_energies().items():
                     if len(k) >= 2:
-                        raise TypeError("Dataset.visualize is currently only available for 1-D scans.")
+                        raise TypeError("TorsionDriveDataset.visualize is currently only available for 1-D scans.")
 
                     if use_measured_angle:
                         # Recalculate the dihedral angle

--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -4,16 +4,14 @@ QCPortal Database ODM
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import pandas as pd
-import numpy as np
 
 from pydantic import BaseModel
-from qcelemental import constants
 
 from .collection_utils import register_collection
 from .collection import Collection
 from ..models import ObjectId, Molecule, OptimizationSpecification, QCSpecification, TorsionDriveInput
 from ..models.torsiondrive import TDKeywords
-from ..visualization import scatter_plot
+from ..visualization import custom_plot
 
 
 class TDRecord(BaseModel):
@@ -258,7 +256,8 @@ class TorsionDriveDataset(Collection):
 
         return spec.name
 
-    def status(self, specs: Union[str, List[str]]=None, collapse: bool=True, status: Optional[str]=None) -> 'DataFrame':
+    def status(self, specs: Union[str, List[str]]=None, collapse: bool=True,
+               status: Optional[str]=None) -> 'DataFrame':
         """Returns the status of all current specifications.
 
         Parameters
@@ -414,66 +413,27 @@ class TorsionDriveDataset(Collection):
             self.query(spec)
 
         traces = []
-
-        xmin = 1e12
-        xmax = -1e12
+        ranges = []
         # Loop over specifications
         for spec in specs:
             # Loop over indices (groups colors by entry)
             for index in entries:
 
-                record = self.get_entry(index)
+                # Plot the figure using the torsiondrives plotting function
+                fig = self.df.loc[index, spec].visualize(
+                    relative=relative,
+                    units=units,
+                    digits=digits,
+                    use_measured_angle=use_measured_angle,
+                    return_figure=True)
 
-                td = self.df.loc[index, spec]
-                min_energy = 1e12
+                ranges.append(fig.layout.xaxis.range)
+                trace = fig.data[0] # Pull out the underlying scatterplot
 
-                # Pull the dict apart
-                x = []
-                y = []
-                for k, v in td.get_final_energies().items():
-                    if len(k) >= 2:
-                        raise TypeError("TorsionDriveDataset.visualize is currently only available for 1-D scans.")
-
-                    if use_measured_angle:
-                        # Recalculate the dihedral angle
-                        dihedral_indices = record.td_keywords.dihedrals[0]
-                        mol = td.get_final_molecules(k)
-                        x.append(mol.measure(dihedral_indices))
-
-                    else:
-                        x.append(k[0])
-
-                    y.append(v)
-
-                    # Update minmum energy
-                    if v < min_energy:
-                        min_energy = v
-
-                trace = {"mode": "lines+markers"}
                 if show_spec:
-                    trace["name"] = f"{index}-{spec}"
+                    trace.name = f"{index}-{spec}"
                 else:
-                    trace["name"] = f"{index}"
-
-                x = np.array(x)
-                y = np.array(y)
-
-                # Sort by angle
-                sorter = np.argsort(x)
-                x = x[sorter]
-                y = y[sorter]
-                if relative:
-                    y -= min_energy
-
-                # Find the x dimension
-                if x.max() > xmax:
-                    xmax = x.max()
-                if x.min() < xmin:
-                    xmin = x.min()
-
-                cf = constants.conversion_factor("hartree", units)
-                trace["x"] = x
-                trace["y"] = np.around(y * cf, digits)
+                    trace.name = f"{index}"
 
                 traces.append(trace)
 
@@ -495,11 +455,11 @@ class TorsionDriveDataset(Collection):
             "xaxis": {
                 "title": "Dihedral Angle [degrees]",
                 "zeroline": False,
-                "range": [xmin - 10, xmax + 10]
+                "range": [min(x[0] for x in ranges), max(x[1] for x in ranges)]
             }
         }
 
-        return scatter_plot(traces, custom_layout=custom_layout, return_figure=return_figure)
+        return custom_plot(traces, custom_layout, return_figure=return_figure)
 
 
 register_collection(TorsionDriveDataset)

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -258,8 +258,8 @@ class TorsionDriveRecord(RecordBase):
 
             if use_measured_angle:
                 # Recalculate the dihedral angle
-                dihedral_indices = record.td_keywords.dihedrals[0]
-                mol = td.get_final_molecules(k)
+                dihedral_indices = self.keywords.dihedrals[0]
+                mol = self.get_final_molecules(k)
                 x.append(mol.measure(dihedral_indices))
 
             else:

--- a/qcfractal/interface/visualization.py
+++ b/qcfractal/interface/visualization.py
@@ -56,6 +56,27 @@ def _configure_return(figure, filename, return_figure):
         return plotly.offline.iplot(figure, filename=filename)
 
 
+def custom_plot(data: Any, layout: Any, return_figure=True) -> 'plotly.Figure':
+    """A custom plotly plot where the data and layout are pre-specified
+
+    Parameters
+    ----------
+    data : Any
+        Plotly data block
+    layout : Any
+        Plotly layout block
+    return_figure : bool, optional
+        Returns the raw plotly figure or not
+    """
+
+    check_plotly()
+    import plotly.graph_objs as go
+
+    figure = go.Figure(data=data, layout=layout)
+
+    return _configure_return(figure, "qcportal-bar", return_figure)
+
+
 def bar_plot(traces: 'List[Series]', title=None, ylabel=None, return_figure=True) -> 'plotly.Figure':
     """Renders a plotly bar plot
 

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -65,7 +65,6 @@ def torsiondrive_fixture(fractal_compute_server):
         assert len(fractal_compute_server.list_current_tasks()) == 0
         return ret.data
 
-
     yield spin_up_test, client
 
 
@@ -138,7 +137,7 @@ def test_service_iterate_error(torsiondrive_fixture):
 
 
 def test_service_torsiondrive_compute_error(torsiondrive_fixture):
-    """Ensure errors are caught and logged when iterating serivces"""
+    """Ensure errors are caught and logged when computing serivces"""
 
     spin_up_test, client = torsiondrive_fixture
 
@@ -150,6 +149,19 @@ def test_service_torsiondrive_compute_error(torsiondrive_fixture):
 
     assert status[0]["status"] == "ERROR"
     assert "All tasks" in status[0]["error"]["error_message"]
+
+
+def test_service_torsiondrive_visualization(torsiondrive_fixture):
+    """Test the visualization function for the 1-D case"""
+
+    spin_up_test, client = torsiondrive_fixture
+    ret = spin_up_test()
+
+    # Get a TorsionDriveORM result and check data
+    result = client.query_procedures(id=ret.ids)[0]
+    assert result.status == "COMPLETE"
+
+    result.visualize()
 
 
 @using_geometric
@@ -215,7 +227,6 @@ def test_service_gridoptimization_single_opt(fractal_compute_server):
     assert pytest.approx(starting_mol.measure([1, 2])) != initial_distance
     assert pytest.approx(starting_mol.measure([1, 2])) == 2.488686479260597
 
-
     # Check tags on individual procedures
     proc_id = list(result.grid_optimizations.values())[0]
     opt = client.query_procedures(id=proc_id)[0]
@@ -223,7 +234,6 @@ def test_service_gridoptimization_single_opt(fractal_compute_server):
     task = client.query_tasks(id=opt.task_id)[0]
     assert task.priority == 0
     assert task.tag == "gridopt"
-
 
 
 @using_geometric


### PR DESCRIPTION
## Description
Refactors TorsionDrive visualization to the individual objects. This moves begins a `visualization` pass for all record objects.

Small docs stub for TD Datasets. Still trying to figure out how to document these.

Starting up again after our hiatus!

## Status
- [ ] Changelog updated
- [x] Ready to go