### PR TITLE
QCEl: Bumps depends to v0.4

### DIFF
--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -14,9 +14,9 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
   - sqlalchemy
   - psycopg2
-  - plotly
 
 # Test depends
   - pytest
@@ -32,7 +32,7 @@ dependencies:
 
 # QCArchive includes
   - qcengine>=0.6.2
-  - qcelemental>=0.3.1
+  - qcelemental>=0.4.0
 
 # Pip includes
   - pip:

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -14,9 +14,9 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
   - sqlalchemy
   - psycopg2
-  - plotly
 
 # Test depends
   - pytest
@@ -25,4 +25,4 @@ dependencies:
 
 # QCArchive includes
   - qcengine>=0.6.2
-  - qcelemental>=0.3.1
+  - qcelemental>=0.4.0

--- a/devtools/conda-envs/dev_head.yaml
+++ b/devtools/conda-envs/dev_head.yaml
@@ -14,9 +14,9 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
   - sqlalchemy
   - psycopg2
-  - plotly
 
 # Test depends
   - pytest

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -34,7 +34,7 @@ dependencies:
   - pytest-cov
   - codecov
 """
-qca_ecosystem_template = ["qcengine>=0.6.2", "qcelemental>=0.3.1"]
+qca_ecosystem_template = ["qcengine>=0.6.2", "qcelemental>=0.4.0"]
 
 # Note we temporarily duplicate mongoengine as conda-forge appears to be broken
 pip_depends_template = []

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -15,9 +15,9 @@ dependencies:
   - cryptography
   - pydantic
   - mongoengine
+  - plotly
   - sqlalchemy
   - psycopg2
-  - plotly
 
 # Test depends
   - pytest
@@ -28,8 +28,8 @@ dependencies:
   - psi4
   - rdkit
   - geometric>=0.9.3
-  - torsiondrive>=0.9.6
+  - torsiondrive
 
 # QCArchive includes
   - qcengine>=0.6.2
-  - qcelemental>=0.3.1
+  - qcelemental>=0.4.0

--- a/qcfractal/interface/models/tests/test_hashes.py
+++ b/qcfractal/interface/models/tests/test_hashes.py
@@ -12,8 +12,7 @@ from ..torsiondrive import TorsionDriveRecord
 
 def test_molecule_water_canary_hash():
 
-    water_dimer_minima = Molecule.from_data(
-        """
+    water_dimer_minima = Molecule.from_data("""
     0 1
     O  -1.551007  -0.114520   0.000000
     H  -1.934259   0.762503   0.000000
@@ -23,29 +22,29 @@ def test_molecule_water_canary_hash():
     H   1.680398  -0.373741  -0.758561
     H   1.680398  -0.373741   0.758561
     """,
-        dtype="psi4")
-    assert water_dimer_minima.get_hash() == "e816b396c7b00e49ef2d9c8b670c955df0a410c7"
+                                            dtype="psi4")
+    assert water_dimer_minima.get_hash() == "42f3ac52af52cf2105c252031334a2ad92aa911c"
 
     # Check orientation
     mol = water_dimer_minima.orient_molecule()
-    assert mol.get_hash() == "b9bbe6028825d2e61c1ccfcdd0f4be4c3fa6efda"
+    assert mol.get_hash() == "632490a0601500bfc677e9277275f82fbc45affe"
 
     frag_0 = mol.get_fragment(0, orient=True)
     frag_1 = mol.get_fragment(1, orient=True)
-    assert frag_0.get_hash() == "f701c1724e645f52c09dbf36d01fe17d9d882a8a"
-    assert frag_1.get_hash() == "4469ff05895a6375a91ce9a225f96e3f9938450b"
+    assert frag_0.get_hash() == "d0b499739f763e8d3a5556b4ddaeded6a148e4d5"
+    assert frag_1.get_hash() == "bdc1f75bd1b7b999ff24783d7c1673452b91beb9"
 
-@pytest.mark.parametrize("geom, hash_index", [
-    ([0, 0, 0, 0, 5, 0], "ba76b68bb11e042712b2444d6b42ebbf92b944fc"),
-    ([0, 0, 0, 0, 5, 0 + 1.e-12], "ba76b68bb11e042712b2444d6b42ebbf92b944fc"),
-    ([0, 0, 0, 0, 5, 0 - 1.e-12], "ba76b68bb11e042712b2444d6b42ebbf92b944fc"),
-    ([0, 0, 0, 0, 5, 0 + 1.e-7], "ba76b68bb11e042712b2444d6b42ebbf92b944fc"),
+@pytest.mark.parametrize("geom", [
+    [0, 0, 0, 0, 5, 0],
+    [0, 0, 0, 0, 5, 0 + 1.e-12],
+    [0, 0, 0, 0, 5, 0 - 1.e-12],
+    [0, 0, 0, 0, 5, 0 + 1.e-7],
 ]) # yapf: disable
-def test_molecule_geometry_canary_hash(geom, hash_index):
+def test_molecule_geometry_canary_hash(geom):
 
     mol = Molecule(geometry=geom, symbols=["H", "H"])
 
-    assert mol.get_hash() == hash_index
+    assert mol.get_hash() == "fb69e6744407b220a96d6ddab4ec2099619db791"
 
 
 ## Keyword Set hash
@@ -142,6 +141,7 @@ def test_keywords_comparison_hash(data1, data2):
     assert opt1s.hash_index == opt2.hash_index
     assert opt1s.hash_index == opt2s.hash_index
 
+
 @pytest.mark.parametrize("model", [ResultRecord, OptimizationRecord])
 def test_hash_fields(model):
     assert "procedure" in model.get_hash_fields()
@@ -195,16 +195,12 @@ def test_result_record_canary_hash(data, hash_index):
     opt = ResultRecord(**{**_base_result, **data})
 
     assert hash_index == opt.get_hash_index(), data
-    assert opt.hash_index is None # Not set
+    assert opt.hash_index is None  # Not set
+
 
 ## Optimization hashes
 _qc_spec = {"driver": "gradient", "method": "HF", "basis": "sto-3g", "keywords": None, "program": "prog"}
-_base_opt = {
-    "keywords": {},
-    "program": "prog2",
-    "initial_molecule": "5c7896fb95d592ad07a2fe3b",
-    "qc_spec": _qc_spec
-}
+_base_opt = {"keywords": {}, "program": "prog2", "initial_molecule": "5c7896fb95d592ad07a2fe3b", "qc_spec": _qc_spec}
 @pytest.mark.parametrize("data, hash_index", [
 
     # Check same
@@ -275,7 +271,9 @@ _base_gridopt = {
     "grid_optimizations": {},
     "final_energy_dict": {},
     "starting_grid": tuple(),
-    "provenance": {"creator": ""}
+    "provenance": {
+        "creator": ""
+    }
 }
 
 
@@ -329,32 +327,61 @@ _base_torsion = {
 }
 
 
-@pytest.mark.parametrize("data, hash_index", [
+@pytest.mark.parametrize(
+    "data, hash_index",
+    [
+        ({}, "dd305011ee2b741b1dcd03350994920a3718b289"),
 
-    ({}, "dd305011ee2b741b1dcd03350994920a3718b289"),
+        # Check same
+        ({
+            "keywords": {
+                "dihedrals": [[0, 1, 2, 3]],
+                "grid_spacing": [10],
+                "tol": 1.e-12
+            }
+        }, "cb3f9c9bd4eda742b0429ebea0c3d12719ab2582"),
+        ({
+            "keywords": {
+                "dihedrals": [[0, 1, 2, 3]],
+                "grid_spacing": [10],
+                "tol": 0
+            }
+        }, "cb3f9c9bd4eda742b0429ebea0c3d12719ab2582"),
+        ({
+            "keywords": {
+                "dihedrals": [[0, 1, 2, 3]],
+                "grid_spacing": [10],
+                "tol": 1.e-9
+            }
+        }, "903cc0deb4f0e7b8bc41a69cf5fbd0c9420176a4"),
 
-    # Check same
-    ({"keywords": {"dihedrals": [[0, 1, 2, 3]], "grid_spacing": [10], "tol": 1.e-12}},
-     "cb3f9c9bd4eda742b0429ebea0c3d12719ab2582"),
+        # Check opt keywords stability
+        ({
+            "optimization_spec": {
+                **_opt_spec,
+                **{
+                    "keywords": {
+                        "tol": 0.0
+                    }
+                }
+            }
+        }, "a12fd524b0e215b5252b464ca4041091916df8bb"),
+        ({
+            "optimization_spec": {
+                **_opt_spec,
+                **{
+                    "keywords": {
+                        "tol": 1.e-12
+                    }
+                }
+            }
+        }, "a12fd524b0e215b5252b464ca4041091916df8bb"),
 
-    ({"keywords": {"dihedrals": [[0, 1, 2, 3]], "grid_spacing": [10], "tol": 0}},
-     "cb3f9c9bd4eda742b0429ebea0c3d12719ab2582"),
-
-    ({"keywords": {"dihedrals": [[0, 1, 2, 3]], "grid_spacing": [10], "tol": 1.e-9}},
-     "903cc0deb4f0e7b8bc41a69cf5fbd0c9420176a4"),
-
-    # Check opt keywords stability
-    ({"optimization_spec": {**_opt_spec, **{"keywords": {"tol": 0.0}}}},
-      "a12fd524b0e215b5252b464ca4041091916df8bb"),
-
-    ({"optimization_spec": {**_opt_spec, **{"keywords": {"tol": 1.e-12}}}},
-      "a12fd524b0e215b5252b464ca4041091916df8bb"),
-
-    # Check fields
-    ({"initial_molecule": ["5c78987e95d592ad07a2fe3c"]},
-     "f209751a4a6559a8d2d539c070f3b701d1ddf9f2"),
-
-]) # yapf disable
+        # Check fields
+        ({
+            "initial_molecule": ["5c78987e95d592ad07a2fe3c"]
+        }, "f209751a4a6559a8d2d539c070f3b701d1ddf9f2"),
+    ])  # yapf disable
 def test_torsiondrive_canary_hash(data, hash_index):
 
     td = TorsionDriveRecord(**{**_base_torsion, **data})

--- a/qcfractal/interface/tests/test_dataset.py
+++ b/qcfractal/interface/tests/test_dataset.py
@@ -56,10 +56,10 @@ def water_ds():
             "DFT": -10.0
         })
 
-    dimer_string = dimer.to_string()
+    dimer_string = dimer.to_string("psi4")
     # Add single stoich from strings, not a valid set
     ds.add_rxn(
-        "Water Dimer, dimer - str (invalid)", [(dimer_string, 1.0), (dimer_string.splitlines()[-5], 0.0)],
+        "Water Dimer, dimer - str (invalid)", [(dimer_string, 1.0), (frag_0, 0.0)],
         attributes={"R": "Minima"},
         reaction_results={
             "Benchmark": -20.0,
@@ -84,7 +84,7 @@ def water_ds():
         },
         other_fields={"Something": "Other thing"})
 
-    ds.add_ie_rxn("Water dimer", dimer.to_string())
+    ds.add_ie_rxn("Water dimer", dimer.to_string("psi4"))
 
     # Add unverified records (requires a active server)
     ds.data.records = ds._new_records
@@ -111,7 +111,7 @@ def nbody_ds():
             "default": [(dimer, 1.0)],
         })
 
-    ds.add_ie_rxn("Water Dimer", dimer.to_string())
+    ds.add_ie_rxn("Water Dimer", dimer.to_string("psi4"))
     ds.add_ie_rxn("Ne Tetramer", portal.data.get_molecule("neon_tetramer.psimol"))
 
     # Ne Tetramer benchmark

--- a/qcfractal/interface/tests/test_molecule.py
+++ b/qcfractal/interface/tests/test_molecule.py
@@ -37,7 +37,7 @@ def test_molecule_constructors():
     assert neon_from_psi.compare(neon_from_psi, neon_from_json)
     assert neon_from_json.get_molecular_formula() == "Ne4"
 
-    assert water_psi.compare(portal.Molecule.from_data(water_psi.to_string()))
+    assert water_psi.compare(portal.Molecule.from_data(water_psi.to_string("psi4")))
 
 
 def test_molecule_file_constructors():
@@ -70,7 +70,7 @@ def test_water_minima_data():
          [-2.6821528, -0.12325075, 0.],
          [-3.27523824, 0.81341093, 1.43347255],
          [-3.27523824, 0.81341093, -1.43347255]]) # yapf: disable
-    assert mol.get_hash() == "b41f1e38bc4be5482fcd1d4dd53ca7c65146ab91"
+    assert mol.get_hash() == "3c4b98f515d64d1adc1648fe1fe1d6789e978d34"
 
 
 def test_water_minima_fragment():
@@ -79,8 +79,8 @@ def test_water_minima_fragment():
 
     frag_0 = mol.get_fragment(0, orient=True)
     frag_1 = mol.get_fragment(1, orient=True)
-    assert frag_0.get_hash() == "0b13814f79b8f74f17499b31fe7b76cd97b89449"
-    assert frag_1.get_hash() == "4469ff05895a6375a91ce9a225f96e3f9938450b"
+    assert frag_0.get_hash() == "5f31757232a9a594c46073082534ca8a6806d367"
+    assert frag_1.get_hash() == "bdc1f75bd1b7b999ff24783d7c1673452b91beb9"
 
     frag_0_1 = mol.get_fragment(0, 1)
     frag_1_0 = mol.get_fragment(1, 0)
@@ -104,7 +104,7 @@ def test_pretty_print():
 def test_to_string():
 
     mol = portal.data.get_molecule("water_dimer_minima.psimol")
-    assert isinstance(mol.to_string(), str)
+    assert isinstance(mol.to_string("psi4"), str)
 
 
 def test_water_orient():

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
             # QCArchive depends
             'qcengine>=0.6.2',
-            'qcelemental>=0.3.3',
+            'qcelemental>=0.4.0',
 
             # Testing
             'pytest',


### PR DESCRIPTION
## Description
Updates API to reflect QCEl changes including the molecular hash differences. This is noted in #245.

## Status
- [ ] Changelog updated
- [x] Ready to go