### PR TITLE
Remove entry point for template generator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ if __name__ == "__main__":
                 "qcfractal-server=qcfractal.cli.qcfractal_server:main",
                 "qcfractal-manager=qcfractal.cli.qcfractal_manager:main",
                 "qcfractal-dashboard=qcfractal.cli.qcfractal_dashboard:main",
-                "qcfractal-template=qcfractal.cli.qcfractal_template_generator:main"
             ]
         },
         extras_require={


### PR DESCRIPTION
## Description

Forgot to do this in #291, should be the last bit of the template
generator for the managers which has now been replaced in whole by
the qcfractal-manager CLI.

## Status
- [x] Changelog updated
- [x] Ready to go