### PR TITLE
Store QC libs version in DB

### DIFF
--- a/qcfractal/storage_sockets/sql_models.py
+++ b/qcfractal/storage_sockets/sql_models.py
@@ -136,6 +136,16 @@ class AccessLogORM(Base):
         Index('access_log_date', "access_date"),
     )
 
+class VersionsORM(Base):
+    __tablename__ = 'versions'
+
+    id = Column(Integer, primary_key=True)
+    created_on = Column(DateTime, default=datetime.datetime.utcnow)
+    elemental_version = Column(String, nullable=False)
+    fractal_version = Column(String, nullable=False)
+    engine_version = Column(String)
+
+
 class KVStoreORM(Base):
     """TODO: rename to """
     __tablename__ = "kv_store"


### PR DESCRIPTION
## Description
Save in DB the versions of QCElemental and QCFractal that created the DB

## Todos
Get the libraries version in the right place.
Use the returned json when needed to compare against current ones.

## Status
- [x] Ready to go