### PR TITLE
Add missing dask and dask-jobqueue dependencies for openff.yaml

### DIFF
--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -33,3 +33,7 @@ dependencies:
 # QCArchive includes
   - qcengine>=0.6.2
   - qcelemental>=0.3.1
+
+# Distributed computing
+  - dask
+  - dask-jobqueue

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -37,3 +37,6 @@ dependencies:
 # Distributed computing
   - dask
   - dask-jobqueue
+
+# geometric
+  - openmm

--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -23,7 +23,7 @@ Enhancements
 
 - (:pr:`??`) Tasks which fail are now more verbose in the log as to why they failed. This is additional information
   on top of the number of pass/fail.
-- (:pr:`255`) OpenFF conda environment now installs ``dask`` and ``dask-jobqueue`` by default
+- (:pr:`255`) OpenFF conda environment now installs ``dask``, ``dask-jobqueue``, and ``openmm`` by default
 
 
 0.6.0 / 2019-03-30

--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -23,6 +23,7 @@ Enhancements
 
 - (:pr:`??`) Tasks which fail are now more verbose in the log as to why they failed. This is additional information
   on top of the number of pass/fail.
+- (:pr:`??`) OpenFF conda environment now installs ``dask`` and ``dask-jobqueue`` by default
 
 
 0.6.0 / 2019-03-30

--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -23,7 +23,7 @@ Enhancements
 
 - (:pr:`??`) Tasks which fail are now more verbose in the log as to why they failed. This is additional information
   on top of the number of pass/fail.
-- (:pr:`??`) OpenFF conda environment now installs ``dask`` and ``dask-jobqueue`` by default
+- (:pr:`255`) OpenFF conda environment now installs ``dask`` and ``dask-jobqueue`` by default
 
 
 0.6.0 / 2019-03-30


### PR DESCRIPTION
## Description
This PR adds two critical dependencies (`dask` and `dask-jobqueue`) to the OpenFF conda devtools environment.

## Status
- [x] Changelog updated
- [x] Ready to go