### PR TITLE
Add parsl compute manager to CLI

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -99,7 +99,8 @@ class ClusterSettings(BaseSettings):
 
 class DaskQueueSettings(BaseSettings):
     """Pass through options beyond interface are permitted"""
-    address: str = None
+    interface: str = None
+    extra: List[str] = None
 
     def __init__(self, **kwargs):
         """Enforce that the keys we are going to set remain untouched"""


### PR DESCRIPTION
After a bunch of double checking all the variables and init calls, I think this should be the first passable implementation of the Parsl queue manager to the CLI command. I think its just the SLURM 

No testing done yet, but at least I think I got it down to minimal amounts of if/elif in the main block.

## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Test on our cluster
  - [ ] Handle non-standard ethernet port communication between worker and executor, see if this is even an issue

## Questions
- [x] HighThroughputExecutor or ExtremeScalingExecutor?
- [x] How to handle memory assignment, as I don't think there is a way to do so, leave it to QCEngine?
- [x] What to do about missing LSF and MOAB managers as Parsl does not have them right now.

## Status
- [ ] Changelog updated
- [x] Ready to go