### PR TITLE
Stale Job Tracking

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -277,7 +277,7 @@ def main(args=None):
             "processes": settings.common.ntasks, # Number of workers to generate == tasks
             "walltime": settings.cluster.walltime,
             "job_extra": scheduler_opts,
-            "env_exta": settings.cluster.task_startup_commands,
+            "env_extra": settings.cluster.task_startup_commands,
             **dask_settings}
 
         # Import the dask things we need

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -63,6 +63,8 @@ class FractalClient(object):
         self.username = username
         self._verify = verify
         self._headers = {}
+        # Mode toggle for network error testing
+        self._mock_network_error = False
 
         # If no 3rd party verification, quiet urllib
         if self._verify is False:
@@ -108,6 +110,10 @@ class FractalClient(object):
             "headers": self._headers,
             "verify": self._verify,
         }
+
+        if self.mock_network_error:
+            raise requests.exceptions.RequestException("mock_network_error is on, failing by design!")
+
         try:
             if method == "get":
                 r = requests.get(addr, **kwargs)
@@ -131,6 +137,18 @@ class FractalClient(object):
             raise IOError("Server communication failure. Reason: {}".format(r.reason))
 
         return r
+
+    @property
+    def mock_network_error(self):
+        """
+        Boolean for debugging purposes. When set to True, requests to the server always raise a network error without
+        actually making an attempt to connect
+        """
+        return self._mock_network_error
+
+    @mock_network_error.setter
+    def mock_network_error(self, value):
+        self._mock_network_error = bool(value)
 
     def _automodel_request(self,
                            name: str,

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -63,7 +63,8 @@ class FractalClient(object):
         self.username = username
         self._verify = verify
         self._headers = {}
-        # Mode toggle for network error testing
+
+        # Mode toggle for network error testing, not public facing
         self._mock_network_error = False
 
         # If no 3rd party verification, quiet urllib
@@ -111,7 +112,7 @@ class FractalClient(object):
             "verify": self._verify,
         }
 
-        if self.mock_network_error:
+        if self._mock_network_error:
             raise requests.exceptions.RequestException("mock_network_error is on, failing by design!")
 
         try:
@@ -137,18 +138,6 @@ class FractalClient(object):
             raise IOError("Server communication failure. Reason: {}".format(r.reason))
 
         return r
-
-    @property
-    def mock_network_error(self):
-        """
-        Boolean for debugging purposes. When set to True, requests to the server always raise a network error without
-        actually making an attempt to connect
-        """
-        return self._mock_network_error
-
-    @mock_network_error.setter
-    def mock_network_error(self, value):
-        self._mock_network_error = bool(value)
 
     def _automodel_request(self,
                            name: str,

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -45,6 +45,8 @@ class QueueManager:
                  manager_name: str="unlabled",
                  update_frequency: Union[int, float]=2,
                  verbose: bool=True,
+                 server_error_retries: Optional[int]=1,
+                 stale_update_limit: Optional[int]=10,
                  cores_per_task: Optional[int]=None,
                  memory_per_task: Optional[Union[int, float]]=None,
                  scratch_directory: Optional[str]=None):
@@ -65,6 +67,18 @@ class QueueManager:
             The cluster the manager belongs to
         update_frequency : int
             The frequency to check for new tasks in seconds
+        verbose: bool, optional, Default: True
+            Whether or not to have the manager be verbose (logger level debug and up)
+        server_error_retries: int, optional, Default: 1
+            How many times finished jobs are attempted to be pushed to the server in
+            in the event of a server communication error.
+            After number of attempts, the failed jobs are dropped from this manager and considered "stale"
+            Set to `None` to keep retrying
+        stale_update_limit: int, optional, Default: 10
+            Number of stale update attempts to keep around
+            If this limit is ever hit, the server initiates as shutdown as best it can
+            since communication with the server has gone wrong too many times.
+            Set to `None` for unlimited
         cores_per_task : int, optional, Default: None
             How many CPU cores per computation task to allocate for QCEngine
             None indicates "use however many you can detect"
@@ -73,7 +87,7 @@ class QueueManager:
             None indicates "use however much you can consume"
         scratch_directory: str, optional, Default: None
             Scratch directory location to do QCEngine compute
-            None indicates "wherever the system default is"
+            None indicates "wherever the system default is"'
         """
 
         # Setup logging
@@ -102,6 +116,13 @@ class QueueManager:
         self.periodic = {}
         self.active = 0
         self.exit_callbacks = []
+
+        # Server response/stale job handling
+        self.server_error_retries = server_error_retries
+        self.stale_update_limit = stale_update_limit
+        self._stale_updates_tracked = 0
+        self._stale_payload_tracking = []
+        self.n_stale_jobs = 0
 
         # QCEngine data
         self.available_programs = qcng.list_available_programs()
@@ -230,7 +251,7 @@ class QueueManager:
         """
         Shuts down all IOLoops and periodic updates.
         """
-        self.logger.info("QueueManager recieved shutdown signal: {}.\n".format(signame))
+        self.logger.info("QueueManager received shutdown signal: {}.\n".format(signame))
 
         # Cancel all events
         if self.scheduler is not None:
@@ -291,7 +312,13 @@ class QueueManager:
             return {"nshutdown": 0}
 
         nshutdown = response["nshutdown"]
-        self.logger.info("Shutdown was successful, {} tasks returned to master queue.".format(nshutdown))
+        shutdown_string = "Shutdown was successful, {} tasks returned to master queue."
+        if self.n_stale_jobs:
+            shutdown_string = shutdown_string.format(
+                f"{min(0, nshutdown-self.stale_jobs)} active and {nshutdown} stale")
+        else:
+            shutdown_string = shutdown_string.format(nshutdown)
+        self.logger.info(shutdown_string)
         return response
 
     def add_exit_callback(self, callback: Callable, *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
@@ -309,6 +336,66 @@ class QueueManager:
         """
         self.exit_callbacks.append((callback, args, kwargs))
 
+    def _post_update(self, payload_data):
+        """Internal function to post payload update"""
+        payload = self._payload_template()
+        # Update with data
+        payload["data"] = payload_data
+        try:
+            self.client._automodel_request("queue_manager", "post", payload)
+        except IOError:
+            # Trapped behavior elsewhere
+            raise
+        except Exception as fatal:
+            # Non IOError, something has gone very wrong
+            self.logger.error("An error was detected which was not an expected requests-type error. The manager "
+                              "will attempt shutdown as best it can. Please report this error to the QCFractal "
+                              "developers as this block should not be "
+                              "seen outside of debugging modes. Error is as follows\n{}".format(fatal))
+            try:
+                self.shutdown()
+            finally:
+                raise fatal
+
+    def _update_stale_jobs(self):
+        """
+        Attempt to post the previous payload failures
+        """
+        clear_indices = []
+        for index, (results, attempts) in enumerate(self._stale_payload_tracking):
+            try:
+                self._post_update(results)
+                self.logger.info(f"Successfully pushed jobs from {attempts+1} updates ago")
+                clear_indices.append(index)
+            except IOError:
+                # Tried and failed
+                attempts += 1
+                # Case: Still within the retry limit
+                if self.server_error_retries is None or self.server_error_retries > attempts:
+                    self._stale_payload_tracking[index][-1] = attempts
+                    self.logger.warning(f"Re-attempt to post jobs from {attempts} ago failed again, will retry")
+                # Case: Over limit
+                else:
+                    self.logger.warning(f"Could not post jobs from {attempts} ago and over attempt limit, marking "
+                                        f"jobs as stale.")
+                    self.n_stale_jobs += len(results)
+                    clear_indices.append(index)
+                    self._stale_updates_tracked += 1
+        # Cleanup clear indices
+        for index in clear_indices[::-1]:
+            self._stale_payload_tracking.pop(index)
+        # Check stale limiters
+        if self.stale_update_limit is not None and (
+                len(self._stale_payload_tracking) + self._stale_updates_tracked) > self.stale_update_limit:
+            self.logger.error("Exceeded number of stale updates allowed! Attempting to shutdown gracefully...")
+            # Log all not-quite stale jobs to stale
+            for (results, _) in self._stale_payload_tracking:
+                self.n_stale_jobs += len(results)
+            try:
+                self.shutdown()
+            finally:
+                raise RuntimeError("Exceeded number of stale updates allowed!")
+
     def update(self, new_tasks: bool=True) -> bool:
         """Examines the queue for completed tasks and adds successful completions to the database
         while unsuccessful are logged for future inspection.
@@ -316,22 +403,26 @@ class QueueManager:
         """
 
         self.assert_connected()
+        self._update_stale_jobs()
 
         results = self.queue_adapter.acquire_complete()
         n_success = 0
         n_fail = 0
         n_result = len(results)
         error_payload = []
+        jobs_pushed = f"Pushed {n_result} complete tasks to the server "
         if n_result:
-            payload = self._payload_template()
-
-            # Upload new results
-            payload["data"] = results
             try:
-                self.client._automodel_request("queue_manager", "post", payload)
+                self._post_update(results)
             except IOError:
-                # TODO something as we didnt successfully add the data
-                self.logger.warning("Post complete tasks was not successful. Data may be lost.")
+                if self.server_error_retries is None or self.server_error_retries > 0:
+                    self.logger.warning("Post complete tasks was not successful. Attempting again on next update.")
+                    self._stale_payload_tracking.append([results, 0])
+                    jobs_pushed = f"Tried to push {n_result} complete tasks to the server "
+                else:
+                    self.logger.warning("Post complete tasks was not successful. Data may be lost.")
+                    self.n_stale_jobs += len(results)
+                    jobs_pushed = f"Failed to push {n_result} complete tasks to the server "
 
             self.active -= n_result
             for key, result in results.items():
@@ -342,8 +433,7 @@ class QueueManager:
                                          f"Msg: {result.error.error_message}")
             n_fail = n_result - n_success
 
-        self.logger.info("Pushed {} complete tasks to the server "
-                         "({} success / {} fail).".format(n_result, n_success, n_fail))
+        self.logger.info(jobs_pushed + f"({n_success} success / {n_fail} fail).")
         if n_fail:
             self.logger.warning("The following tasks failed with the errors:")
             for error in error_payload:

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -66,7 +66,7 @@ def test_queue_manager_shutdown(compute_adapter_fixture):
     manager = queue.QueueManager(client, adapter)
 
     hooh = ptl.data.get_molecule("hooh.json")
-    ret = client.add_compute("rdkit", "UFF", "", "energy", None, [hooh.json_dict()], tag="other")
+    client.add_compute("rdkit", "UFF", "", "energy", None, [hooh.json_dict()], tag="other")
 
     # Pull job to manager and shutdown
     manager.update()
@@ -82,6 +82,61 @@ def test_queue_manager_shutdown(compute_adapter_fixture):
     manager.await_results()
     ret = client.query_results()
     assert len(ret) == 1
+
+@testing.using_rdkit
+def test_queue_manager_server_delay(compute_adapter_fixture):
+    """Test to ensure interrupts to the server shutdown correctly"""
+    client, server, adapter = compute_adapter_fixture
+    reset_server_database(server)
+
+    manager = queue.QueueManager(client, adapter, server_error_retries=1)
+
+    hooh = ptl.data.get_molecule("hooh.json")
+    ret = client.add_compute("rdkit", "UFF", "", "energy", None, [hooh.json_dict()], tag="other")
+
+    # Pull job to manager and shutdown
+    manager.update()
+    assert len(manager.list_current_tasks()) == 1
+
+    # Mock a network error
+    client.mock_network_error = True
+    # Let the calculation finish
+    manager.queue_adapter.await_results()
+    # Try to push the changes through the network error
+    manager.update()
+    assert len(manager.list_current_tasks()) == 0
+    assert len(manager._stale_payload_tracking) == 1
+    assert manager.n_stale_jobs == 0
+
+    # Try again to push the tracked attempts into stale
+    manager.update()
+    assert len(manager.list_current_tasks()) == 0
+    assert len(manager._stale_payload_tracking) == 0
+    assert manager.n_stale_jobs == 1
+    # Update again to push jobs to stale
+    manager.update()
+
+    # Return the jobs to the server
+    client.mock_network_error = False
+    assert manager.shutdown()["nshutdown"] == 1
+
+    # Once more, but this time restart the server in between
+    manager = queue.QueueManager(client, adapter, server_error_retries=1)
+    manager.update()
+    assert len(manager.list_current_tasks()) == 1
+    manager.queue_adapter.await_results()
+    # Trigger our failure
+    client.mock_network_error = True
+    manager.update()
+    assert len(manager.list_current_tasks()) == 0
+    assert len(manager._stale_payload_tracking) == 1
+    assert manager.n_stale_jobs == 0
+    # Stop mocking a network error
+    client.mock_network_error = False
+    manager.update()
+    assert len(manager.list_current_tasks()) == 0
+    assert len(manager._stale_payload_tracking) == 0
+    assert manager.n_stale_jobs == 0
 
 
 def test_queue_manager_heartbeat(compute_adapter_fixture):

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -92,14 +92,14 @@ def test_queue_manager_server_delay(compute_adapter_fixture):
     manager = queue.QueueManager(client, adapter, server_error_retries=1)
 
     hooh = ptl.data.get_molecule("hooh.json")
-    ret = client.add_compute("rdkit", "UFF", "", "energy", None, [hooh.json_dict()], tag="other")
+    client.add_compute("rdkit", "UFF", "", "energy", None, [hooh.json_dict()], tag="other")
 
     # Pull job to manager and shutdown
     manager.update()
     assert len(manager.list_current_tasks()) == 1
 
     # Mock a network error
-    client.mock_network_error = True
+    client._mock_network_error = True
     # Let the calculation finish
     manager.queue_adapter.await_results()
     # Try to push the changes through the network error
@@ -117,7 +117,7 @@ def test_queue_manager_server_delay(compute_adapter_fixture):
     manager.update()
 
     # Return the jobs to the server
-    client.mock_network_error = False
+    client._mock_network_error = False
     assert manager.shutdown()["nshutdown"] == 1
 
     # Once more, but this time restart the server in between
@@ -126,13 +126,13 @@ def test_queue_manager_server_delay(compute_adapter_fixture):
     assert len(manager.list_current_tasks()) == 1
     manager.queue_adapter.await_results()
     # Trigger our failure
-    client.mock_network_error = True
+    client._mock_network_error = True
     manager.update()
     assert len(manager.list_current_tasks()) == 0
     assert len(manager._stale_payload_tracking) == 1
     assert manager.n_stale_jobs == 0
     # Stop mocking a network error
-    client.mock_network_error = False
+    client._mock_network_error = False
     manager.update()
     assert len(manager.list_current_tasks()) == 0
     assert len(manager._stale_payload_tracking) == 0


### PR DESCRIPTION
## Description
This PR introduces better handling and logging for failed job
`post` events. Failed `update` actions are queued and retried to a
set number of times before the manager drops the jobs and considers
them "stale." A maximum number of stale updates are allowed to be
tracked before the server just shuts itself down.

I'm working on a test for this block of code, but its ready otherwise

This also fixes a bug in the `dask` queue_manager CLI script where
`env_extra` was misspelled and thus ignored by `dask`. (it was
`env_exta`).

## Todos
  - [x] Add a test

## Status
- [ ] Changelog updated
- [x] Ready to go (ish, missing test, but it does work locally)