### PR TITLE
Automatic pagination for very large collections

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -98,6 +98,7 @@ class FractalClient(object):
         self.server_info = self._automodel_request("information", "get", {}, full_return=True).dict()
 
         self.server_name = self.server_info["name"]
+        self.query_limit = self.server_info["query_limit"]
 
         from . import __version__  # Import here to avoid circular import from __init__
         from . import _isportal

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -418,7 +418,7 @@ class BaseProcedureDataset(Collection):
         mapper = self._get_procedure_ids(spec.name)
         query_ids = list(mapper.values())
 
-        # Poor mans paginate
+        # Chunk up the queries
         procedures = []
         for i in range(0, len(query_ids), self.client.query_limit):
             chunk_ids = query_ids[i:i + self.client.query_limit]

--- a/qcfractal/interface/collections/collection_utils.py
+++ b/qcfractal/interface/collections/collection_utils.py
@@ -99,7 +99,7 @@ def composition_planner(program=None, method=None, basis=None, driver=None, keyw
 
     base = {"program": program, "method": method, "basis": basis, "driver": driver, "keywords": keywords}
 
-    if ("-d3" in method.lower()) and ("dftd3" != program.lower()):
+    if ("-d3" in method.lower()) and ("dftd3" != program.lower()) and ("hessian" != driver.lower()):
         dftd3keys = {"program": "dftd3", "method": method, "basis": None, "driver": driver, "keywords": None}
         base["method"] = method.split("-D3")[0]
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -603,15 +603,17 @@ class Dataset(Collection):
         existing = []
         for compute_set in composition_planner(**dbkeys):
 
-            ret = self.client.add_compute(
-                compute_set["program"],
-                compute_set["method"],
-                compute_set["basis"],
-                compute_set["driver"],
-                compute_set["keywords"],
-                umols,
-                tag=tag,
-                priority=priority)
+            for i in range(0, len(umols), self.client.query_limit):
+                chunk_mols = umols[i:i + self.client.query_limit]
+                ret = self.client.add_compute(
+                    compute_set["program"],
+                    compute_set["method"],
+                    compute_set["basis"],
+                    compute_set["driver"],
+                    compute_set["keywords"],
+                    chunk_mols,
+                    tag=tag,
+                    priority=priority)
 
             ids.extend(ret.ids)
             submitted.extend(ret.submitted)

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -547,14 +547,22 @@ class Dataset(Collection):
         ret = []
         for query_set in composition_planner(**query):
 
-            query_set["molecule"] = set(indexer.values())
-
+            # Set the index to remove duplicates
+            molecules = list(set(indexer.values()))
             query_set["projection"] = {"molecule": True, field: True}
-            records = pd.DataFrame(self.client.query_results(**query_set), columns=["molecule", field])
+
+            # Chunk up the queries
+            records = []
+            for i in range(0, len(molecules), self.client.query_limit):
+                query_set["molecule"] = molecules[i:i + self.client.query_limit]
+                records.extend(self.client.query_results(**query_set))
+
+            records = pd.DataFrame(records, columns=["molecule", field])
 
             df = pd.DataFrame.from_dict(indexer, orient="index", columns=["molecule"])
             df.reset_index(inplace=True)
 
+            # Outer join on left to merge duplicate molecules
             df = df.merge(records, how="left", on="molecule")
             df.set_index("index", inplace=True)
             df.drop("molecule", axis=1, inplace=True)


### PR DESCRIPTION
## Description
Automatically chunks computations and queries for very large collections.

Next steps would be to create a global configuration for portal where we have information like verbosity and Jupyter notebook environment so that we can automatically show `tqdm` around these large queries. In this way we can automatically show progress bars for something that may take longer than ~10 seconds to pull from the server.

This also prevents Hessian computations from running through dftd3 itself. @loriab How opposed would you be if elemental had a finite difference hess/grad capabilities (no symmetries) that would power automated f-d Hessian dftd3?

@jchodera 

## Status
- [ ] Changelog updated
- [x] Ready to go