### PR TITLE
Manager settings QOL Update: Names

### DIFF
--- a/docs/qcfractal/source/managers.rst
+++ b/docs/qcfractal/source/managers.rst
@@ -80,9 +80,9 @@ Server running on that cluster, and using the SLURM partition ``default``, save 
 
     common:
      adapter: dask
-     ntasks: 1
-     ncores: 1
-     memory: 8
+     tasks_per_job: 1
+     cores_per_job: 1
+     memory_per_job: 8
 
     cluster:
      scheduler: slurm
@@ -116,18 +116,20 @@ help block.
     $ qcfractal-manager --help
 
     usage: qcfractal-manager [-h] [--config-file CONFIG_FILE] [--adapter ADAPTER]
-                         [--ntasks NTASKS] [--ncores NCORES] [--memory MEMORY]
-                         [--scratch-directory SCRATCH_DIRECTORY] [-v]
-                         [--fractal-uri FRACTAL_URI] [-u USERNAME]
-                         [-p PASSWORD] [--verify VERIFY]
-                         [--max-tasks MAX_TASKS] [--manager-name MANAGER_NAME]
-                         [--queue-tag QUEUE_TAG]
-                         [--log-file-prefix LOG_FILE_PREFIX]
-                         [--update-frequency UPDATE_FREQUENCY] [--test]
-                         [--ntests NTESTS]
+                             [--tasks_per_job TASKS_PER_JOB]
+                             [--cores_per_job CORES_PER_JOB]
+                             [--memory_per_job MEMORY_PER_JOB]
+                             [--scratch-directory SCRATCH_DIRECTORY] [-v]
+                             [--fractal-uri FRACTAL_URI] [-u USERNAME]
+                             [-p PASSWORD] [--verify VERIFY]
+                             [--max-tasks MAX_TASKS] [--manager-name MANAGER_NAME]
+                             [--queue-tag QUEUE_TAG]
+                             [--log-file-prefix LOG_FILE_PREFIX]
+                             [--update-frequency UPDATE_FREQUENCY] [--test]
+                             [--ntests NTESTS] [--schema]
 
     A CLI for a QCFractal QueueManager with a ProcessPoolExecutor, Dask, or Parsl
-    backend. The Dask and Parsl backends *require* a config file due to the
+    backend. The Dask and Parsl backends *requires* a config file due to the
     complexity of its setup. If a config file is specified, the remaining options
     serve as CLI overwrites of the config.
 
@@ -138,10 +140,13 @@ help block.
     Common Adapter Settings:
       --adapter ADAPTER     The backend adapter to use, currently only {'dask',
                             'parsl', 'pool'} are valid.
-      --ntasks NTASKS       The number of simultaneous tasks for the executor to
+      --tasks_per_job TASKS_PER_JOB
+                            The number of simultaneous tasks for the executor to
                             run, resources will be divided evenly.
-      --ncores NCORES       The number of process for the executor
-      --memory MEMORY       The total amount of memory on the system in GB
+      --cores_per_job CORES_PER_JOB
+                            The number of process for the executor
+      --memory_per_job MEMORY_PER_JOB
+                            The total amount of memory on the system in GB
       --scratch-directory SCRATCH_DIRECTORY
                             Scratch directory location
       -v, --verbose         Increase verbosity of the logger.
@@ -159,6 +164,7 @@ help block.
     QueueManager settings:
       --max-tasks MAX_TASKS
                             Maximum number of tasks to hold at any given time.
+                            Generally should not be set.
       --manager-name MANAGER_NAME
                             The name of the manager to start
       --queue-tag QUEUE_TAG
@@ -176,6 +182,7 @@ help block.
                             config file and exit. This will always show the most
                             up-to-date schema. It will be presented in a JSON-like
                             format.
+
 
 
 Terminology

--- a/docs/qcfractal/source/managers.rst
+++ b/docs/qcfractal/source/managers.rst
@@ -118,16 +118,16 @@ help block.
 
     usage: qcfractal-manager [-h] [--config-file CONFIG_FILE] [--adapter ADAPTER]
                              [--tasks_per_worker TASKS_PER_WORKER]
-                             [--cores_per_worker CORES_PER_WORKER]
-                             [--memory_per_worker MEMORY_PER_WORKER]
+                             [--cores-per-worker CORES_PER_WORKER]
+                             [--memory-per-worker MEMORY_PER_WORKER]
                              [--scratch-directory SCRATCH_DIRECTORY] [-v]
                              [--fractal-uri FRACTAL_URI] [-u USERNAME]
                              [-p PASSWORD] [--verify VERIFY]
                              [--manager-name MANAGER_NAME] [--queue-tag QUEUE_TAG]
                              [--log-file-prefix LOG_FILE_PREFIX]
                              [--update-frequency UPDATE_FREQUENCY]
-                             [--max-tasks MAX_TASKS] [--test] [--ntests NTESTS]
-                             [--schema]
+                             [--max-queued-tasks MAX_QUEUED_TASKS] [--test]
+                             [--ntests NTESTS] [--schema]
 
     A CLI for a QCFractal QueueManager with a ProcessPoolExecutor, Dask, or Parsl
     backend. The Dask and Parsl backends *requires* a config file due to the
@@ -144,9 +144,9 @@ help block.
       --tasks_per_worker TASKS_PER_WORKER
                             The number of simultaneous tasks for the executor to
                             run, resources will be divided evenly.
-      --cores_per_worker CORES_PER_WORKER
-                            The number of process for each executor's workers
-      --memory_per_worker MEMORY_PER_WORKER
+      --cores-per-worker CORES_PER_WORKER
+                            The number of process for each executor's Workers
+      --memory-per-worker MEMORY_PER_WORKER
                             The total amount of memory on the system in GB
       --scratch-directory SCRATCH_DIRECTORY
                             Scratch directory location
@@ -171,7 +171,7 @@ help block.
                             The path prefix of the logfile to write to.
       --update-frequency UPDATE_FREQUENCY
                             The frequency in seconds to check for complete tasks.
-      --max-tasks MAX_TASKS
+      --max-queued-tasks MAX_QUEUED_TASKS
                             Maximum number of tasks to hold at any given time.
                             Generally should not be set.
 

--- a/docs/qcfractal/source/managers.rst
+++ b/docs/qcfractal/source/managers.rst
@@ -1,26 +1,26 @@
 Fractal Queue Managers
 ======================
 
-Queue Managers are the processes which interface with the Fractal Server and
+Queue Managers are the processes which interface with the Fractal :term:`Server` and
 clusters, supercomputers, and cloud resources to execute the tasks in the
-Fractal Server. These managers pull compute :term:`tasks<Task>` from the
-server, and then pass them to various distributed back ends for computation
-for a variety of different needs. The architecture of the Fractal Server
+Fractal :term:`Server`. These managers pull compute :term:`tasks<Task>` from the
+:term:`Server`, and then pass them to various distributed back ends for computation
+for a variety of different needs. The architecture of the Fractal :term:`Server`
 allows many managers to be created in multiple physical locations. Currently,
-QCFractal supports the following:
+Fractal supports the following:
 
 - `Pool` - A python `ProcessPoolExecutor` for computing tasks on a single machine (or node).
 - `Dask <http://dask.pydata.org/en/latest/docs.html>`_ - A graph-based workflow engine for laptops and small clusters.
 - `Parsl <http://parsl-project.org>`_ - High-performance workflows.
 - `Fireworks <https://materialsproject.github.io/fireworks/>`_ - A asynchronous Mongo-based distributed queuing system.
 
-These backends allow QCFractal to be incredibly elastic in utilized
+These backends allow Fractal to be incredibly elastic in utilized
 computational resources, scaling from a single laptop to thousands of nodes on
 physically separate hardware. Our end goal is to be able to setup a manager at
 a physical site and allow it to scale up and down as its task queue requires
 and execute compute over long periods of time (months) without intervention.
 
-The basic setup of the Queue Managers and how they interact with the :term:`Server` is as follows:
+The basic setup of the Queue :term:`Managers <Manager>` and how they interact with the :term:`Server` is as follows:
 
 .. image:: media/QCQuManagerBasic.png
    :width: 800px
@@ -30,9 +30,10 @@ The basic setup of the Queue Managers and how they interact with the :term:`Serv
 In this, multiple :term:`managers <Manager>` talk to a central :term:`Fractal Server<Server>` and deploy
 :term:`tasks<Task>` to different compute resources based on availability, physical location, and :term:`tags<Tag>`.
 
-The main goals of the Queue Manager is to reduce the user's level of expertise needed to start compute with Fractal and,
-more importantly, to need as little manual intervention as possible to have persistent compute. Ideally, you start
-the manager in a background process, leave it be while it checks in with the Fractal Server from time to time
+The main goals of the Queue :term:`Manager` is to reduce the user's level of expertise needed to start compute with
+Fractal and, more importantly, to need as little manual intervention as possible to have persistent compute. Ideally,
+you start the :term:`Manager` in a background process, leave it be while it checks in with the
+:term:`Fractal Server<Server>` from time to time
 to get :term:`tasks<Task>`, and pushes/pulls :term:`tasks<Task>` from the distributed :term:`Adapter` as need be.
 
 The communication between each of the layers involved, and the mechanism by which they communicate is summarized in
@@ -47,7 +48,7 @@ The different levels of communication are all established automatically once the
 this image shows how information flow from point-to-point.
 
 The manager itself is a fairly lightweight process and consumes very little CPU power on its own. You should talk with
-your sysadmin before running this on a head node, but the Queue Manager itself will consume
+your sysadmin before running this on a head node, but the Queue :term:`Manager` itself will consume
 less than 1% CPU we have found and virtually no RAM.
 
 If you are interested in the more detailed workings of the :term:`Manager`, please see the :doc:`managers_detailed`
@@ -80,9 +81,9 @@ Server running on that cluster, and using the SLURM partition ``default``, save 
 
     common:
      adapter: dask
-     tasks_per_job: 1
-     cores_per_job: 1
-     memory_per_job: 8
+     tasks_per_worker: 1
+     cores_per_worker: 1
+     memory_per_worker: 8
 
     cluster:
      scheduler: slurm
@@ -116,17 +117,17 @@ help block.
     $ qcfractal-manager --help
 
     usage: qcfractal-manager [-h] [--config-file CONFIG_FILE] [--adapter ADAPTER]
-                             [--tasks_per_job TASKS_PER_JOB]
-                             [--cores_per_job CORES_PER_JOB]
-                             [--memory_per_job MEMORY_PER_JOB]
+                             [--tasks_per_worker TASKS_PER_WORKER]
+                             [--cores_per_worker CORES_PER_WORKER]
+                             [--memory_per_worker MEMORY_PER_WORKER]
                              [--scratch-directory SCRATCH_DIRECTORY] [-v]
                              [--fractal-uri FRACTAL_URI] [-u USERNAME]
                              [-p PASSWORD] [--verify VERIFY]
-                             [--max-tasks MAX_TASKS] [--manager-name MANAGER_NAME]
-                             [--queue-tag QUEUE_TAG]
+                             [--manager-name MANAGER_NAME] [--queue-tag QUEUE_TAG]
                              [--log-file-prefix LOG_FILE_PREFIX]
-                             [--update-frequency UPDATE_FREQUENCY] [--test]
-                             [--ntests NTESTS] [--schema]
+                             [--update-frequency UPDATE_FREQUENCY]
+                             [--max-tasks MAX_TASKS] [--test] [--ntests NTESTS]
+                             [--schema]
 
     A CLI for a QCFractal QueueManager with a ProcessPoolExecutor, Dask, or Parsl
     backend. The Dask and Parsl backends *requires* a config file due to the
@@ -140,12 +141,12 @@ help block.
     Common Adapter Settings:
       --adapter ADAPTER     The backend adapter to use, currently only {'dask',
                             'parsl', 'pool'} are valid.
-      --tasks_per_job TASKS_PER_JOB
+      --tasks_per_worker TASKS_PER_WORKER
                             The number of simultaneous tasks for the executor to
                             run, resources will be divided evenly.
-      --cores_per_job CORES_PER_JOB
-                            The number of process for the executor
-      --memory_per_job MEMORY_PER_JOB
+      --cores_per_worker CORES_PER_WORKER
+                            The number of process for each executor's workers
+      --memory_per_worker MEMORY_PER_WORKER
                             The total amount of memory on the system in GB
       --scratch-directory SCRATCH_DIRECTORY
                             Scratch directory location
@@ -158,13 +159,10 @@ help block.
                             FractalServer username
       -p PASSWORD, --password PASSWORD
                             FractalServer password
-      --verify VERIFY       Do verify the SSL certificate, turn off for servers
-                            with custom SSL certificiates.
+      --verify VERIFY       Do verify the SSL certificate, leave off (unset) for
+                            servers with custom SSL certificates.
 
     QueueManager settings:
-      --max-tasks MAX_TASKS
-                            Maximum number of tasks to hold at any given time.
-                            Generally should not be set.
       --manager-name MANAGER_NAME
                             The name of the manager to start
       --queue-tag QUEUE_TAG
@@ -173,6 +171,9 @@ help block.
                             The path prefix of the logfile to write to.
       --update-frequency UPDATE_FREQUENCY
                             The frequency in seconds to check for complete tasks.
+      --max-tasks MAX_TASKS
+                            Maximum number of tasks to hold at any given time.
+                            Generally should not be set.
 
     Optional Settings:
       --test                Boot and run a short test suite to validate setup
@@ -220,7 +221,8 @@ of. However, if you feel something is missing, let us know!
         LSF, SGE, etc. This, by itself, does not have any concept of the :term:`Manager` or even the :term:`Adapter`
         as both interface with *it*, not the other way around. Individual users' clusters may, and almost always,
         have a different configuration, even amongst the same governing software. Therefore, no two Schedulers
-        should be treated the same.
+        should be treated the same. In many cases, the :term:`Adapter` submits a :term:`Job` to the Scheduler with
+        instructions of how the :term:`Job` should start a :term:`Worker` once it is allocated and booted.
 
     Job
         The specific allocation of resources (CPU, Memory, wall clock, etc) provided by the :term:`Scheduler` to the
@@ -228,7 +230,10 @@ of. However, if you feel something is missing, let us know!
         ``sbatch``), however, it is more apt to think of the resources allocated in this way as "resources to be
         distributed to the :term:`Task` by the :term:`Adapter`". Although a user running a :term:`Manager` will likely
         not directly interact with these, its important to track as these are what your :term:`Scheduler` is actually
-        running and your allocations will be charged by.
+        running and your allocations will be charged by. At least (and usually only) one :term:`Worker` will be
+        deployed to a :term:`Job` from the :term:`Adapter` to handle incoming :term:`Task`\s. Once the :term:`Worker`
+        lands, it will report back to the :term:`Adapter` and all communications happen between those two objects; the
+        Job simply runs until either the :term:`Adapter` stops it, or the :term:`Scheduler` ends it.
 
     Task
         A single unit of compute as defined by the Fractal :term:`Server` (i.e. the item which comes from the Task
@@ -237,10 +242,12 @@ of. However, if you feel something is missing, let us know!
 
     Worker
         The process executed from the :term:`Adapter` on the allocated hardware inside a :term:`Job`. This process
-        receives the :term:`tasks<Task>` tracked by the :term:`Adapter` and is responsible for their execution. There may
-        be multiple Workers within a single :term:`Job`, and the resources allocated for said :term:`Job` will be
-        distributed by the :term:`Adapter` using whatever the :term:`Adapter` is configured to do. This is often uniform,
-        but not always.
+        receives the :term:`tasks<Task>` tracked by the :term:`Adapter` and is responsible for their execution. The
+        Worker itself is responsible for consuming the resources of the :term:`Job` and distributing them to handle
+        concurrent :term:`tasks<Task>`. In most cases, there will be 1 Worker per :term:`Job`, but there are some
+        uncommon instances where this isn't true. You can safely assume the 1 Worker/:term:`Job` case for Fractal
+        usage. Resources allocated for the Worker will be distributed by the :term:`Adapter`\s configuration,
+        but is usually uniform.
 
     Server
         The Fractal Server that the :term:`Manager` connects to. This is the source of the

--- a/docs/qcfractal/source/managers_faq.rst
+++ b/docs/qcfractal/source/managers_faq.rst
@@ -16,7 +16,7 @@ Turn on ``verbose`` mode, either add the ``-v`` flag to the CLI, or set the
 ``common.verbose`` to ``True`` in the YAML file. Setting this flag will produce
 much more detailed information. This sets the loggers to ``DEBUG`` level.
 
-In the future, we may allow for different levels of verbosity, but for now there is
+In the future, we may allow for different levels of increased verbosity, but for now there is
 only the one level.
 
 Can I start more than one Manager at a time?
@@ -26,6 +26,8 @@ Yes. This is often done if you would like to create multiple :term:`task<Task>` 
 have different resource requirements or spin up managers that can access
 different resources. Check with your cluster administrators though to find out
 their policy on multiple processes running on the clusters head node.
+
+You can reuse the same config file, just invoke the CLI again.
 
 Can I connect to a Fractal Server besides MolSSI's?
 +++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -139,6 +141,12 @@ This problem is obfuscated by the fact that
 incomplete Conda configuration. **We strongly recommend you do not try setting the absolute Python path** in your
 scripts to get around this, and instead try to ``source`` the Conda ``profile.d`` first.
 
+Other variants:
+
+- "Tests from one program pass, but others don't"
+- "I get errors about unable to find program, but its installed"
+- "I get path and/or import errors when testing"
+
 
 My jobs appear to be running, but only one (or few) workers are starting
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -148,5 +156,7 @@ a few things may be happening.
 
 - If jobs are completing very fast, the :term:`Adapter` may not feel like it needs to start more
   :term:`workers<Worker>`, which is fine.
-- Check your ``manger.max_tasks`` arg to pull more :term:`tasks<Task>` from the :term:`Server` to fill
-  the jobs you have started.
+- (Not recommended, use for debug only) Check your ``manger.max_tasks`` arg to pull more :term:`tasks<Task>`
+  from the :term:`Server` to fill the jobs you have started. This option is usually automatically calculated based on
+  your ``common.tasks_per_worker`` and ``cluster.max_cluster_jobs`` to keep all :term:`workers<Worker>` busy and
+  still have a buffer.

--- a/docs/qcfractal/source/managers_faq.rst
+++ b/docs/qcfractal/source/managers_faq.rst
@@ -139,7 +139,16 @@ This problem is obfuscated by the fact that
 :term:`workers<Worker>` such as Dask Workers can still start initially despite being a Python code themselves. Many
 :term:`adapters<Adapter>` will start their programs using the absolute Python binary path which gets around the
 incomplete Conda configuration. **We strongly recommend you do not try setting the absolute Python path** in your
-scripts to get around this, and instead try to ``source`` the Conda ``profile.d`` first.
+scripts to get around this, and instead try to ``source`` the Conda ``profile.d`` first. For example, you might
+need to add something like this to your YAML file (change paths/environment names as needed):
+
+.. code-block:: yaml
+
+    cluster:
+        task_startup_commands:
+            - source ~/miniconda3/etc/profile.d/conda.sh
+            - conda activate qcfractal
+
 
 Other variants:
 
@@ -156,7 +165,7 @@ a few things may be happening.
 
 - If jobs are completing very fast, the :term:`Adapter` may not feel like it needs to start more
   :term:`workers<Worker>`, which is fine.
-- (Not recommended, use for debug only) Check your ``manger.max_tasks`` arg to pull more :term:`tasks<Task>`
+- (Not recommended, use for debug only) Check your ``manger.max_queued_tasks`` arg to pull more :term:`tasks<Task>`
   from the :term:`Server` to fill the jobs you have started. This option is usually automatically calculated based on
-  your ``common.tasks_per_worker`` and ``cluster.max_cluster_jobs`` to keep all :term:`workers<Worker>` busy and
+  your ``common.tasks_per_worker`` and ``common.max_workers`` to keep all :term:`workers<Worker>` busy and
   still have a buffer.

--- a/docs/qcfractal/source/managers_samples.rst
+++ b/docs/qcfractal/source/managers_samples.rst
@@ -26,9 +26,9 @@ file:
 
     common:
      adapter: dask
-     tasks_per_job: 1
-     cores_per_job: 1
-     memory_per_job: 8
+     tasks_per_worker: 1
+     cores_per_worker: 1
+     memory_per_worker: 8
 
     server:
      fractal_uri: "localhost:7777"
@@ -50,18 +50,18 @@ Mutiple Tasks, 1 Cluster Job
 ----------------------------
 
 This example starts a max of 1 cluster :term:`Job`, but multiple :term:`tasks<Task>`. The hardware will be
-consumed uniformly by each :term:`Worker`. With 8 cores, 20 GB of memory, and 4 tasks; each :term:`Worker` will get
-2 core and 5 GB of memory to work with. We set ``cluster.max_cluster_jobs`` to 1 to limit the number
-of jobs which can be started. Since this is SLURM, the ``squeue`` information will show this
+consumed uniformly by the :term:`Worker`. With 8 cores, 20 GB of memory, and 4 tasks; the :term:`Worker` will provide
+2 cores and 5 GB of memory to compute each :term:`Task`. We set ``cluster.max_cluster_jobs`` to 1 to limit the number
+of :term:`jobs <Job>` which can be started. Since this is SLURM, the ``squeue`` information will show this
 user has run 1 ``sbatch`` jobs which requested 4 cores and 20 GB of memory.
 
 .. code-block:: yaml
 
     common:
      adapter: dask
-     tasks_per_job: 4
-     cores_per_job: 8
-     memory_per_job: 20
+     tasks_per_worker: 4
+     cores_per_worker: 8
+     memory_per_worker: 20
 
     server:
      fractal_uri: "localhost:7777"
@@ -84,15 +84,16 @@ Testing the Manager Setup
 -------------------------
 
 This will test the :term:`Manager` to make sure its setup correctly, and does not need to
-connect to the :term:`Server`, and therefore does not need a ``server`` block.
+connect to the :term:`Server`, and therefore does not need a ``server`` block. It will still however submit
+:term:`jobs <Job>`.
 
 .. code-block:: yaml
 
     common:
      adapter: dask
-     tasks_per_job: 2
-     cores_per_job: 4
-     memory_per_job: 10
+     tasks_per_worker: 2
+     cores_per_worker: 4
+     memory_per_worker: 10
 
     manager:
      manager_name: "TestBox_NeverSeen_OnServer"
@@ -117,17 +118,20 @@ Sun Grid Engine (SGE) cluster, start a conda environment, and load a module.
 An important note about this one, we have now set ``max_cluster_jobs`` to something larger than 1.
 Each :term:`Job` will still request 4 cores and 256 GB of memory to be evenly distributed between the
 4 :term:`tasks<Task>`, however, the :term:`Adapter` will **attempt to start 5 independent** :term:`jobs<Job>`, for a
-total of 80 cores, 1.280 TB of memory, distributed over 20 :term:`workers<Worker>`. If the :term:`Scheduler` does not
+total of 80 cores, 1.280 TB of memory, distributed over 5 :term:`workers<Worker>` collectively running 20
+:term:`tasks<Task>`. If the :term:`Scheduler` does not
 allow all of those :term:`jobs<Job>` to start, whether due to lack of resources or user limits, the
-:term:`Adapter` can still start fewer :term:`jobs<Job>`, each with 16 cores, 256 GB of memory.
+:term:`Adapter` can still start fewer :term:`jobs<Job>`, each with 16 cores and 256 GB of memory, but :term:`Task`
+concurrency will change by blocks of 4 since the :term:`Worker` in each :term:`Job` is configured to handle 4
+:term:`Tasks` each.
 
 .. code-block:: yaml
 
     common:
      adapter: dask
-     tasks_per_job: 4
-     cores_per_job: 16
-     memory_per_job: 256
+     tasks_per_worker: 4
+     cores_per_worker: 16
+     memory_per_worker: 256
 
     server:
      fractal_uri: localhost:7777
@@ -156,16 +160,18 @@ Additional Scheduler Flags
 A :term:`Scheduler` may ask you to set additional flags (or you might want to) when submitting a :term:`Job`.
 Maybe its a Sys. Admin enforced rule, maybe you want to pull from a specific account, or set something not
 interpreted for you in the :term:`Manager` or :term:`Adapter` (do tell us though if this is the case). This
-example sets additional flags on a PBS cluster such that the final :term:`Job` file will have ``#PBS {my headers}``.
+example sets additional flags on a PBS cluster such that the final :term:`Job` launch file will have
+``#PBS {my headers}``.
+
 This example also uses Parsl and sets a scratch directory.
 
 .. code-block:: yaml
 
     common:
      adapter: parsl
-     tasks_per_job: 1
-     cores_per_job: 6
-     memory_per_job: 64
+     tasks_per_worker: 1
+     cores_per_worker: 6
+     memory_per_worker: 64
      scratch_directory: "$TMPDIR"
 
     server:

--- a/docs/qcfractal/source/managers_samples.rst
+++ b/docs/qcfractal/source/managers_samples.rst
@@ -26,9 +26,9 @@ file:
 
     common:
      adapter: dask
-     ntasks: 1
-     ncores: 1
-     memory: 8
+     tasks_per_job: 1
+     cores_per_job: 1
+     memory_per_job: 8
 
     server:
      fractal_uri: "localhost:7777"
@@ -59,9 +59,9 @@ user has run 1 ``sbatch`` jobs which requested 4 cores and 20 GB of memory.
 
     common:
      adapter: dask
-     ntasks: 4
-     ncores: 8
-     memory: 20
+     tasks_per_job: 4
+     cores_per_job: 8
+     memory_per_job: 20
 
     server:
      fractal_uri: "localhost:7777"
@@ -90,9 +90,9 @@ connect to the :term:`Server`, and therefore does not need a ``server`` block.
 
     common:
      adapter: dask
-     ntasks: 2
-     ncores: 4
-     memory: 10
+     tasks_per_job: 2
+     cores_per_job: 4
+     memory_per_job: 10
 
     manager:
      manager_name: "TestBox_NeverSeen_OnServer"
@@ -125,9 +125,9 @@ allow all of those :term:`jobs<Job>` to start, whether due to lack of resources 
 
     common:
      adapter: dask
-     ntasks: 4
-     ncores: 16
-     memory: 256
+     tasks_per_job: 4
+     cores_per_job: 16
+     memory_per_job: 256
 
     server:
      fractal_uri: localhost:7777
@@ -163,9 +163,9 @@ This example also uses Parsl and sets a scratch directory.
 
     common:
      adapter: parsl
-     ntasks: 1
-     ncores: 6
-     memory: 64
+     tasks_per_job: 1
+     cores_per_job: 6
+     memory_per_job: 64
      scratch_directory: "$TMPDIR"
 
     server:

--- a/docs/qcfractal/source/managers_samples.rst
+++ b/docs/qcfractal/source/managers_samples.rst
@@ -51,9 +51,9 @@ Mutiple Tasks, 1 Cluster Job
 
 This example starts a max of 1 cluster :term:`Job`, but multiple :term:`tasks<Task>`. The hardware will be
 consumed uniformly by the :term:`Worker`. With 8 cores, 20 GB of memory, and 4 tasks; the :term:`Worker` will provide
-2 cores and 5 GB of memory to compute each :term:`Task`. We set ``cluster.max_cluster_jobs`` to 1 to limit the number
-of :term:`jobs <Job>` which can be started. Since this is SLURM, the ``squeue`` information will show this
-user has run 1 ``sbatch`` jobs which requested 4 cores and 20 GB of memory.
+2 cores and 5 GB of memory to compute each :term:`Task`. We set ``common.max_workers`` to 1 to limit the number
+of :term:`Workers<Worker>` and :term:`Jobs <Job>` which can be started. Since this is SLURM, the ``squeue`` information
+will show this user has run 1 ``sbatch`` jobs which requested 4 cores and 20 GB of memory.
 
 .. code-block:: yaml
 
@@ -62,6 +62,7 @@ user has run 1 ``sbatch`` jobs which requested 4 cores and 20 GB of memory.
      tasks_per_worker: 4
      cores_per_worker: 8
      memory_per_worker: 20
+     max_workers: 1
 
     server:
      fractal_uri: "localhost:7777"
@@ -74,7 +75,6 @@ user has run 1 ``sbatch`` jobs which requested 4 cores and 20 GB of memory.
     cluster:
      scheduler: slurm
      walltime: "72:00:00"
-     max_cluster_jobs: 1
 
     dask:
      queue: default
@@ -115,10 +115,10 @@ Suppose there are some commands you want to run *before* starting the :term:`Wor
 environment, or setting some environment variables. This lets you specify that. For this, we will run on a
 Sun Grid Engine (SGE) cluster, start a conda environment, and load a module.
 
-An important note about this one, we have now set ``max_cluster_jobs`` to something larger than 1.
+An important note about this one, we have now set ``max_workers`` to something larger than 1.
 Each :term:`Job` will still request 4 cores and 256 GB of memory to be evenly distributed between the
 4 :term:`tasks<Task>`, however, the :term:`Adapter` will **attempt to start 5 independent** :term:`jobs<Job>`, for a
-total of 80 cores, 1.280 TB of memory, distributed over 5 :term:`workers<Worker>` collectively running 20
+total of 80 cores, 1.280 TB of memory, distributed over 5 :term:`Workers<Worker>` collectively running 20 concurrent
 :term:`tasks<Task>`. If the :term:`Scheduler` does not
 allow all of those :term:`jobs<Job>` to start, whether due to lack of resources or user limits, the
 :term:`Adapter` can still start fewer :term:`jobs<Job>`, each with 16 cores and 256 GB of memory, but :term:`Task`
@@ -132,6 +132,7 @@ concurrency will change by blocks of 4 since the :term:`Worker` in each :term:`J
      tasks_per_worker: 4
      cores_per_worker: 16
      memory_per_worker: 256
+     max_workers: 5
 
     server:
      fractal_uri: localhost:7777
@@ -148,7 +149,6 @@ concurrency will change by blocks of 4 since the :term:`Worker` in each :term:`J
          - module load mpi/gcc/openmpi-1.6.4
          - conda activate qcfmanager
      walltime: "71:00:00"
-     max_cluster_jobs: 5
 
     dask:
      queue: free64
@@ -172,6 +172,7 @@ This example also uses Parsl and sets a scratch directory.
      tasks_per_worker: 1
      cores_per_worker: 6
      memory_per_worker: 64
+     max_workers: 5
      scratch_directory: "$TMPDIR"
 
     server:
@@ -181,11 +182,9 @@ This example also uses Parsl and sets a scratch directory.
      verify: False
 
     manager:
-     max_tasks: 10
      manager_name: "PBS_Parsl_MyPIGroupAccount_Manger"
 
     cluster:
-     max_cluster_jobs: 5
      node_exclusivity: False
      scheduler: pbs
      scheduler_options:

--- a/docs/qcfractal/source/setup_compute.rst
+++ b/docs/qcfractal/source/setup_compute.rst
@@ -139,7 +139,7 @@ Using the Python API
     workflow_client = distributed.Client("tcp://10.0.1.40:8786")
 
     ncores = 4
-    memory_per_task = 2
+    mem = 2
 
     # Build a manager
     manager = QueueManager(fractal_client, workflow_client, cores_per_task=ncores, memory_per_task=mem)

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -54,9 +54,9 @@ class CommonManagerSettings(BaseSettings):
     )
     tasks_per_worker: int = Schema(
         1,
-        description="Number of concurrent tasks to run *per worker* which is executed. Total number of concurrent "
-                    "tasks is this value times cluster.max_cluster_jobs, assuming the hardware is available. With the "
-                    "pool adapter, and/or if cluster.max_cluster_jobs=1, this is the number of concurrent jobs."
+        description="Number of concurrent tasks to run *per Worker* which is executed. Total number of concurrent "
+                    "tasks is this value times max_workers, assuming the hardware is available. With the "
+                    "pool adapter, and/or if max_workers=1, tasks_per_worker *is* the number of concurrent tasks."
     )
     cores_per_worker: int = Schema(
         qcng.config.get_global("ncores"),
@@ -71,8 +71,19 @@ class CommonManagerSettings(BaseSettings):
         description="Amount of memory (in GB) to be consumed and distributed over the tasks_per_worker. This memory is "
                     "divided evenly, but is ultimately at the control of the adapter. Engine will only allow each of "
                     "its calls to consume memory_per_worker/tasks_per_worker of memory. Total memory consumed by this "
-                    "manager at any one time is this value times cluster.max_cluster_jobs. The default value is read "
+                    "manager at any one time is this value times max_workers. The default value is read "
                     "from the amount of memory detected on the system you are executing on.",
+        gt=0
+    )
+    max_workers: int = Schema(
+        1,
+        description="The maximum number of Workers which are allowed to be run at the same time. The total number of "
+                    "concurrent tasks will maximize at this quantity times tasks_per_worker."
+                    "The total number "
+                    "of Jobs on a cluster which will be started is equal to this parameter in most cases, and should "
+                    "be assumed 1 Worker per Job. Any exceptions to this will be documented. "
+                    "In node exclusive mode this is equivalent to the maximum number of nodes which you will consume. "
+                    "This must be a positive, non zero integer.",
         gt=0
     )
     scratch_directory: Optional[str] = Schema(
@@ -135,7 +146,7 @@ class QueueManagerSettings(BaseSettings):
     manager_name: str = Schema(
         "unlabeled",
         description="Name of this scheduler to present to the Fractal Server. Descriptive names help the server "
-                    "identify you and help with debugging."
+                    "identify the manager resource and assists with debugging."
     )
     queue_tag: Optional[str] = Schema(
         None,
@@ -172,11 +183,11 @@ class QueueManagerSettings(BaseSettings):
                     "number times the number of found quantum chemistry programs. Does nothing if `test` is False",
         gt=0
     )
-    max_tasks: Optional[int] = Schema(
+    max_queued_tasks: Optional[int] = Schema(
         None,
         description="Generally should not be set. Number of tasks to pull from the Fractal Server to keep locally at "
                     "all times. If `None`, this is automatically computed as "
-                    "`ciel(common.tasks_per_worker*cluster.max_cluster_jobs*1.2) + 1`. As tasks are completed, the "
+                    "`ceil(common.tasks_per_worker*common.max_workers*1.2) + 1`. As tasks are completed, the "
                     "local pool is filled back up to this value. These tasks will all attempt to be run concurrently, "
                     "but concurrent tasks are limited by number of cluster jobs and tasks per job. Pulling too many of "
                     "these can result in under-utilized managers from other sites and result in less FIFO returns. As "
@@ -209,15 +220,6 @@ class ClusterSettings(BaseSettings):
     the options here are things like wall time (per job), which Scheduler your cluster has (like PBS or SLURM),
     etc. No additional options are allowed here.
     """
-    max_cluster_jobs: int = Schema(
-        1,
-        description="The maximum number of cluster jobs which are allowed to be run at the same time. The total number "
-                    "of workers which can be started (and thus simultaneous Fractal tasks which can be run) is equal "
-                    "to this parameter in most cases, and should be assumed 1 Worker per Job. "
-                    "In exclusive mode this is equivalent to the maximum number of nodes which you will consume. "
-                    "This must be a positive, non zero integer.",
-        gt=0
-    )
     node_exclusivity: bool = Schema(
         False,
         description="Run your cluster jobs in node-exclusivity mode. This option may not be available to all scheduler "
@@ -238,9 +240,9 @@ class ClusterSettings(BaseSettings):
     )
     task_startup_commands: List[str] = Schema(
         [],
-        description="Additional commands to be run before starting the workers and the task distribution. This can "
+        description="Additional commands to be run before starting the Workers and the task distribution. This can "
                     "include commands needed to start things like conda environments or setting environment variables "
-                    "before executing the workers. These commands are executed first before any of the distributed "
+                    "before executing the Workers. These commands are executed first before any of the distributed "
                     "commands run and are added to the batch scripts as individual commands per entry, verbatim."
     )
     walltime: str = Schema(
@@ -248,16 +250,16 @@ class ClusterSettings(BaseSettings):
         description="Wall clock time of each cluster job started. Presented as a string in HH:MM:SS form, but your "
                     "cluster may have a different structural syntax. This number should be set high as there should "
                     "be a number of Fractal tasks which are run for each submitted cluster job. Ideally, the job "
-                    "will start, the worker will land, and the worker will crunch through as many tasks as it can; "
-                    "meaning the job which has a worker in it must continue existing to minimize time spend "
+                    "will start, the Worker will land, and the Worker will crunch through as many tasks as it can; "
+                    "meaning the job which has a Worker in it must continue existing to minimize time spend "
                     "redeploying Workers."
     )
     adaptive: AdaptiveCluster = Schema(
         AdaptiveCluster.adaptive,
-        description="Whether or not to use adaptive scaling of workers or not. If set to 'static', a fixed number of "
-                    "workers will be started (and likely *NOT* restarted when the wall clock is reached). When set to "
+        description="Whether or not to use adaptive scaling of Workers or not. If set to 'static', a fixed number of "
+                    "Workers will be started (and likely *NOT* restarted when the wall clock is reached). When set to "
                     "'adaptive' (the default), the distributed engine will try to adaptively scale the number of "
-                    "workers based on tasks in the queue. This is str instead of bool type variable in case more "
+                    "Workers based on tasks in the queue. This is str instead of bool type variable in case more "
                     "complex adaptivity options are added in the future."
     )
 
@@ -315,7 +317,7 @@ class DaskQueueSettings(SettingsBlocker):
         description="Name of the network adapter to use as communication between the head node and the compute node."
                     "There are oddities of this when the head node and compute node use different ethernet adapter "
                     "names and we have not figured out exactly which combination is needed between this and the "
-                    "poorly documented `ip` keyword which appears to be for workers, but not the Client."
+                    "poorly documented `ip` keyword which appears to be for Workers, but not the Client."
     )
     extra: Optional[List[str]] = Schema(
         None,
@@ -337,7 +339,7 @@ cli_utils.doc_formatter(DaskQueueSettings)
 
 class ParslExecutorSettings(SettingsBlocker):
     """
-    Settings for the Parsl Executor class. This serves as the primary mechanism for distributing workers to jobs.
+    Settings for the Parsl Executor class. This serves as the primary mechanism for distributing Workers to jobs.
     In most cases, you will not need to set any of these options, as several options are automatically inferred
     from other settings. Any option set here is passed through to the HighThroughputExecutor class of Parsl.
 
@@ -354,7 +356,7 @@ class ParslExecutorSettings(SettingsBlocker):
         description="This only needs to be set in conditional cases when the head node and compute nodes use a "
                     "differently named ethernet adapter.\n\n"
                     "An address to connect to the main Parsl process which is reachable from the network in which "
-                    "workers will be running. This can be either a hostname as returned by hostname or an IP address. "
+                    "Workers will be running. This can be either a hostname as returned by hostname or an IP address. "
                     "Most login nodes on clusters have several network interfaces available, only some of which can be "
                     "reached from the compute nodes. Some trial and error might be necessary to identify what "
                     "addresses are reachable from compute nodes."
@@ -464,8 +466,8 @@ def parse_args():
         "--tasks_per_worker",
         type=int,
         help="The number of simultaneous tasks for the executor to run, resources will be divided evenly.")
-    common.add_argument("--cores_per_worker", type=int, help="The number of process for each executor's workers")
-    common.add_argument("--memory_per_worker", type=int, help="The total amount of memory on the system in GB")
+    common.add_argument("--cores-per-worker", type=int, help="The number of process for each executor's Workers")
+    common.add_argument("--memory-per-worker", type=int, help="The total amount of memory on the system in GB")
     common.add_argument("--scratch-directory", type=str, help="Scratch directory location")
     common.add_argument("-v", "--verbose", action="store_true", help="Increase verbosity of the logger.")
 
@@ -485,8 +487,8 @@ def parse_args():
     manager.add_argument("--queue-tag", type=str, help="The queue tag to pull from")
     manager.add_argument("--log-file-prefix", type=str, help="The path prefix of the logfile to write to.")
     manager.add_argument("--update-frequency", type=int, help="The frequency in seconds to check for complete tasks.")
-    manager.add_argument("--max-tasks", type=int, help="Maximum number of tasks to hold at any given time. Generally "
-                                                       "should not be set.")
+    manager.add_argument("--max-queued-tasks", type=int, help="Maximum number of tasks to hold at any given time. "
+                                                              "Generally should not be set.")
 
     # Additional args
     optional = parser.add_argument_group('Optional Settings')
@@ -517,8 +519,8 @@ def parse_args():
         "common": _build_subset(args, {"adapter", "tasks_per_worker", "cores_per_worker", "memory_per_worker",
                                        "scratch_directory", "verbose"}),
         "server": _build_subset(args, {"fractal_uri", "password", "username", "verify"}),
-        "manager": _build_subset(args, {"max_tasks", "manager_name", "queue_tag", "log_file_prefix", "update_frequency",
-                                        "test", "ntests"}),
+        "manager": _build_subset(args, {"max_queued_tasks", "manager_name", "queue_tag", "log_file_prefix",
+                                        "update_frequency", "test", "ntests"}),
         # This set is for this script only, items here should not be passed to the ManagerSettings nor any other
         # classes
         "debug": _build_subset(args, {"schema"})
@@ -707,7 +709,7 @@ def main(args=None):
         # Setup up adaption
         # Workers are distributed down to the cores through the sub-divided processes
         # Optimization may be needed
-        workers = settings.common.tasks_per_worker * settings.cluster.max_cluster_jobs
+        workers = settings.common.tasks_per_worker * settings.common.max_workers
         if settings.cluster.adaptive == AdaptiveCluster.adaptive:
             cluster.adapt(minimum=0, maximum=workers, interval="10s")
         else:
@@ -763,7 +765,7 @@ def main(args=None):
         # Create one construct to quickly merge dicts with a final check
         common_parsl_provider_construct = {
             "init_blocks": 0,  # Update this at a later time of Parsl
-            "max_blocks": settings.cluster.max_cluster_jobs,
+            "max_blocks": settings.common.max_workers,
             "walltime": settings.cluster.walltime,
             "scheduler_options": f'{provider_header} ' + f'\n{provider_header} '.join(scheduler_opts) + '\n',
             "nodes_per_block": 1,
@@ -781,7 +783,7 @@ def main(args=None):
         parsl_executor_construct = {
             "label": "QCFractal_Parsl_{}_Executor".format(settings.cluster.scheduler.title()),
             "cores_per_worker": cores_per_task,
-            "max_workers": settings.common.tasks_per_worker * settings.cluster.max_cluster_jobs,
+            "max_workers": settings.common.tasks_per_worker * settings.common.max_workers,
             "provider": provider,
             "address": address_by_hostname(),
             **settings.parsl.executor.dict(skip_defaults=True)}
@@ -797,19 +799,16 @@ def main(args=None):
 
     # Build out the manager itself
     # Compute max tasks
-    if settings.manager.max_tasks is None:
-        cluster_jobs = 1
-        if settings.cluster is not None:
-            cluster_jobs = settings.cluster.max_cluster_jobs
+    if settings.manager.max_queued_tasks is None:
         # Tasks * jobs * buffer + 1
-        max_tasks = ceil(settings.common.tasks_per_worker * cluster_jobs * 1.20) + 1
+        max_queued_tasks = ceil(settings.common.tasks_per_worker * settings.common.max_workers * 1.20) + 1
     else:
-        max_tasks = settings.manager.max_tasks
+        max_queued_tasks = settings.manager.max_queued_tasks
 
     manager = qcfractal.queue.QueueManager(
         client,
         queue_client,
-        max_tasks=max_tasks,
+        max_tasks=max_queued_tasks,
         queue_tag=settings.manager.queue_tag,
         manager_name=settings.manager.manager_name,
         update_frequency=settings.manager.update_frequency,

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -40,12 +40,12 @@ def active_server(request):
 
 @testing.mark_slow
 def test_manager_local_testing_process():
-    assert testing.run_process(["qcfractal-manager", "--adapter=pool", "--test", "--tasks_per_job=2"], **_options)
+    assert testing.run_process(["qcfractal-manager", "--adapter=pool", "--test", "--tasks_per_worker=2"], **_options)
 
 
 @testing.mark_slow
 def test_manager_executor_manager_boot(active_server):
-    args = ["qcfractal-manager", active_server.test_uri_cli, "--adapter=pool", "--tasks_per_job=2", "--verify=False"]
+    args = ["qcfractal-manager", active_server.test_uri_cli, "--adapter=pool", "--tasks_per_worker=2", "--verify=False"]
     assert testing.run_process(args, interupt_after=7, **_options)
 
 
@@ -55,8 +55,8 @@ def test_manager_executor_manager_boot_from_file(active_server, tmp_path):
     yaml_file = """
     common:
         adapter: pool
-        tasks_per_job: 4
-        cores_per_job: 4
+        tasks_per_worker: 4
+        cores_per_worker: 4
     server:
         fractal_uri: {}
         verify: False

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -40,12 +40,12 @@ def active_server(request):
 
 @testing.mark_slow
 def test_manager_local_testing_process():
-    assert testing.run_process(["qcfractal-manager", "--adapter=pool", "--test", "--ntasks=2"], **_options)
+    assert testing.run_process(["qcfractal-manager", "--adapter=pool", "--test", "--tasks_per_job=2"], **_options)
 
 
 @testing.mark_slow
 def test_manager_executor_manager_boot(active_server):
-    args = ["qcfractal-manager", active_server.test_uri_cli, "--adapter=pool", "--ntasks=2", "--verify=False"]
+    args = ["qcfractal-manager", active_server.test_uri_cli, "--adapter=pool", "--tasks_per_job=2", "--verify=False"]
     assert testing.run_process(args, interupt_after=7, **_options)
 
 
@@ -55,8 +55,8 @@ def test_manager_executor_manager_boot_from_file(active_server, tmp_path):
     yaml_file = """
     common:
         adapter: pool
-        ntasks: 4
-        ncores: 4
+        tasks_per_job: 4
+        cores_per_job: 4
     server:
         fractal_uri: {}
         verify: False


### PR DESCRIPTION
## Description

Introduces some name changes to some of the Manager options to be
more exact on what they do. The following changes are proposed:


* `ntasks` -> `tasks_per_worker`
* `ncores` -> `cores_per_worker`
* `memory` -> `memory_per_worker`
* `cluster.max_nodes` -> `common.max_workers`
    ~* This one is already in but open for discussion since no release tied to it yet~

This also changes `max_tasks` to be functionally set by default as:

`ceil(cores_per_worker * max_workers * 1.2) + 1`
~

Users can still set this, but are discouraged from doing so.

cc @ChayaSt @vtlim @j-wags as my references for you who have tried to set this up on your own.

## Questions
- Opinions on this (and any setting I didn't touch too!)

## Status
- [ ] Changelog updated
- [x] Ready to go

## Edits:

Updated names based on recent changes

2nd: Final names set, moved the max_nodes in `cluster` to `max_workers` in `common`.