### PR TITLE
Client-based task manipulation

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -823,6 +823,49 @@ class FractalClient(object):
 
         return self._automodel_request("task_queue", "get", payload, full_return=full_return)
 
+    def modify_tasks(self,
+                     operation: str,
+                     base_result: 'QueryObjectId',
+                     id: 'QueryObjectId' = None,
+                     full_return: bool = False) -> int:
+        """Summary
+
+        Parameters
+        ----------
+        operation : str
+            The operation to perform on the selected tasks. Valid operations are:
+             - `restart` - Restarts a task by moving its status from 'ERROR' to 'WAITING'
+        base_result : QueryObjectId
+            The id of the result that the task is associated with.
+        id : QueryObjectId, optional
+            The id of the individual task to restart. As a note querying tasks via their id is rarely performed and
+            is often an internal quantity.
+        full_return : bool, optional
+            Returns the full server response if True that contains additional metadata.
+
+        Returns
+        -------
+        int
+            The number of modified tasks.
+        """
+        operation = operation.lower()
+        valid_ops = {"restart"}
+
+        if operation not in valid_ops:
+            raise ValueError(f"Operation '{operation}' is not available, valid operations are: {valid_ops}")
+
+        payload = {
+            "meta": {
+                "operation": operation
+            },
+            "data": {
+                "id": id,
+                "base_result": base_result,
+            }
+        }
+
+        return self._automodel_request("task_queue", "update", payload, full_return=full_return)
+
     def add_service(self,
                     service: Union[GridOptimizationInput, TorsionDriveInput],
                     tag: Optional[str] = None,

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -864,7 +864,7 @@ class FractalClient(object):
             }
         }
 
-        return self._automodel_request("task_queue", "update", payload, full_return=full_return)
+        return self._automodel_request("task_queue", "put", payload, full_return=full_return)
 
     def add_service(self,
                     service: Union[GridOptimizationInput, TorsionDriveInput],

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -505,7 +505,7 @@ register_model("task_queue", "GET", TaskQueueGETBody, TaskQueueGETResponse)
 
 
 class TaskQueuePOSTBody(BaseModel):
-    class Data(BaseModel):
+    class Meta(BaseModel):
         procedure: str
         program: str
 
@@ -515,7 +515,7 @@ class TaskQueuePOSTBody(BaseModel):
         class Config(RESTConfig):
             allow_extra = "allow"
 
-    meta: Dict[str, Any]
+    meta: Meta
     data: List[Union[ObjectId, Molecule]]
 
     class Config(RESTConfig):
@@ -532,6 +532,42 @@ class TaskQueuePOSTResponse(BaseModel):
 
 
 register_model("task_queue", "POST", TaskQueuePOSTBody, TaskQueuePOSTResponse)
+
+class TaskQueueUPDATEBody(BaseModel):
+    class Data(BaseModel):
+        id: QueryObjectId = None
+        base_result: QueryObjectId = None
+
+        class Config(RESTConfig):
+            pass
+
+    class Meta(BaseModel):
+        operation: str
+
+        class Config(RESTConfig):
+            pass
+
+        @validator("operation")
+        def cast_to_lower(cls, v):
+            return v.lower()
+
+    meta: Meta
+    data: Data
+
+    class Config(RESTConfig):
+        pass
+
+
+class TaskQueueUPDATEResponse(BaseModel):
+
+    meta: ResponseMeta
+    data: ComputeResponse
+
+    class Config(RESTConfig):
+        pass
+
+
+register_model("task_queue", "UPDATE", TaskQueueUPDATEBody, TaskQueueUPDATEResponse)
 
 ### Service Queue
 

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -64,7 +64,7 @@ class SingleResultTasks(BaseTasks):
     """
 
     def verify_input(self, data):
-        program = data.meta["program"].lower()
+        program = data.meta.program.lower()
         if program not in qcng.list_all_programs():
             return "Program '{}' not available in QCEngine.".format(program)
 
@@ -93,15 +93,16 @@ class SingleResultTasks(BaseTasks):
         # Unpack all molecules
         molecule_list = self.storage.get_add_molecules_mixed(data.data)["data"]
 
-        if data.meta["keywords"]:
-            keywords = self.storage.get_add_keywords_mixed([data.meta["keywords"]])["data"][0]
+        if data.meta.keywords:
+            keywords = self.storage.get_add_keywords_mixed([data.meta.keywords])["data"][0]
 
         else:
             keywords = None
 
         # Grab the tag if available
-        tag = data.meta.pop("tag", None)
-        priority = data.meta.pop("priority", None)
+        meta = data.meta.dict()
+        tag = meta.pop("tag", None)
+        priority = meta.pop("priority", None)
 
         # Construct full tasks
         new_tasks = []
@@ -112,7 +113,7 @@ class SingleResultTasks(BaseTasks):
                 results_ids.append(None)
                 continue
 
-            record = ResultRecord(**data.meta, molecule=mol.id)
+            record = ResultRecord(**meta.copy(), molecule=mol.id)
             inp = record.build_schema_input(mol, keywords)
             inp.extras["_qcfractal_tags"] = {"program": record.program, "keywords": record.keywords}
 
@@ -130,11 +131,11 @@ class SingleResultTasks(BaseTasks):
             task = TaskRecord(**{
                 "spec": {
                     "function": "qcengine.compute",  # todo: add defaults in models
-                    "args": [inp.json_dict(), data.meta["program"]],  # todo: json_dict should come from results
+                    "args": [inp.json_dict(), data.meta.program],  # todo: json_dict should come from results
                     "kwargs": {}  # todo: add defaults in models
                 },
                 "parser": "single",
-                "program": data.meta["program"],
+                "program": data.meta.program,
                 "tag": tag,
                 "priority": priority,
                 "base_result": {
@@ -182,11 +183,11 @@ class OptimizationTasks(BaseTasks):
     """
 
     def verify_input(self, data):
-        program = data.meta["program"].lower()
+        program = data.meta.program.lower()
         if program not in qcng.list_all_procedures():
             return "Procedure '{}' not available in QCEngine.".format(program)
 
-        program = data.meta["qc_spec"]["program"].lower()
+        program = data.meta.qc_spec["program"].lower()
         if program not in qcng.list_all_programs():
             return "Program '{}' not available in QCEngine.".format(program)
 
@@ -241,13 +242,13 @@ class OptimizationTasks(BaseTasks):
         intitial_molecule_list = self.storage.get_add_molecules_mixed(data.data)["data"]
 
         # Unpack keywords
-        if data.meta["keywords"] is None:
+        if data.meta.keywords is None:
             opt_keywords = {}
         else:
-            opt_keywords = data.meta["keywords"]
-        opt_keywords["program"] = data.meta["qc_spec"]["program"]
+            opt_keywords = data.meta.keywords
+        opt_keywords["program"] = data.meta.qc_spec["program"]
 
-        qc_spec = QCSpecification(**data.meta["qc_spec"])
+        qc_spec = QCSpecification(**data.meta.qc_spec.dict())
         if qc_spec.keywords:
             qc_keywords = self.storage.get_add_keywords_mixed([qc_spec.keywords])["data"][0]
             if qc_keywords is None:
@@ -255,8 +256,8 @@ class OptimizationTasks(BaseTasks):
         else:
             qc_keywords = None
 
-        tag = data.meta.pop("tag", None)
-        priority = data.meta.pop("priority", None)
+        tag = data.meta.tag
+        priority = data.meta.priority
 
         new_tasks = []
         results_ids = []
@@ -270,7 +271,7 @@ class OptimizationTasks(BaseTasks):
                 initial_molecule=initial_molecule.id,
                 qc_spec=qc_spec,
                 keywords=opt_keywords,
-                program=data.meta["program"])
+                program=data.meta.program)
 
             inp = doc.build_schema_input(initial_molecule=initial_molecule, qc_keywords=qc_keywords)
             inp.input_specification.extras["_qcfractal_tags"] = {
@@ -291,12 +292,12 @@ class OptimizationTasks(BaseTasks):
             task = TaskRecord(**{
                 "spec": {
                     "function": "qcengine.compute_procedure",
-                    "args": [inp.json_dict(), data.meta["program"]],
+                    "args": [inp.json_dict(), data.meta.program],
                     "kwargs": {}
                 },
                 "parser": "optimization",
                 "program": qc_spec.program,
-                "procedure": data.meta["program"],
+                "procedure": data.meta.program,
                 "tag": tag,
                 "priority": priority,
                 "base_result": {

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -248,7 +248,7 @@ class OptimizationTasks(BaseTasks):
             opt_keywords = data.meta.keywords
         opt_keywords["program"] = data.meta.qc_spec["program"]
 
-        qc_spec = QCSpecification(**data.meta.qc_spec.dict())
+        qc_spec = QCSpecification(**data.meta.qc_spec)
         if qc_spec.keywords:
             qc_keywords = self.storage.get_add_keywords_mixed([qc_spec.keywords])["data"][0]
             if qc_keywords is None:

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -271,7 +271,7 @@ class QueueManagerHandler(APIHandler):
 
         elif op == "shutdown":
             nshutdown = self.storage.queue_reset_status(name)
-            self.storage.manager_update(name, returned=nshutdown, status="INACTIVE", **body.meta.dict())
+            self.storage.manager_update(manager=name, returned=nshutdown, status="INACTIVE", **body.meta.dict())
 
             self.logger.info("QueueManager: Shutdown of manager {} detected, recycling {} incomplete tasks.".format(
                 name, nshutdown))

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -57,6 +57,25 @@ class TaskQueueHandler(APIHandler):
         self.logger.info("GET: TaskQueue - {} pulls.".format(len(response.data)))
         self.write(response.json())
 
+    def update(self):
+        """Posts new services to the service queue.
+        """
+
+        body_model, response_model = rest_model("task_queue", "update")
+        body = self.parse_bodymodel(body_model)
+
+        if (body.data.id is None) and (body.data.result_id is None):
+            raise tornado.web.HTTPError(status_code=400, reason="Id or ResultId must be specified.")
+
+        if body.meta.operation == "restart":
+            tasks = self.storage.queue_reset_status(**body.data.dict(), reset_error=True)
+        else:
+            raise tornado.web.HTTPError(status_code=400, reason=f"Operation '{operation}' is not valid.")
+        response = response_model(**tasks)
+
+        self.logger.info("GET: TaskQueue - {} pulls.".format(len(response.data)))
+        self.write(response.json())
+
 
 class ServiceQueueHandler(APIHandler):
     """

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -489,7 +489,7 @@ class FractalServer:
         ret = self.storage.get_managers(status="ACTIVE", modified_before=dt)
 
         for blob in ret["data"]:
-            nshutdown = self.storage.queue_reset_status(blob["name"])
+            nshutdown = self.storage.queue_reset_status(manager=blob["name"])
             self.storage.manager_update(blob["name"], returned=nshutdown, status="INACTIVE")
 
             self.logger.info("Hearbeat missing from {}. Shutting down, recycling {} incomplete tasks.".format(

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1688,7 +1688,7 @@ class SQLAlchemySocket:
                            id: Union[str, List[str]] = None,
                            base_result: Union[str, List[str]] = None,
                            manager: Optional[str] = None,
-                           reset_running: bool = True,
+                           reset_running: bool = False,
                            reset_error: bool = False) -> int:
         """
         Reset the status of the tasks that a manager owns from Running to Waiting

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1686,7 +1686,7 @@ class SQLAlchemySocket:
 
     def queue_reset_status(self,
                            id: Union[str, List[str]] = None,
-                           base_result_id: Union[str, List[str]] = None,
+                           base_result: Union[str, List[str]] = None,
                            manager: Optional[str] = None,
                            reset_running: bool = True,
                            reset_error: bool = False) -> int:
@@ -1698,7 +1698,7 @@ class SQLAlchemySocket:
         ----------
         id : Union[str, List[str]], optional
             The id of the task to modify
-        base_result_id : Union[str, List[str]], optional
+        base_result : Union[str, List[str]], optional
             The id of the base result to modify
         manager : Optional[str], optional
             The manager name to reset the status of
@@ -1717,7 +1717,7 @@ class SQLAlchemySocket:
             # nothing to do
             return 0
 
-        if sum(x is not None for x in [id, base_result_id, manager]) == 0:
+        if sum(x is not None for x in [id, base_result, manager]) == 0:
             raise ValueError("All query fields are None, reset_status must specify queries.")
 
         status = []
@@ -1728,7 +1728,7 @@ class SQLAlchemySocket:
 
         query = format_query(TaskQueueORM,
                              id=id,
-                             base_result_id=base_result_id,
+                             base_result_id=base_result,
                              manager=manager,
                              status=status)
 

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -94,14 +94,14 @@ def test_task_client_restart(fractal_compute_server):
     # Manually handle the compute
     fractal_compute_server.await_results()
 
-    tasks = client.query_tasks(base_result=ret.submitted)
-    assert tasks["status"] == "ERROR"
+    tasks = client.query_tasks(base_result=ret.submitted)[0]
+    assert tasks.status == "ERROR"
 
     upd = client.modify_tasks("restart", ret.submitted)
-    assert upd == 1
+    assert upd.n_updated == 1
 
-    tasks = client.query_tasks(base_result=ret.submitted)
-    assert tasks["status"] == "WAITING"
+    tasks = client.query_tasks(base_result=ret.submitted)[0]
+    assert tasks.status == "WAITING"
 
 
 @testing.using_rdkit

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -83,6 +83,26 @@ def test_task_error(fractal_compute_server):
     assert m[0]["failures"] > 0
     assert m[0]["completed"] > 0
 
+@testing.using_rdkit
+def test_task_client_restart(fractal_compute_server):
+    client = ptl.FractalClient(fractal_compute_server)
+
+    mol = ptl.models.Molecule(**{"geometry": [0, 0, 1], "symbols": ["He"]})
+    # Cookiemonster is an invalid method
+    ret = client.add_compute("rdkit", "cookiemonster", "", "energy", None, [mol])
+
+    # Manually handle the compute
+    fractal_compute_server.await_results()
+
+    tasks = client.query_tasks(base_result=ret.submitted)
+    assert tasks["status"] == "ERROR"
+
+    upd = client.modify_tasks("restart", ret.submitted)
+    assert upd == 1
+
+    tasks = client.query_tasks(base_result=ret.submitted)
+    assert tasks["status"] == "WAITING"
+
 
 @testing.using_rdkit
 def test_queue_error(fractal_compute_server):

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -13,6 +13,7 @@ from qcfractal.testing import reset_server_database, test_server
 
 CLIENT_USERNAME = "test_compute_adapter"
 
+
 @pytest.fixture(scope="module")
 def compute_adapter_fixture(test_server):
 
@@ -57,14 +58,6 @@ def test_queue_manager_single_tags(compute_adapter_fixture):
         assert manager["username"] == CLIENT_USERNAME
 
 
-    # stuff_log = next(x for x in manager_logs if x["tag"] == "stuff")
-    # assert stuff_log["submitted"] == 0
-
-    # other_log = next(x for x in manager_logs if x["tag"] == "other")
-    # assert other_log["submitted"] == 1
-    # assert other_log["completed"] == 1
-
-
 @testing.using_rdkit
 def test_queue_manager_shutdown(compute_adapter_fixture):
     """Tests to ensure tasks are returned to queue when the manager shuts down
@@ -91,6 +84,7 @@ def test_queue_manager_shutdown(compute_adapter_fixture):
     manager.await_results()
     ret = client.query_results()
     assert len(ret) == 1
+
 
 @testing.using_rdkit
 def test_queue_manager_server_delay(compute_adapter_fixture):
@@ -157,13 +151,12 @@ def test_queue_manager_heartbeat(compute_adapter_fixture):
     with testing.loop_in_thread() as loop:
 
         # Build server, manually handle IOLoop (no start/stop needed)
-        server = FractalServer(
-            port=testing.find_open_port(),
-            storage_project_name=server.storage_database,
-            storage_uri=server.storage_uri,
-            loop=loop,
-            ssl_options=False,
-            heartbeat_frequency=0.1)
+        server = FractalServer(port=testing.find_open_port(),
+                               storage_project_name=server.storage_database,
+                               storage_uri=server.storage_uri,
+                               loop=loop,
+                               ssl_options=False,
+                               heartbeat_frequency=0.1)
 
         # Clean and re-init the database
         testing.reset_server_database(server)

--- a/qcfractal/tests/test_storage_sql.py
+++ b/qcfractal/tests/test_storage_sql.py
@@ -1038,3 +1038,14 @@ def test_mol_pagination(storage_socket):
 
     # cleanup
     storage_socket.del_molecules(inserted['data'])
+
+def test_reset_task_blocks(storage_socket):
+    """
+        Ensures queue_reset_status must have some search variables so that it does not reset everything.
+    """
+
+    with pytest.raises(ValueError):
+        storage_socket.queue_reset_status(reset_running=True)
+
+    with pytest.raises(ValueError):
+        storage_socket.queue_reset_status(reset_error=True)


### PR DESCRIPTION
## Description
Allows the resetting of tasks via a Client and potentially other operations in the future. Closes #304.

Also found an area where a request meta field was a loose dictionary instead of a proper model. This has been fixed.

## Status
- [ ] Changelog updated
- [x] Ready to go