### PR TITLE
get_future error's return FailedOperation instead of dict

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -11,7 +11,7 @@ from enum import Enum
 from functools import partial
 from math import ceil
 
-from typing import List, Optional, Any, Dict, Union
+from typing import List, Optional
 
 import tornado.log
 

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -108,6 +108,14 @@ def test_cli_managers(adapter, scheduler, tmp_path):
 
 
 @testing.mark_slow
+@testing.using_parsl
+def test_cli_manager_parsl_launchers(tmp_path):
+    config = load_manager_config("parsl", "slurm")
+    config["parsl"]["provider"].update({"launcher": {"launcher_class": "singleNODELauncher"}})
+    cli_manager_runs(config, tmp_path)
+
+
+@testing.mark_slow
 @pytest.mark.parametrize("adapter", [
     pytest.param("dask", marks=testing.using_dask_jobqueue),
     pytest.param("parsl", marks=testing.using_parsl),

--- a/qcfractal/queue/executor_adapter.py
+++ b/qcfractal/queue/executor_adapter.py
@@ -6,14 +6,18 @@ import traceback
 from typing import Any, Dict, Hashable, Tuple
 
 from .base_adapter import BaseAdapter
+from qcelemental.models import FailedOperation
 
 
 def _get_future(future):
     try:
         return future.result()
     except Exception as e:
-        msg = traceback.format_exc()
-        ret = {"success": False, "error_message": msg}
+        msg = "Caught Executor Error:\n" + traceback.format_exc()
+        ret = FailedOperation(**{"success": False,
+                                 "error": {"error_type":  e.__class__.__name__,
+                                           "error_message": msg}
+                                 })
         return ret
 
 

--- a/qcfractal/queue/parsl_adapter.py
+++ b/qcfractal/queue/parsl_adapter.py
@@ -8,6 +8,7 @@ import traceback
 from typing import Any, Callable, Dict, Hashable, Optional, Tuple
 
 from .base_adapter import BaseAdapter
+from qcelemental.models import FailedOperation
 
 
 def _get_future(future):
@@ -16,7 +17,10 @@ def _get_future(future):
         return future.result()
     except Exception as e:
         msg = "Caught Parsl Error:\n" + traceback.format_exc()
-        ret = {"success": False, "error": msg}
+        ret = FailedOperation(**{"success": False,
+                                 "error": {"error_type":  e.__class__.__name__,
+                                           "error_message": msg}
+                                 })
         return ret
 
 


### PR DESCRIPTION
## Description
Not sure what exactly is causing the errors to be thrown, but
I'm pretty sure this is the code being executed which is causing the
failures.

More debugging from live data may be needed as I have not
spent too long figuring out how to test this.

Several uses have reported this symptom where the `managers.py` file tries to do a `result.success` call, but `dict` does not have such a method. This should trap that at least so further debugging can happen. I suspect this happens when the future crashes (e.g. the Cluster's scheduler does a `kill -9` on the job the worker is in), but I have yet to prove that.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Add a way to test this, open to ideas here. Even without testing, we can refine as this starts getting trapped in runs.

## Status
- [ ] Changelog updated
- [x] Ready to go