### PR TITLE
fix bug in torsiondrive_dataset with duplicated initial_molecules

### DIFF
--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -16,7 +16,7 @@ from ..visualization import custom_plot
 class TDRecord(BaseModel):
     """Data model for the `reactions` list in Dataset"""
     name: str
-    initial_molecules: List[ObjectId]
+    initial_molecules: Set[ObjectId]
     td_keywords: TDKeywords
     attributes: Dict[str, Union[int, float, str]]  # Might be overloaded key types
     object_map: Dict[str, ObjectId] = {}


### PR DESCRIPTION
## Description
This PR fix a small bug in TorsionDrive dataset and service interface. Previously the bug will cause a crash in the server, when input `initial_molecules` has duplicates:
```
[E 190712 16:25:11 web:1788] Uncaught exception POST /service_queue (127.0.0.1)
    HTTPServerRequest(protocol='https', host='localhost:7777', method='POST', uri='/service_queue', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/home/qyd/codes/anaconda3/envs/qcf-dev/lib/python3.6/site-packages/tornado/web.py", line 1697, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/home/qyd/codes/openff_repos/QCFractal/qcfractal/queue/handlers.py", line 110, in post
        self.storage, self.logger, service_input, tag=body.meta.tag, priority=body.meta.priority))
      File "/home/qyd/codes/openff_repos/QCFractal/qcfractal/services/services.py", line 48, in initialize_service
        storage_socket, logger, service_input, tag=tag, priority=priority)
      File "/home/qyd/codes/openff_repos/QCFractal/qcfractal/services/torsiondrive_service.py", line 60, in initialize_from_api
        initial_molecule=[x.id for x in service_input.initial_molecule],
      File "/home/qyd/codes/openff_repos/QCFractal/qcfractal/services/torsiondrive_service.py", line 60, in <listcomp>
        initial_molecule=[x.id for x in service_input.initial_molecule],
    AttributeError: 'NoneType' object has no attribute 'id'
[E 190712 16:25:11 web:2246] 500 POST /service_queue (127.0.0.1) 96.14ms
```

This script can be used to reproduce the error: [debug.py.zip](https://github.com/MolSSI/QCFractal/files/3388206/debug.py.zip)

This PR propose a fix to remove duplicates at the interface.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Fixed

## Status
- [ ] Changelog updated
- [x] Ready to go