### PR TITLE
Implement get_final_results() for GridOptimizationRecord and TorsionDriveRecord

### DIFF
--- a/qcfractal/interface/models/gridoptimization.py
+++ b/qcfractal/interface/models/gridoptimization.py
@@ -275,7 +275,7 @@ class GridOptimizationRecord(RecordBase):
             query_result_ids = list(map_id_key.keys())
             # put the ids into batch of 10k limit
             batch_size_limit = 10000
-            for i_batch in range(len(query_result_ids)-1 // batch_size_limit):
+            for i_batch in range((len(query_result_ids)+batch_size_limit-1) // batch_size_limit):
                 query_batch_ids = query_result_ids[i_batch * batch_size_limit: (i_batch+1) * batch_size_limit]
                 # run the query on this batch
                 for grad_result_record in self.client.query_results(id=query_batch_ids):

--- a/qcfractal/interface/models/gridoptimization.py
+++ b/qcfractal/interface/models/gridoptimization.py
@@ -273,14 +273,10 @@ class GridOptimizationRecord(RecordBase):
                     map_id_key[final_grad_record_id] = k
             # combine the ids into one query
             query_result_ids = list(map_id_key.keys())
-            # put the ids into batch of 10k limit
-            batch_size_limit = 10000
-            for i_batch in range((len(query_result_ids)+batch_size_limit-1) // batch_size_limit):
-                query_batch_ids = query_result_ids[i_batch * batch_size_limit: (i_batch+1) * batch_size_limit]
-                # run the query on this batch
-                for grad_result_record in self.client.query_results(id=query_batch_ids):
-                    k = map_id_key[grad_result_record.id]
-                    ret[k] = grad_result_record
+            # run the query on this batch
+            for grad_result_record in self.client.query_results(id=query_result_ids):
+                k = map_id_key[grad_result_record.id]
+                ret[k] = grad_result_record
 
             self.cache["final_results"] = ret
 

--- a/qcfractal/interface/models/gridoptimization.py
+++ b/qcfractal/interface/models/gridoptimization.py
@@ -235,3 +235,55 @@ class GridOptimizationRecord(RecordBase):
 
         data = self.cache["final_molecules"]
         return self._organize_return(data, key)
+
+
+    def get_final_results(self, key: Union[int, Tuple[int, ...], str]=None) -> Dict[str, Any]:
+        """Returns the final opt gradient result records at each grid point.
+
+        Parameters
+        ----------
+        key : Union[int, str, None], optional
+            Specifies a single entry to pull from.
+
+        Returns
+        -------
+        final_results : Dict[str, qcfractal.interface.models.records.ResultRecord]
+            Returns ResultRecord at each grid point in a dictionary or at a
+            single point if a key is specified.
+
+        Examples
+        --------
+        >>> mols = grid_optimization_record.get_final_results()
+        >>> type(mols[(-90, )])
+        qcfractal.interface.models.records.ResultRecord
+
+        >>> type(grid_optimization_record.get_final_results((-90,)))
+        qcfractal.interface.models.records.ResultRecord
+
+        """
+
+        if "final_results" not in self.cache:
+            map_id_key = {}
+            ret = {}
+            for k, task_id in self.grid_optimizations.items():
+                task = self.client.query_procedures(id=task_id)[0]
+                if len(task.trajectory) > 0:
+                    final_grad_record_id = task.trajectory[-1]
+                    # store the id -> grid id mapping
+                    map_id_key[final_grad_record_id] = k
+            # combine the ids into one query
+            query_result_ids = list(map_id_key.keys())
+            # put the ids into batch of 10k limit
+            batch_size_limit = 10000
+            for i_batch in range(len(query_result_ids)-1 // batch_size_limit):
+                query_batch_ids = query_result_ids[i_batch * batch_size_limit: (i_batch+1) * batch_size_limit]
+                # run the query on this batch
+                for grad_result_record in self.client.query_results(id=query_batch_ids):
+                    k = map_id_key[grad_result_record.id]
+                    ret[k] = grad_result_record
+
+            self.cache["final_results"] = ret
+
+        data = self.cache["final_results"]
+
+        return self._organize_return(data, key)

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -170,7 +170,7 @@ class TorsionDriveRecord(RecordBase):
 
         Returns
         -------
-        energy : Dict[str, Any]
+        energy : Dict[str, float]
             Returns energies at each grid point in a dictionary or at a
             single point if a key is specified.
 
@@ -193,7 +193,7 @@ class TorsionDriveRecord(RecordBase):
 
         Returns
         -------
-        final_molecules : Dict[str, Any]
+        final_molecules : Dict[str, qcelemental.models.molecule.Molecule]
             Returns molecule at each grid point in a dictionary or at a
             single point if a key is specified.
 
@@ -220,6 +220,60 @@ class TorsionDriveRecord(RecordBase):
             self.cache["final_molecules"] = ret
 
         data = self.cache["final_molecules"]
+
+        return self._organize_return(data, key)
+
+    def get_final_results(self, key: Union[int, Tuple[int, ...], str]=None) -> Dict[str, Any]:
+        """Returns the final opt gradient result records at each grid point
+
+        Parameters
+        ----------
+        key : Union[int, str, None], optional
+            Specifies a single entry to pull from.
+
+        Returns
+        -------
+        final_results : Dict[str, qcfractal.interface.models.records.ResultRecord]
+            Returns ResultRecord at each grid point in a dictionary or at a
+            single point if a key is specified.
+
+        Examples
+        --------
+        >>> mols = torsiondrive_obj.get_final_results()
+        >>> type(mols[(-90, )])
+        qcfractal.interface.models.records.ResultRecord
+
+        >>> type(torsiondrive_obj.get_final_results((-90,)))
+        qcfractal.interface.models.records.ResultRecord
+
+        """
+
+        if "final_results" not in self.cache:
+
+            map_id_key = {}
+            ret = {}
+            for k, tasks in self.get_history().items():
+                k = self._serialize_key(k)
+                minpos = self.minimum_positions[k]
+                final_opt_task = tasks[minpos]
+                if len(final_opt_task.trajectory) > 0:
+                    final_grad_record_id = final_opt_task.trajectory[-1]
+                    # store the id -> grid id mapping
+                    map_id_key[final_grad_record_id] = k
+            # combine the ids into one query
+            query_result_ids = list(ret_result_ids.keys())
+            # put the ids into batch of 10k limit
+            batch_size_limit = 10000
+            for i_batch in range(len(query_result_ids) // batch_size_limit):
+                query_batch_ids = query_result_ids[i_batch * batch_size_limit: (i_batch+1) * batch_size_limit]
+                # run the query on this batch
+                for grad_result_record in self.client.get_final_results(id=query_batch_ids):
+                    k = map_id_key[grad_result_record.id]
+                    ret[k] = grad_result_record
+
+            self.cache["final_results"] = ret
+
+        data = self.cache["final_results"]
 
         return self._organize_return(data, key)
 

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -265,14 +265,10 @@ class TorsionDriveRecord(RecordBase):
                     map_id_key[final_grad_record_id] = k
             # combine the ids into one query
             query_result_ids = list(map_id_key.keys())
-            # put the ids into batch of 10k limit
-            batch_size_limit = 10000
-            for i_batch in range((len(query_result_ids)+batch_size_limit-1) // batch_size_limit):
-                query_batch_ids = query_result_ids[i_batch * batch_size_limit: (i_batch+1) * batch_size_limit]
-                # run the query on this batch
-                for grad_result_record in self.client.query_results(id=query_batch_ids):
-                    k = map_id_key[grad_result_record.id]
-                    ret[k] = grad_result_record
+            # run the query on this batch
+            for grad_result_record in self.client.query_results(id=query_result_ids):
+                k = map_id_key[grad_result_record.id]
+                ret[k] = grad_result_record
 
             self.cache["final_results"] = ret
 

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -159,6 +159,7 @@ class TorsionDriveRecord(RecordBase):
 
         return self._organize_return(data, key, minimum=minimum)
 
+
     def get_final_energies(self, key: Union[int, Tuple[int, ...], str]=None) -> Dict[str, Any]:
         """
         Provides the final optimized energies at each grid point.
@@ -182,6 +183,7 @@ class TorsionDriveRecord(RecordBase):
         """
 
         return self._organize_return(self.final_energy_dict, key)
+
 
     def get_final_molecules(self, key: Union[int, Tuple[int, ...], str]=None) -> Dict[str, Any]:
         """Returns the optimized molecules at each grid point
@@ -223,6 +225,7 @@ class TorsionDriveRecord(RecordBase):
 
         return self._organize_return(data, key)
 
+
     def get_final_results(self, key: Union[int, Tuple[int, ...], str]=None) -> Dict[str, Any]:
         """Returns the final opt gradient result records at each grid point
 
@@ -261,13 +264,13 @@ class TorsionDriveRecord(RecordBase):
                     # store the id -> grid id mapping
                     map_id_key[final_grad_record_id] = k
             # combine the ids into one query
-            query_result_ids = list(ret_result_ids.keys())
+            query_result_ids = list(map_id_key.keys())
             # put the ids into batch of 10k limit
             batch_size_limit = 10000
-            for i_batch in range(len(query_result_ids) // batch_size_limit):
+            for i_batch in range(len(query_result_ids)-1 // batch_size_limit):
                 query_batch_ids = query_result_ids[i_batch * batch_size_limit: (i_batch+1) * batch_size_limit]
                 # run the query on this batch
-                for grad_result_record in self.client.get_final_results(id=query_batch_ids):
+                for grad_result_record in self.client.query_results(id=query_batch_ids):
                     k = map_id_key[grad_result_record.id]
                     ret[k] = grad_result_record
 

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -267,7 +267,7 @@ class TorsionDriveRecord(RecordBase):
             query_result_ids = list(map_id_key.keys())
             # put the ids into batch of 10k limit
             batch_size_limit = 10000
-            for i_batch in range(len(query_result_ids)-1 // batch_size_limit):
+            for i_batch in range((len(query_result_ids)+batch_size_limit-1) // batch_size_limit):
                 query_batch_ids = query_result_ids[i_batch * batch_size_limit: (i_batch+1) * batch_size_limit]
                 # run the query on this batch
                 for grad_result_record in self.client.query_results(id=query_batch_ids):

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -259,6 +259,20 @@ def test_service_torsiondrive_visualization(torsiondrive_fixture):
     result.visualize()
 
 
+def test_service_torsiondrive_get_final_results(torsiondrive_fixture):
+    """Test the get_final_results function for the 1-D case"""
+
+    spin_up_test, client = torsiondrive_fixture
+    ret = spin_up_test()
+
+    # Get a TorsionDriveORM result and check data
+    result = client.query_procedures(id=ret.ids)[0]
+    assert result.status == "COMPLETE"
+
+    final_result_records = result.get_final_results()
+    assert set(final_result_records.keys()) == {(-90,), (-0,), (90,), (180,)}
+
+
 @using_geometric
 @using_rdkit
 def test_service_gridoptimization_single_opt(fractal_compute_server):
@@ -316,7 +330,7 @@ def test_service_gridoptimization_single_opt(fractal_compute_server):
 
     assert result.starting_molecule != result.initial_molecule
 
-    # Check initial vs startin molecule
+    # Check initial vs starting molecule
     assert result.initial_molecule == mol_ret[0]
     starting_mol = client.query_molecules(id=result.starting_molecule)[0]
     assert pytest.approx(starting_mol.measure([1, 2])) != initial_distance
@@ -329,6 +343,10 @@ def test_service_gridoptimization_single_opt(fractal_compute_server):
     task = client.query_tasks(id=opt.task_id)[0]
     assert task.priority == 0
     assert task.tag == "gridopt"
+
+    # Check final ResultRecords
+    final_result_records = result.get_final_results()
+    assert len(final_result_records) == 4
 
 
 @using_geometric


### PR DESCRIPTION
## Description
Current `get_final_energies()` and `get_final_molecules()` does not expose gradients of the last frame, which is useful in force field fitting, so as suggested by @dgasmith, I implemented the `get_final_results()` method, which returns a dictionary with the same key as above methods, and the values are the ResultRecord for the last gradient evaluation of the final geometry optimization.

## Todos
- [x] Implement get_final_results() for GridOptimizationRecord
- [x] Implement get_final_results() for TorsionDriveRecord

## Questions
- [ ] Where is the best place to write tests

## Status
- [ ] Changelog updated
- [x] Ready to go