### PR TITLE
Make task errors more verbose in the logs

### DIFF
--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -15,6 +15,16 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+0.6.1 / 2019-??-??
+------------------
+
+Enhancements
+++++++++++++
+
+- (:pr:`??`) Tasks which fail are now more verbose in the log as to why they failed. This is additional information
+  on top of the number of pass/fail.
+
+
 0.6.0 / 2019-03-30
 ------------------
 

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -253,6 +253,14 @@ class QueueManagerHandler(APIHandler):
         name = self._get_name_from_metadata(body.meta)
         self.storage.manager_update(name, completed=completed, failures=error)
 
+        # Report failures after updating database for speed and data stability
+        if error:
+            self.logger.info("The following received tasks failed with the errors:")
+            for key, result in body.data.items():
+                if not result['success']:
+                    self.logger.info(f"Job {key} failed: {result['error']['error_type']} - "
+                                     f"Msg: {result['error']['error_message']}")
+
     def put(self):
         """
         Various manager manipulation operations

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -253,14 +253,6 @@ class QueueManagerHandler(APIHandler):
         name = self._get_name_from_metadata(body.meta)
         self.storage.manager_update(name, completed=completed, failures=error)
 
-        # Report failures after updating database for speed and data stability
-        if error:
-            self.logger.info("The following received tasks failed with the errors:")
-            for key, result in body.data.items():
-                if not result['success']:
-                    self.logger.info(f"Job {key} failed: {result['error']['error_type']} - "
-                                     f"Msg: {result['error']['error_message']}")
-
     def put(self):
         """
         Various manager manipulation operations

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -347,9 +347,9 @@ class QueueManager:
         self.logger.info("Pushed {} complete tasks to the server "
                          "({} success / {} fail).".format(n_result, n_success, n_fail))
         if n_fail:
-            self.logger.info("The following tasks failed with the errors:")
+            self.logger.warning("The following tasks failed with the errors:")
             for error in error_payload:
-                self.logger.info(error)
+                self.logger.warning(error)
 
         open_slots = max(0, self.max_tasks - self.active)
 


### PR DESCRIPTION
## Description

This PR has the loggers report more details about tasks which fail,
both on the manager and the server side.

## Status
- [x] Changelog updated
- [x] Ready to go