### PR TITLE
Remove dask-jobqueue workarounds

### DIFF
--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -28,8 +28,10 @@ dependencies:
   - rdkit
   - dask
   - distributed
+  - dask-jobqueue>=0.5.0
   - ipyparallel
   - ipykernel
+  - parsl>=0.8.0
 
 # QCArchive includes
   - qcengine>=0.6.2
@@ -37,5 +39,4 @@ dependencies:
 
 # Pip includes
   - pip:
-    - parsl
     - fireworks

--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -12,7 +12,7 @@ dependencies:
   - requests
   - bcrypt
   - cryptography
-  - pydantic
+  - pydantic>=0.20,<0.30
   - mongoengine
   - plotly
   - sqlalchemy>=1.3

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -12,7 +12,7 @@ dependencies:
   - requests
   - bcrypt
   - cryptography
-  - pydantic
+  - pydantic>=0.20,<0.30
   - mongoengine
   - plotly
   - sqlalchemy>=1.3

--- a/devtools/conda-envs/dev_head.yaml
+++ b/devtools/conda-envs/dev_head.yaml
@@ -12,7 +12,7 @@ dependencies:
   - requests
   - bcrypt
   - cryptography
-  - pydantic
+  - pydantic>=0.20,<0.30
   - mongoengine
   - plotly
   - sqlalchemy>=1.3

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -2,7 +2,6 @@
 Automatically generates the QCArchive environments
 """
 from ruamel.yaml import YAML
-import glob
 import copy
 
 yaml = YAML()
@@ -89,8 +88,9 @@ environs = [{
     
     # Tools to test out all available adapters, ipy is for Parsl
     "filename": "adapters.yaml",
-    "dependencies": ["rdkit", "dask", "distributed", "dask-jobqueue", "ipyparallel", "ipykernel"],
-    "pip_dependencies": ["parsl", "fireworks"]
+    "dependencies": ["rdkit", "dask", "distributed", "dask-jobqueue>=0.5.0", "ipyparallel", "ipykernel",
+                     "parsl>=0.8.0"],
+    "pip_dependencies": ["fireworks"]
 }, {
 
     # Tests for the OpenFF toolchain (geometric and torsiondrive) 

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -22,7 +22,7 @@ dependencies:
   - requests
   - bcrypt
   - cryptography
-  - pydantic
+  - pydantic>=0.20,<0.30
   - mongoengine
   - plotly
   - sqlalchemy>=1.3

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -13,7 +13,7 @@ dependencies:
   - requests
   - bcrypt
   - cryptography
-  - pydantic
+  - pydantic>=0.20,<0.30
   - mongoengine
   - plotly
   - sqlalchemy>=1.3

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -3,12 +3,9 @@ A command line interface to the qcfractal server.
 """
 
 import argparse
-import inspect
 import signal
 import logging
-import os
 from enum import Enum
-from functools import partial
 from math import ceil
 
 from typing import List, Optional

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
             'cryptography',
             'numpy>=1.7',
             'pandas',
-            'pydantic>=0.20',
+            'pydantic>=0.20,<0.30',
             'pymongo>=3.0',
             'requests',
             'tornado',


### PR DESCRIPTION
This also now adds an implicit minimum version pin to Dask Jobqueue
0.5.0 and Parsl 0.8.0 should users call those.

I also went back and fixed the dask node exclusivity setting for the
other clusters to the best of my ability and the docs I could find.
I improved the docs for that setting to help users should it throw an
error.

## Status
- [ ] Changelog updated
- [x] Ready to go