### PR TITLE
0.7.0 Final Changelog

### DIFF
--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -15,7 +15,7 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
-0.7.0 / 2019-05-??
+0.7.0 / 2019-05-27
 ------------------
 
 .. warning:: Final MongoDB Supported Release
@@ -28,8 +28,8 @@ Changelog
 New Features
 ++++++++++++
 
-- (:pr:`206`, :pr:`249`) SQL Database is now feature complete and implemented. As final testing in production is
-  continued, MongoDB will be phased out in the future.
+- (:pr:`206`, :pr:`249`, :pr:`264`, :pr:`267`) SQL Database is now feature complete and implemented. As final testing in
+  production is continued, MongoDB will be phased out in the future.
 - (:pr:`242`) Parsl can now be used as an ``Adapter`` in the Queue Managers.
 - (:pr:`247`) The new ``OptimizationDataset`` collection has been added! This collection returns a set of optimized
   molecular structures given an initial input.
@@ -38,6 +38,8 @@ New Features
 - (:pr:`260`) Its now even easier to install Fractal/Portal through conda with pre-built environments on the
   ``qcarchive`` conda channel. This channel only provides environment files, no packages (and there are not plans to
   do so.)
+- (:pr:`269`) The Fractal Snowflake project has been extended to work in Jupyter Notebooks. A Fractal Snowflake can
+  be created with the ``FractalSnowflakeHandler`` inside of a Jupyter Session.
 
 Database Compatibility Updates
 ++++++++++++++++++++++++++++++
@@ -65,7 +67,9 @@ Enhancements
 - (:pr:`248`) Jobs which fail, or cannot be returned correctly, from Queue Managers are now better handled in the
   Manager and don't sit in the Manager's internal buffer. They will attempt to be returned to the Server on later
   updates. If too many jobs become stale, the Manager will shut itself down for safety.
-- (:pr:`258`) Fractal Queue Managers are now fully documented, both from the CLI and through the doc pages themselves.
+- (:pr:`258` and :pr:`268`) Fractal Queue Managers are now fully documented, both from the CLI and through the doc pages
+  themselves. There have also been a few variables renamed and moved to be more clear the nature of what they do.
+  See the PR for the renamed variables.
 - (:pr:`251`) The Fractal Server now reports valid minimum/maximum allowed client versions. The Portal Client will try
   check these numbers against itself and fail to connect if it is not within the Server's allowed ranges. Clients
   started from Fractal's ``interface`` do not make this check.

--- a/docs/qcfractal/source/managers.rst
+++ b/docs/qcfractal/source/managers.rst
@@ -12,9 +12,9 @@ Fractal supports the following:
 - `Pool` - A python `ProcessPoolExecutor` for computing tasks on a single machine (or node).
 - `Dask <http://dask.pydata.org/en/latest/docs.html>`_ - A graph-based workflow engine for laptops and small clusters.
 - `Parsl <http://parsl-project.org>`_ - High-performance workflows.
-- `Fireworks <https://materialsproject.github.io/fireworks/>`_ - A asynchronous Mongo-based distributed queuing system.
+- `Fireworks <https://materialsproject.github.io/fireworks/>`_ - An asynchronous Mongo-based distributed queuing system.
 
-These backends allow Fractal to be incredibly elastic in utilized
+These backends allow Fractal to be incredibly elastic in utilizing
 computational resources, scaling from a single laptop to thousands of nodes on
 physically separate hardware. Our end goal is to be able to setup a manager at
 a physical site and allow it to scale up and down as its task queue requires
@@ -189,7 +189,7 @@ help block.
 Terminology
 -----------
 
-There are a number of terms which can overlap in due to the layers of abstraction and the type of software and hardware
+There are a number of terms which can overlap due to the layers of abstraction and the type of software and hardware
 the Queue Manager interacts with. To help with that, the pages in this section will use the terminology defined below.
 Several pieces of software we interface with may have their own terms or the same term with different meaning, but
 because one goal of the Manager is to abstract those concepts away as best it can, we choose the following set. If

--- a/docs/qcfractal/source/managers_config_api.rst
+++ b/docs/qcfractal/source/managers_config_api.rst
@@ -13,7 +13,7 @@ each of the headers (top level objects) and a description for each one. The fina
         option_for_server: "some string"
 
 
-This is the complete set of options and auto-generated from the parser itself, so should be accurate for the given
+This is the complete set of options, auto-generated from the parser itself, so it should be accurate for the given
 release. If you are using a developmental build or want to see the schema yourself, you can run the
 ``qcfractal-manager --schema`` command and it will display the whole schema for the YAML input.
 

--- a/docs/qcfractal/source/managers_faq.rst
+++ b/docs/qcfractal/source/managers_faq.rst
@@ -34,12 +34,12 @@ Can I connect to a Fractal Server besides MolSSI's?
 
 Yes! Just change the ``server.fractal_uri`` argument.
 
-Can I connect to a more than one Fractal Server
-+++++++++++++++++++++++++++++++++++++++++++++++
+Can I connect to more than one Fractal Server
++++++++++++++++++++++++++++++++++++++++++++++
 
 Yes and No. Each :term:`Manager` can only connect to a single :term:`Fractal Server<Server>`, but
 you can start multiple managers with different config files pointing to different
-:term:`Fractal Servers<Server>`
+:term:`Fractal Servers<Server>`.
 
 How do I help contribute compute time to the MolSSI database?
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -50,7 +50,7 @@ We would love to talk to you and help get you contributing as well!
 I have this issue, here is my config file...
 ++++++++++++++++++++++++++++++++++++++++++++
 
-Great! We only ask that you please **remove the password from the config file before posting it.**
+Happy to look at it! We only ask that you please **remove the password from the config file before posting it.**
 If we see a password, we'll do our best to delete it, but
 that does not ensure someone did not see it.
 

--- a/docs/qcfractal/source/managers_samples.rst
+++ b/docs/qcfractal/source/managers_samples.rst
@@ -18,7 +18,7 @@ SLURM Cluster, Dask Adapter with additional options
 
 This example is similar to the :ref:`example on the start page for Managers<manager_starter_example>`, but with some
 additional options such as connecting back to a central Fractal instance and setting more cluster-specific options.
-Again, this starts manager with a dask :term:`Adapter`, on a SLURM cluster, consuming 1 CPU and 8 GB of ram, targeting
+Again, this starts a manager with a dask :term:`Adapter`, on a SLURM cluster, consuming 1 CPU and 8 GB of ram, targeting
 a Fractal Server running on that cluster, and using the SLURM partition ``default``, save the following YAML config
 file:
 
@@ -46,8 +46,8 @@ file:
      queue: default
 
 
-Mutiple Tasks, 1 Cluster Job
-----------------------------
+Multiple Tasks, 1 Cluster Job
+-----------------------------
 
 This example starts a max of 1 cluster :term:`Job`, but multiple :term:`tasks<Task>`. The hardware will be
 consumed uniformly by the :term:`Worker`. With 8 cores, 20 GB of memory, and 4 tasks; the :term:`Worker` will provide
@@ -83,7 +83,7 @@ will show this user has run 1 ``sbatch`` jobs which requested 4 cores and 20 GB 
 Testing the Manager Setup
 -------------------------
 
-This will test the :term:`Manager` to make sure its setup correctly, and does not need to
+This will test the :term:`Manager` to make sure it's setup correctly, and does not need to
 connect to the :term:`Server`, and therefore does not need a ``server`` block. It will still however submit
 :term:`jobs <Job>`.
 
@@ -116,7 +116,7 @@ environment, or setting some environment variables. This lets you specify that. 
 Sun Grid Engine (SGE) cluster, start a conda environment, and load a module.
 
 An important note about this one, we have now set ``max_workers`` to something larger than 1.
-Each :term:`Job` will still request 4 cores and 256 GB of memory to be evenly distributed between the
+Each :term:`Job` will still request 16 cores and 256 GB of memory to be evenly distributed between the
 4 :term:`tasks<Task>`, however, the :term:`Adapter` will **attempt to start 5 independent** :term:`jobs<Job>`, for a
 total of 80 cores, 1.280 TB of memory, distributed over 5 :term:`Workers<Worker>` collectively running 20 concurrent
 :term:`tasks<Task>`. If the :term:`Scheduler` does not
@@ -158,7 +158,7 @@ Additional Scheduler Flags
 --------------------------
 
 A :term:`Scheduler` may ask you to set additional flags (or you might want to) when submitting a :term:`Job`.
-Maybe its a Sys. Admin enforced rule, maybe you want to pull from a specific account, or set something not
+Maybe it's a Sys. Admin enforced rule, maybe you want to pull from a specific account, or set something not
 interpreted for you in the :term:`Manager` or :term:`Adapter` (do tell us though if this is the case). This
 example sets additional flags on a PBS cluster such that the final :term:`Job` launch file will have
 ``#PBS {my headers}``.

--- a/docs/qcportal/source/changelog.rst
+++ b/docs/qcportal/source/changelog.rst
@@ -15,21 +15,14 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
-0.7.0 / 2019-05-??
+0.7.0 / 2019-05-27
 ------------------
-
-.. warning:: Final MongoDB Supported Release
-
-    **This is the last major release which support MongoDB.** Fractal is moving towards a PostgreSQL for database to
-    make upgrades more stable and because it is more suited to the nature of QCArchive Data. The upgrade path for
-    MongoDB -> PostgreSQL will be provided by the Fractal developers in the next release. This first one will likely
-    be a bit manual in th form of scripts, but afterwords will be engineered to be more automatic and documented.
 
 New Features
 ++++++++++++
 
-- (:pr:`206`, :pr:`249`) SQL Database is now feature complete and implemented. As final testing in production is
-  continued, MongoDB will be phased out in the future.
+- (:pr:`206`, :pr:`249`, :pr:`264`, :pr:`267`) SQL Database is now feature complete and implemented. As final testing in
+  production is continued, MongoDB will be phased out in the future.
 - (:pr:`242`) Parsl can now be used as an ``Adapter`` in the Queue Managers.
 - (:pr:`247`) The new ``OptimizationDataset`` collection has been added! This collection returns a set of optimized
   molecular structures given an initial input.
@@ -38,6 +31,8 @@ New Features
 - (:pr:`260`) Its now even easier to install Fractal/Portal through conda with pre-built environments on the
   ``qcarchive`` conda channel. This channel only provides environment files, no packages (and there are not plans to
   do so.)
+- (:pr:`269`) The Fractal Snowflake project has been extended to work in Jupyter Notebooks. A Fractal Snowflake can
+  be created with the ``FractalSnowflakeHandler`` inside of a Jupyter Session.
 
 Database Compatibility Updates
 ++++++++++++++++++++++++++++++
@@ -63,9 +58,11 @@ Enhancements
 - (:pr:`247`) Procedure classes now all derive from a common base class to be more consistent with one another and
   for any new Procedures going forward.
 - (:pr:`248`) Jobs which fail, or cannot be returned correctly, from Queue Managers are now better handled in the
-  Manager and don't sit in the Queue Manager's internal buffer. They will attempt to be returned to the Server on later
-  updates. If too many jobs become stale, the Queue Manager will shut itself down for safety.
-- (:pr:`258`) Fractal's Queue Managers are now fully documented, both from the CLI and through the doc pages themselves.
+  Manager and don't sit in the Manager's internal buffer. They will attempt to be returned to the Server on later
+  updates. If too many jobs become stale, the Manager will shut itself down for safety.
+- (:pr:`258` and :pr:`268`) Fractal Queue Managers are now fully documented, both from the CLI and through the doc pages
+  themselves. There have also been a few variables renamed and moved to be more clear the nature of what they do.
+  See the PR for the renamed variables.
 - (:pr:`251`) The Fractal Server now reports valid minimum/maximum allowed client versions. The Portal Client will try
   check these numbers against itself and fail to connect if it is not within the Server's allowed ranges. Clients
   started from Fractal's ``interface`` do not make this check.
@@ -77,6 +74,8 @@ Bug Fixes
   parsed correctly.
 - (:pr:`250`) Record objects now correctly set their provenance time on object creation, not module import.
 - (:pr:`253`) A spelling bug was fixed in GridOptimization which caused hashing to not be processed correctly.
+- (:pr:`270`) LSF clusters not in ``MB`` for the units on memory by config are now auto-detected (or manually set)
+  without large workarounds in the YAML file and the CLI file itself. Supports documented settings of LSF 9.1.3.
 
 0.6.0 / 2019-03-30
 ------------------

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -173,7 +173,7 @@ class QueueManagerSettings(BaseSettings):
     test: bool = Schema(
         False,
         description="Turn on testing mode for this Manager. The Manager will not connect to any Fractal Server, and "
-                    "instead submit netsts worth trial tasks per quantum chemistry program it finds. These tasks are "
+                    "instead submits netsts worth trial tasks per quantum chemistry program it finds. These tasks are "
                     "generated locally and do not need a running Fractal Server to work. Helpful for ensuring the "
                     "Manager is configured correctly and the quantum chemistry codes are operating as expected."
     )
@@ -235,8 +235,8 @@ class ClusterSettings(BaseSettings):
         description="Additional options which are fed into the header files for your submitted jobs to your cluster's "
                     "Scheduler/Queuing system. The directives are automatically filled in, so if you want to set "
                     "something like '#PBS -n something', you would instead just do '-n something'. Each directive "
-                    "should be a separate string entry in the list. No validation is done on this w.r.t. valid "
-                    "directives so it is on the user to know what they need to set."
+                    "should be a separate string entry in the list. No validation is done on this with respect to "
+                    "valid directives so it is on the user to know what they need to set."
     )
     task_startup_commands: List[str] = Schema(
         [],
@@ -302,10 +302,10 @@ class DaskQueueSettings(SettingsBlocker):
     `cluster.scheduler` settings. Although many values are set automatically from other settings, there are
     some additional values such as `interface` and `extra` which are passed through to the constructor.
 
-    Valid values for this field are function of your cluster.scheduler and no linting is done ahead of trying to pass
+    Valid values for this field are functions of your cluster.scheduler and no linting is done ahead of trying to pass
     these to Dask.
 
-    NOTE: The parameters listed here have are a special exception for additional features Fractal has engineered or
+    NOTE: The parameters listed here are a special exception for additional features Fractal has engineered or
     options which should be considered for some of the edge cases we have discovered. If you try to set a value
     which is derived from other options in the YAML file, an error is raised and you are told exactly which one is
     forbidden.
@@ -345,7 +345,7 @@ class ParslExecutorSettings(SettingsBlocker):
 
     https://parsl.readthedocs.io/en/latest/stubs/parsl.executors.HighThroughputExecutor.html
 
-    NOTE: The parameters listed here have are a special exception for additional features Fractal has engineered or
+    NOTE: The parameters listed here are a special exception for additional features Fractal has engineered or
     options which should be considered for some of the edge cases we have discovered. If you try to set a value
     which is derived from other options in the YAML file, an error is raised and you are told exactly which one is
     forbidden.
@@ -370,11 +370,11 @@ cli_utils.doc_formatter(ParslExecutorSettings)
 
 class ParslProviderSettings(SettingsBlocker):
     """
-    Settings for the Parsl Provider class. Valid values for this field are function of your cluster.scheduler and no
+    Settings for the Parsl Provider class. Valid values for this field are functions of your cluster.scheduler and no
     linting is done ahead of trying to pass these to Parsl.
     Please see the docs for the provider information
 
-    NOTE: The parameters listed here have are a special exception for additional features Fractal has engineered or
+    NOTE: The parameters listed here are a special exception for additional features Fractal has engineered or
     options which should be considered for some of the edge cases we have discovered. If you try to set a value
     which is derived from other options in the YAML file, an error is raised and you are told exactly which one is
     forbidden.


### PR DESCRIPTION
Final major changelog pass for 0.7. Also includes typo edits from
a proofread.

I removed the Mongo->SQL `.. warning::` block from the changelog for Portal since it does not impact Portal.

## Status
- [x] Changelog updated
- [x] Ready to go