### PR TITLE
Make a Doc continuity pass for 0.7

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -12,27 +12,35 @@ You should test your code, but do not feel compelled to use these specific progr
 Windows testing if you only plan to deploy on specific platforms. These are just to help you get started
 
 * `travis-ci`: Linux and OSX based testing through [Travis-CI](https://about.travis-ci.com/) 
-  * `install.sh`: Pip/Miniconda installation script for Travis
-* `appveyor`: Windows based testing through [AppVeyor](https://www.appveyor.com/)
-  * `install_conda.ps1` Powershell installation script of Conda components
+  * `before_install.sh`: Pip/Miniconda installation script for Travis
 
-### Conda Recipe:
+### Conda Environment:
 
-This directory contains the files to build and deploy on [Conda](https://conda.io/).
+These directories contain the files to build [Conda](https://conda.io/) environments for rapid setup and testing
 
-* `conda-recipie`: directory containing all the build objects required for Conda. All files in this folder must have their given names
-  * `meta.yaml`: The yaml file needed by Conda to construct the build
-  * `build.sh`: Unix-based instructions for how to install the software interpreted by Conda
-  * `bld.bat`: Windows-based instructions for how to install the software interpreted by Conda
+* `scripts`: Helper and utility scripts kept here to keep other folders and their content within the same context
+  * `conda_env.py`: Helper script with some specific CLI flags for the `conda env` command to install Conda Environment files quickly
+* `conda-envs`: Developer environments for quickly setting up different testing and software stacks to be installed 
+  alongside Fractal. These do *not* install Fractal on their own and are expected to be used with either `setup.py develop` 
+  or `pip install -e` installs of Fractal from source.
+* `prod-envs`: End-user production install files for Fractal. These install Fractal from the Anaconda Cloud for use 
+  at production level sites. No further installations needed from these files. 
 
 
 ## How to contribute changes
-- Clone the repository if you have write access to the main repo, fork the repository if you are a collaborator.
+- Fork the repository
+  * We do not generally permit anyone make direct changes to the main QCFractal repository, even core developers. 
+    Exceptions to this rule are rare and considered on a case-by-case basis, and thus far have only been to fix
+    previous mistaken merges. 
+- Clone your fork
 - Make a new branch with `git checkout -b {your branch name}`
-- Make changes and test your code
+- Make changes and test your code (contribute new tests or modify old ones as needed)
 - Push the branch to the repo (either the main or your fork) with `git push -u origin {your branch name}`
   * Note that `origin` is the default name assigned to the remote, yours may be different
 - Make a PR on GitHub with your changes
+  * We recommend setting the `Allow edits from maintainers` tick box as it makes it easier for other maintainers to 
+    directly make changes to the PR as needed. Although not often used, it is helpful for large PR's where many commits 
+    or contributors are expected.
 - We'll review the changes and get your code into the repo after lively discussion!
 
 

--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -21,9 +21,10 @@ Changelog
 .. warning:: Final MongoDB Supported Release
 
     **This is the last major release which support MongoDB.** Fractal is moving towards a PostgreSQL for database to
-    make upgrades more stable and because it is more suited to the nature of QCArchive Data. The upgrade path for
-    MongoDB -> PostgreSQL will be provided by the Fractal developers in the next release. This first one will likely
-    be a bit manual in th form of scripts, but afterwords will be engineered to be more automatic and documented.
+    make upgrades more stable and because it is more suited to the nature of QCArchive Data. The upgrade path from
+    MongoDB to PostgreSQL will be provided by the Fractal developers in the next release. Due to the complex nature
+    of the upgrade, the PostgreSQL upgrade will through scripts which will be provided. After the PostgreSQL upgrade,
+    there will be built-in utilities to upgrade the Database.
 
 New Features
 ++++++++++++

--- a/docs/qcfractal/source/database_design.rst
+++ b/docs/qcfractal/source/database_design.rst
@@ -1,6 +1,13 @@
 Database Design
 ==================
 
+.. warning:: Final MongoDB Supported Version: 0.7.0
+
+    **0.7.0 is the last major release which support MongoDB.** Fractal is moving towards a PostgreSQL for database to
+    make upgrades more stable and because it is more suited to the nature of QCArchive Data. The upgrade path for
+    MongoDB -> PostgreSQL will be provided by the Fractal developers in the next release. This first one will likely
+    be a bit manual in th form of scripts, but afterwords will be engineered to be more automatic and documented.
+
 QCArchive stores all its data and computations in a database in the backend
 of QCFractal_. The DB is designed with extensibility in mind, allowing
 flexibility and easy accommodation of future features. The current backend
@@ -57,13 +64,14 @@ This table stores the actual computation results along with the attributes
 used to calculate it. Each entry is a single unit of computation.
 The following are the unique set of keys (or indices) that define a result:
 
+- ``driver`` - The type of calculation being evaluated (i.e. ``energy``, ``gradient``, ``hessian``, ``properties``)
 - ``program``: such as ``gamess`` or ``psi4`` (lower case)
 - ``molecule``: the ID of the molecule in the ``Molecule`` table
 - ``method``: the method used in the computation (b3lyp, mp2, ccsd(t))
 - ``keywords``: the ID of the keywords in the ``Keywords`` table
 - ``basis``: the name of the basis used in the computation (6-31g, cc-pvdz, def2-svp)
 
-For more information see :ref:`fractal-results`.
+For more information see: :doc:`results`.
 
 
 4) Procedure
@@ -85,7 +93,7 @@ stored in the ``Result`` and/or the ``Procedure`` tables when they are done.
 So, from the DB point of view, this is an intermediate table for on going
 iterative computations.
 
-More about services in QCArchive can be found here :ref:`fractal-services`.
+More about services in QCArchive can be found here: :doc:`services`.
 
 
 6) TaskQueue
@@ -102,9 +110,13 @@ keeps track of the execution manager and the modification dates.
 7) QueueManagers
 +++++++++++++++++
 
-Managers are the registered servers for computing tasks from the ``TaskQueue``.
+:term:`Managers<Manager>` are the registered servers for computing tasks from the ``TaskQueue``.
 This table keep information about the server such as the host, cluster,
 number of completed tasks, submissions, and failures.
+
+The database only keeps track of what :term:`Tasks<Task>` have been handed out to
+each :term:`Manager` and maintains a heartbeat to ensure the :term:`Manager` is still connected. More information about
+the configuration and executation of managers can be found here: :doc:`managers`.
 
 
 .. _QCSchema: https://github.com/MolSSI/QC_JSON_Schema

--- a/docs/qcfractal/source/database_design.rst
+++ b/docs/qcfractal/source/database_design.rst
@@ -4,9 +4,10 @@ Database Design
 .. warning:: Final MongoDB Supported Version: 0.7.0
 
     **0.7.0 is the last major release which support MongoDB.** Fractal is moving towards a PostgreSQL for database to
-    make upgrades more stable and because it is more suited to the nature of QCArchive Data. The upgrade path for
-    MongoDB -> PostgreSQL will be provided by the Fractal developers in the next release. This first one will likely
-    be a bit manual in th form of scripts, but afterwords will be engineered to be more automatic and documented.
+    make upgrades more stable and because it is more suited to the nature of QCArchive Data. The upgrade path from
+    MongoDB to PostgreSQL will be provided by the Fractal developers in the next release. Due to the complex nature
+    of the upgrade, the PostgreSQL upgrade will through scripts which will be provided. After the PostgreSQL upgrade,
+    there will be built-in utilities to upgrade the Database.
 
 QCArchive stores all its data and computations in a database in the backend
 of QCFractal_. The DB is designed with extensibility in mind, allowing

--- a/docs/qcfractal/source/dev_guidelines.rst
+++ b/docs/qcfractal/source/dev_guidelines.rst
@@ -1,4 +1,26 @@
 Development Guidelines
 ======================
 
-Core development guidelines go here.
+QCArchive developers adhere to a set of guidelines, both in the software stylistic guide, and in the outward conduct.
+We are working on codifying these in a clean list here, but early guides can be as follows
+
+Software Development Guides
+---------------------------
+
+We openly encourage development of the QCArchive and all of its projects in public discourse through GitHub and the
+QCArchive Slack (|join_slack_upper|_).
+
+All changes should be proposed through a PR to the main projects from Forks of said projects.
+
+For more details about the development cycle and guidelines, please
+`see the DevTools Readme on GitHub <https://github.com/MolSSI/QCFractal/blob/master/devtools/README.md>`_ for the
+project.
+
+Personal Conduct Guides
+-----------------------
+
+Basic rule of thumb: Be respectful, welcome people, keep all interactions harassment-free.
+
+Please see the
+`full Code of Conduct on the project's GitHub page <https://github.com/MolSSI/QCFractal/blob/master/CODE_OF_CONDUCT.md>`_
+for more information.

--- a/docs/qcfractal/source/flow.rst
+++ b/docs/qcfractal/source/flow.rst
@@ -5,8 +5,8 @@ The interface between the Portal client, the Fractal server, and the distributed
 compute resources is not something easily conveyed by text. We have created
 flowchart diagrams to help explain what happens from the time Portal invokes a
 call to Fractal, to the time that Fractal finishes handling the request.
-These diagrams are simplified to not show every procedure and middleware
-called, but instead to provide a visual aid to what is happening to help
+These diagrams are simplified to not show every routine and middleware
+call, but instead to provide a visual aid to what is happening to help
 understanding.
 
 .. _flowchart_add_compute:

--- a/docs/qcfractal/source/glossary.rst
+++ b/docs/qcfractal/source/glossary.rst
@@ -1,6 +1,11 @@
 Glossary
 ========
 
+This glossary contains the common terms which appear over the entire Fractal project. There are other, specialized
+glossaries for components of Fractal which are linked below to help group terms together with their contextual docs.
+Some terms may appear in multiple glossaries, but will always have the same meaning, e.g. :term:`Queue Adapter` and
+:term:`Adapter`.
+
 .. glossary::
     :sorted:
 
@@ -47,3 +52,9 @@ Glossary
     DB Table
       A set of data inside the Database which has a common :term:`ObjectId`. The ``table``
       name follows SQL conventions which is also known as a ``collection`` in MongoDB.
+
+
+Contextually Organized Glossaries
+---------------------------------
+
+- :ref:`Queue Manager Glossary<manager_glossary>`

--- a/docs/qcfractal/source/install.rst
+++ b/docs/qcfractal/source/install.rst
@@ -6,12 +6,14 @@ You can install qcfractal with ``conda``, with ``pip``, or by installing from so
 Conda
 -----
 
-You can update qcfractal using `conda <https://www.anaconda.com/download/>`_::
+You can install or update qcfractal using `conda <https://www.anaconda.com/download/>`_::
 
     conda install qcfractal -c conda-forge
 
-The above command install qcfractal and its required dependencies, but *not* any of the quantum
-chemistry codes nor the software to run run :term:`Queue Managers <Manager>`.
+The above command installs qcfractal and its required dependencies, but *not* any of the quantum
+chemistry codes nor the software to run :term:`Queue Managers <Manager>`. This is done to avoid
+requiring *every* software which *can* interface with Fractal, and instead leaving it up to the
+user to get the software they *want*.
 
 The qcfractal package is maintained on the
 `conda-forge channel <https://conda-forge.github.io/>`_.

--- a/docs/qcfractal/source/install.rst
+++ b/docs/qcfractal/source/install.rst
@@ -11,9 +11,8 @@ You can install or update qcfractal using `conda <https://www.anaconda.com/downl
     conda install qcfractal -c conda-forge
 
 The above command installs qcfractal and its required dependencies, but *not* any of the quantum
-chemistry codes nor the software to run :term:`Queue Managers <Manager>`. This is done to avoid
-requiring *every* software which *can* interface with Fractal, and instead leaving it up to the
-user to get the software they *want*.
+chemistry codes nor the software to run :term:`Queue Managers <Manager>`. This is done to avoid requiring *all* software
+which *can* interface with Fractal, and instead requires the user to obtain the software they individually *require*.
 
 The qcfractal package is maintained on the
 `conda-forge channel <https://conda-forge.github.io/>`_.

--- a/docs/qcfractal/source/managers.rst
+++ b/docs/qcfractal/source/managers.rst
@@ -184,7 +184,7 @@ help block.
                             up-to-date schema. It will be presented in a JSON-like
                             format.
 
-
+.. _manager_glossary:
 
 Terminology
 -----------

--- a/docs/qcfractal/source/managers_samples.rst
+++ b/docs/qcfractal/source/managers_samples.rst
@@ -123,7 +123,7 @@ total of 80 cores, 1.280 TB of memory, distributed over 5 :term:`Workers<Worker>
 allow all of those :term:`jobs<Job>` to start, whether due to lack of resources or user limits, the
 :term:`Adapter` can still start fewer :term:`jobs<Job>`, each with 16 cores and 256 GB of memory, but :term:`Task`
 concurrency will change by blocks of 4 since the :term:`Worker` in each :term:`Job` is configured to handle 4
-:term:`Tasks` each.
+:term:`tasks<Task>` each.
 
 .. code-block:: yaml
 

--- a/docs/qcfractal/source/qcarchive_overview.rst
+++ b/docs/qcfractal/source/qcarchive_overview.rst
@@ -67,7 +67,7 @@ QCFractal is the primary persistent server that QCPortal communicates with and h
 ++++++++++++++++++++++
 
 - Hardware: Persistent Server/Supercomputer
-- Actor: Power User
+- Actor: Power User (can be separate from the Fractal Power Users)
 - Primary Developer: Scientific and HPC Communities
 
 The QCArchive project relies on a number of distributed compute workflow
@@ -79,8 +79,9 @@ implementation details of the individual tools.
 
 Current distributed compute backends are:
 
-- `Dask Distributed <http://dask.pydata.org>`_ - Multi-node task graph schedular built in Python.
-- `Fireworks <https://materialsproject.github.io/fireworks/>`_ - Multi-site task schedular built in Python with a central MongoDB server.
+- `Dask Distributed <http://dask.pydata.org>`_ - Multi-node task graph scheduler built in Python.
+- `Parsl <http://parsl-project.org>`_ - High-performance workflows.
+- `Fireworks <https://materialsproject.github.io/fireworks/>`_ - Multi-site task scheduler built in Python with a central MongoDB server.
 
 Pending backend implementations include:
 

--- a/docs/qcfractal/source/results.rst
+++ b/docs/qcfractal/source/results.rst
@@ -9,13 +9,14 @@ optimizations belong under the "Procedures" heading.
 Indices
 -------
 
-A result can be found based off a unique tuple of ``(program, molecule_id, options_set, method, basis)``
+A result can be found based off a unique tuple of ``(driver, program, molecule_id, keywords_set, method, basis)``
 
-- ``program`` - A lowercase string representation of the quantum chemistry program used (``gamess``, ``nwchem``, ``psi4``)
+- ``driver`` - The type of calculation being evaluated (i.e. ``energy``, ``gradient``, ``hessian``, ``properties``)
+- ``program`` - A lowercase string representation of the quantum chemistry program used (``gamess``, ``nwchem``, ``psi4``, etc.)
 - ``molecule_id`` - The :term:`ObjectId` of the molecule used in the computation.
-- ``keywords_set`` - The key to the options set stored in the database (``default`` -> ``{"e_convergence": 1.e-7, "scf_type": "df", ...}``)
-- ``method`` - A lowercase string representation of the method used in the computation (``b3lyp``, ``mp2``, ``ccsd(t)``).
-- ``basis`` - A lowercase string representation of the basis used in the computation (``6-31g``, ``cc-pvdz``, ``def2-svp``)
+- ``keywords_set`` - The key to the options set stored in the database (e.g. ``default`` -> ``{"e_convergence": 1.e-7, "scf_type": "df", ...}``)
+- ``method`` - A lowercase string representation of the method used in the computation (e.g. ``b3lyp``, ``mp2``, ``ccsd(t)``).
+- ``basis`` - A lowercase string representation of the basis used in the computation (e.g. ``6-31g``, ``cc-pvdz``, ``def2-svp``)
 
 Schema
 ------

--- a/docs/qcfractal/source/services.rst
+++ b/docs/qcfractal/source/services.rst
@@ -5,7 +5,7 @@ Services are unique workflows where there is an iterative component on the
 server. A typical service workflow looks like the following:
 
 1. A client submits a new service request to the server.
-2. A service is created on the server and place in the service queue.
+2. A service is created on the server and placed in the service queue.
 3. A service iteration is called that will spawn new tasks.
 4. The service waits until all generated tasks are complete.
 5. The service repeats 3 and 4 until the service iterations are complete.
@@ -16,16 +16,19 @@ steps. The TorsionDrive service optimizes the geometry of a biomolecule at a
 number of frozen dihedral angles to provide an energy profile of the rotation
 of this dihedral bond.
 
-1. A client submits a task to scan the HOOH molecule dihedral every 90 degrees.
-2. The service is received by the server, and the first 0-degree dihedral geometry optimization is spawned.
-3. The service waits until the 0-degree task is complete, and then generates 90 and -90-degree tasks based off this 0-degree geometry.
-4. The service waits for the two new tasks to complete and spawns 0 and 180-degree tasks based on the 90 and - 90-degree geometries.
-5. The service waits for the 90- and -90-degree tasks to complete. Then it builds its final data structure for user querying and marks itself complete.
+Consider the service using a concrete example of scanning the
+hydrogen peroxide dihedral:
+
+1. A client submits a task to scan the HOOH molecule dihedral every 90 degrees as a service.
+2. The service is received by the server, and the first 0-degree dihedral geometry optimization :term:`Task` is spawned.
+3. The service waits until the 0-degree :term:`Task` is complete, and then generates 90 and -90-degree :term:`tasks<Task>` based off this 0-degree geometry.
+4. The service waits for the two new :term:`tasks<Task>` to complete and spawns 0 and 180-degree tasks based on the 90 and - 90-degree geometries.
+5. The service waits for the 90- and -90-degree :term:`tasks<Task>` to complete. Then it builds its final data structure for user querying and marks itself complete.
 
 The service technology allows the ``FractalServer`` to complete very complex
 workflows of arbitrary design. To see a pictorial representation of this
 process, please see the
-:ref:`flowchart showing the psuedo-calls <flowchart_add_procedure>` when a
+:ref:`flowchart showing the pseudo-calls <flowchart_add_procedure>` when a
 service is added to the ``FractalServrer``
 
 

--- a/docs/qcfractal/source/setup_compute.rst
+++ b/docs/qcfractal/source/setup_compute.rst
@@ -32,7 +32,7 @@ Using the Command Line
     The CLI + YAML config file is the current recommended way to start and run
     Fractal Queue Managers
 
-At the moment only ProcessPoolExecutor ``qcfractal-manager`` can be spun up
+At the moment only ProcessPoolExecutor ``qcfractal-manager`` can be spun up purely
 from the command line as other distributed workflow managers require
 additional setup through a YAML config file.
 
@@ -70,7 +70,7 @@ The connected ``qcfractal-server`` instance can be controlled by:
 
 .. code-block:: console
 
-    $ qcfractal-manager --fractal-uri=api.qcfractal.molssi.org:80
+    $ qcfractal-manager --fractal-uri=api.qcfractal.molssi.org:443
 
 Only basic settings can be started through the CLI and most of the options require a YAML config file to get up and
 going. You can check all valid YAML options in :doc:`the Manager documentation pages<managers>` or you can always
@@ -79,6 +79,14 @@ check the current schema from the CLI with:
 .. code-block:: console
 
     $ qcfractal-manager --schema
+
+The CLI has several options which can examined with::
+
+    qcfractal-manager --help
+
+Every option specified in the CLI has an equal option in the YAML config file (except for ``--help`` and ``--schema``),
+but many YAML options are not present in the CLI due to their complex nature. Any option set in both places will
+defer to the CLI's setting, allowing you to overwrite some of the common YAML config options on invocation.
 
 
 .. note::
@@ -99,7 +107,7 @@ Using the Python API
 
     This is for advanced users and special care needs to be taken to ensure
     that both the manager and the workflow tool need to understand the number
-    of cores and memory available to prevent oversubscription of compute.
+    of cores and memory available to prevent over-subscription of compute.
 
 .. code-block:: python
 

--- a/docs/qcfractal/source/setup_server.rst
+++ b/docs/qcfractal/source/setup_server.rst
@@ -10,6 +10,13 @@ and have access to permanent storage.  This location is often either research
 groups local computers, a supercomputer with  appropriately allocated
 resources for this task, or the cloud.
 
+.. note::
+
+    Fractal will use a PostgreSQL database backend instead of MongoDB in versions
+    after 0.7. Upgrade tools will be provided for converting existing Fractal server
+    instances from Mongo to SQL. These docs will be updated at that time to reflect
+    the changes as well.
+
 
 Using the Command Line
 ----------------------
@@ -55,7 +62,7 @@ Within a Python Script
 
 Canonical workflows can be run from a Python script using the ``FractalSnowflake``
 instance. With default options a ``FractalSnowflake`` will spin up a database backend
-which contains no data and then destroy this database upon shudown.
+which contains no data and then destroy this database upon shutdown.
 
 .. warning::
 
@@ -71,7 +78,7 @@ which contains no data and then destroy this database upon shudown.
     >>> client = server.client()
 
 A standard ``FractalServer`` cannot be started in a Python script and then interacted with
-as a ``FractalServer`` uses asynchronous programming by default. ``FractalServer.start`` will
+as a ``FractalServer`` uses asynchronous programming by default. ``FractalServer.stop`` will
 stop the script.
 
 


### PR DESCRIPTION
I've gone though and touched many of the pages to keep the docs in line
with one another as far as features, content, and references. I'm sure
there are plenty of missed items, but I think this will be a good step.

I also updated the `devtools` README.md file to be accurate to the
folder contents and how we go about things.

## Status
- [x] Changelog updated
- [x] Ready to go