### PR TITLE
Envs: Adds production environments to the devtools folder

### DIFF
--- a/devtools/prod-envs/README.md
+++ b/devtools/prod-envs/README.md
@@ -1,0 +1,23 @@
+Production Environments
+=======================
+
+This file contains production environments for the QCArchive ecosystem. These environments are for a mix
+of general compute and specific to an individual organization.
+
+Once environments can be upload, they can be created from anywhere using the following line:
+```bash
+conda env create qcarchive/env -n env_name
+```
+
+To update an environment the current environment needs to be removed:
+```bash
+conda env remove -n env_name
+```
+It should be noted that this does not remove the packages, and creating a new environment should be very quick
+as most required packages should already be installed.
+
+To upload an environment:
+```bash
+anaconda upload --user qcarchive env.yaml
+```
+

--- a/devtools/prod-envs/qcf-manager-openff.yaml
+++ b/devtools/prod-envs/qcf-manager-openff.yaml
@@ -1,0 +1,18 @@
+name: qcf-manager-openff
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python
+  - qcfractal
+  - qcportal
+
+    # Compute engines
+  - psi4::psi4
+  - rdkit
+    
+    # Procedures
+  - geometric
+
+    # Distributed managers
+  - dask-jobqueue

--- a/devtools/prod-envs/qcf-snowflake.yaml
+++ b/devtools/prod-envs/qcf-snowflake.yaml
@@ -1,0 +1,16 @@
+name: qcf-snowflake
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python
+  - qcfractal
+  - qcportal
+
+    # Compute engines
+  - psi4::psi4
+  - rdkit
+    
+    # Procedures
+  - geometric
+


### PR DESCRIPTION
## Description
Adds production environment for QCFractal managers and snowflakes. These have also been uploaded to conda so that one can run:
```
conda env create qcarchive/qcf-snowflake
```

and have a fully featured conda environment ready to go. @Lnaden will add these to the managers docs as well. `conda env create qcarchive/qcf-manager-openff` will get a fully featured OpenFF environment ready for example. @jchodera

## Status
- [ ] Changelog updated
- [x] Ready to go