### PR TITLE
Add Server CLI Documentation

### DIFF
--- a/docs/qcfractal/source/conf.py
+++ b/docs/qcfractal/source/conf.py
@@ -136,7 +136,7 @@ except ModuleNotFoundError:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/qcfractal/source/database_design.rst
+++ b/docs/qcfractal/source/database_design.rst
@@ -28,14 +28,7 @@ to request computations, and all their related data, along with registered users
 computational managers.
 
 
-QCArchive DB is organized into a set of tables (or documents) as shown in the
-following diagram, each of which is described bellow.
-
-
-.. image:: media/database_design.jpg
-   :width: 800px
-   :alt: QCArchive Database Design
-   :align: center
+QCArchive DB is organized into a set of tables (or documents), each of which are detailed below.
 
 
 1) Molecule

--- a/docs/qcfractal/source/glossary.rst
+++ b/docs/qcfractal/source/glossary.rst
@@ -53,6 +53,11 @@ Some terms may appear in multiple glossaries, but will always have the same mean
       A set of data inside the Database which has a common :term:`ObjectId`. The ``table``
       name follows SQL conventions which is also known as a ``collection`` in MongoDB.
 
+    Fractal Config Directory
+      The directory where QCFractal Server and Database configuration files live. This is
+      also the home of the Database itself in the default configuration. Default path is
+      ``~/.qca/qcfractal``
+
 
 Contextually Organized Glossaries
 ---------------------------------

--- a/docs/qcfractal/source/index.rst
+++ b/docs/qcfractal/source/index.rst
@@ -122,6 +122,25 @@ Setting up and running Fractal's Queue Managers on your system.
    managers_faq.rst
    managers_detailed.rst
 
+**Server Documentation**
+
+Configuring and running the Server from the CLI and Config Files
+
+* :doc:`server_config`
+* :doc:`server_init`
+* :doc:`server_start`
+* :doc:`server_upgrade`
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Server Configuration and Running Documentation
+
+   server_config.rst
+   server_init.rst
+   server_start.rst
+   server_upgrade.rst
+
 **Developer Documentation**
 
 Contains in-depth developer documentation.

--- a/docs/qcfractal/source/server_config.rst
+++ b/docs/qcfractal/source/server_config.rst
@@ -1,0 +1,52 @@
+Fractal Server Config CLI and File
+==================================
+
+This page documents the valid options for the YAML file inputs to the :doc:`Config File <server_config>`.
+This first section outlines each of the headers (top level objects) and a description for each one.
+The final file will look like the following:
+
+.. code-block:: yaml
+
+    common:
+        option_1: value_for1
+        another_opt: 42
+    server:
+        option_for_server: "some string"
+
+Command Invocation
+------------------
+
+.. code-block:: bash
+
+    qcfractal-server config [<options>]
+
+Command Description
+-------------------
+
+Show the current config file at an optional location.
+
+Looks in the default location if no arg is provided
+
+Options
+-------
+
+``--base-folder [<folder>]``
+    The QCFractal base directory to attach to. Default: ``~/.qca/qcfractal``
+
+Config File Complete Options
+----------------------------
+
+The valid top-level YAML headers are the parameters of the ``FractalConfig`` class.
+
+.. autoclass:: qcfractal.config.FractalConfig
+
+``database``
+************
+
+.. autoclass:: qcfractal.config.DatabaseSettings
+
+``fractal``
+***********
+
+.. autoclass:: qcfractal.config.FractalServerSettings
+

--- a/docs/qcfractal/source/server_init.rst
+++ b/docs/qcfractal/source/server_init.rst
@@ -1,0 +1,109 @@
+Fractal Server Init
+===================
+
+The sub-command for the ``qcfractal-server`` CLI which initializes a new server instance, including configuring
+the PostgreSQL database if it is not setup yet.
+
+Command Invocation
+------------------
+
+.. code-block:: bash
+
+    qcfractal-server init [<options>]
+
+
+Command Description
+-------------------
+
+This command will attempt to do the following actions for the user in default mode (no args):
+
+* Create the :term:`QCFractal Config directory<Fractal Config Directory>`
+* Create a blank :doc:`Fractal Config file<server_config>` (assumes defaults)
+* Create the folders for housing the PostgreSQL database file, which will be the home of Fractal's data.
+* Initialize PostgreSQL's service at the database location from above
+* Start the PostgreSQL server
+* Populate the database tables and finalize everything for Fractal's operation
+
+In most cases, the user should not have to change any configurations if they are the system owners or admins. However,
+if users want to do something different, they can write their own :doc:`Config File <server_config>` and
+change the settings though the CLI to start the server.
+
+Options
+-------
+
+**This is a set of GLOBAL level options which impact where the ``init`` command looks, and how it interacts with the config file**
+
+``--overwrite``
+    Control whether the rest of the settings overwrite an existing config file in the
+    :term:`QCFractal Config directory<Fractal Config Directory>`
+
+``--base-folder [<folder>]``
+    The QCFractal base directory to attach to. Default: ``~/.qca/qcfractal``
+
+**This set of options pertain to the PostgreSQL database itself** and translate to the ``database`` header in the
+:doc:`server_config`.
+
+``--db-port [<port>]``
+    The PostgreSQL default port, Default ``5432``
+
+``--db-host [<host>]``
+    Default location for the Postgres server. If not ``localhost``, Fractal command lines cannot manage the instance.
+    and will have to be configured in the :doc:`Config File <server_config>`. Default: ``localhost``
+
+``--db-username [<user>]``
+    The postgres username to default to. **Planned Feature - Currently inactive**.
+
+``--db-password [<password>]``
+    The postgres password for the give user. **Planned Feature - Currently inactive**.
+
+``--db-directory [<dir_path>]``
+    "The physical location of the QCFractal instance data, defaults to the root
+    :term:`Config directory<Fractal Config Directory>`.
+
+``--db-default-database [<db_name>]``
+    The default database to connect to. Typically used if you already have a Fractal Database set up or you want to
+    use a different name for the database besides the default. Default ``qcfractal_default``.
+
+``--db-logfile [<logfile>]``
+    The logfile to write postgres logs. Default ``qcfractal_postgres.log``.
+
+``--db-own (True|False)``
+    If own is True, Fractal will control the database instance. If False Postgres will expect a booted server at the
+    database specification. Default ``True``
+
+
+**The settings below here pertain to the Fractal Server** and translate to the ``fractal`` header in the
+:doc:`server_config`.
+
+``--name [<name>]``
+    The Fractal server default name. Controls how the server presents itself to connected clients.
+    Default ``QCFractal Server``
+
+``--port [<port>]``
+    The Fractal default port. This is the port which Fractal listens to for client connections (and for the URI).
+    This is *separate* from the ``--db-port`` which is the port that PostgreSQL database is listening for. In general,
+    these should be separate. Default ``7777``.
+
+``--compres-response (True|False)``
+    Compress REST responses or not, should be True unless behind a proxy. Default ``True``.
+
+``--allow-read (True|False)``
+    Always allows read access to record tables. Default ``True``
+
+``--security [<security_string>]``
+    Optional security features. Not set by default.
+
+``--query-limit [<int_limit>]``
+    The maximum number of records to return per query. Default ``1000``
+
+``--logfile [<log>]``
+    The logfile the Fractal Server writes to. Default ``qcfractal_server.log``
+
+``--service-frequency [<frequency>]``
+    The frequency to update the Fractal services. Default ``60``
+
+``--max-active-services [<max-services>]``
+    The maximum number of concurrent active services. Default ``20``
+
+``--heartbeat-frequency [<heartbeat>]``
+    The frequency (in seconds) to check the heartbeat of :term:`Managers <Manager>`. Default ``1800``

--- a/docs/qcfractal/source/server_start.rst
+++ b/docs/qcfractal/source/server_start.rst
@@ -1,0 +1,66 @@
+Fractal Server Start
+====================
+
+The sub-command for the ``qcfractal-server`` CLI which starts the Fractal server instance
+
+Command Invocation
+------------------
+
+.. code-block:: bash
+
+    qcfractal-server start [<options>]
+
+
+Command Description
+-------------------
+
+This command will attempt to do the following actions for the user in default mode (no args):
+
+* Read the :term:`QCFractal Config directory<Fractal Config Directory>`
+* Read the config file in that directory
+* Connect to the previously created Fractal database created in the PostgreSQL service (see :doc:`server_init`).
+* Start Fractal's periodic services.
+* Create and provide SSL certificates.
+
+The options for the database and starting local compute on the same resources as the server can be controlled through
+the flags below. Also see all the config file options in :doc:`Config File <server_config>`.
+
+Options
+-------
+
+``--base-folder [<folder>]``
+    The QCFractal base directory to attach to. Default: ``~/.qca/qcfractal``
+
+``--port [<port>]``
+    The Fractal default port. This is the port which Fractal listens to for client connections (and for the URI).
+    This is *separate* from the `the port that PostgreSQL database is listening for. In general, these should be
+    separate. Default ``7777``.
+
+``--logfile [<log>]``
+    The logfile the Fractal Server writes to. Default ``qcfractal_server.log``
+
+``--database-name [<db_name>]``
+    The database to connect to, defaults to the default database name. Default ``qcfractal_default``
+
+``--server-name [<server_name>]``
+    The Fractal server default name. Controls how the server presents itself to connected clients.
+    Default ``QCFractal Server``
+
+``--start-periodics (True|False)``
+    **Expert Level Flag Only Warning!** Can disable periodic update (services, heartbeats) if False. Useful when
+    running behind a proxy. Default ``True``
+
+``--disable-ssl (False|True)``
+    Disables SSL if present, if ``False`` a SSL cert will be created for you. Default ``False``
+
+``--tsl-cert [<tsl_cert_str>]``
+    Certificate file for TLS (in PEM format)
+
+``--tsl-key [<tsl_key_str>]``
+    Private key file for TLS (in PEM format)
+
+``--local-manager [<int>]``
+    Creates a local pool QueueManager attached to the server using the number of threads specified by the arg.
+    If this flag is set and no number is provided, 1 (one) thread will be spun up and running locally. If you
+    expect :term:`Fractal Managers<Manager>` to connect to this server, then it is unlikely you need this. Related, if
+    no compute is expected to be done on this server, then it is unlikely this will be needed.

--- a/docs/qcfractal/source/server_upgrade.rst
+++ b/docs/qcfractal/source/server_upgrade.rst
@@ -1,0 +1,39 @@
+Fractal Server Upgrade
+======================
+
+The sub-command for the ``qcfractal-server`` CLI which allows in-place upgrade of Fractal Databases to newer versions
+through SQLAlchemy Alembic.
+
+Command Invocation
+------------------
+
+.. code-block:: bash
+
+    qcfractal-server upgrade [<options>]
+
+
+Command Description
+-------------------
+
+This command will attempt to upgrade an existing Fractal Database (stored in PostgreSQL) to a new version based on the
+currently installed Fractal software version. Not every version of Fractal updates the database, so this command will
+only need to be run when you know the database has changed (or attempting to start it tells you to).
+
+This command will attempt to do the following actions for the user in default mode (no args):
+
+* Read the database location from your :doc:`Config File <server_config>` in the default location (can be controlled)
+* Determine the upgrade paths from your existing version to the version known by Alembic (update information is
+  shipped with the Fractal software)
+* Stage update
+* Commit update if no errors found
+
+You will then need to start the server again through :doc:`server_start` to bring the server back online.
+
+Caveat: This command will **not** initialize the Fractal Database for you from nothing. The database must exist for
+this command to run.
+
+Options
+-------
+
+``--base-folder [<folder>]``
+    The QCFractal base directory to attach to. Default: ``~/.qca/qcfractal``

--- a/docs/qcfractal/source/setup_server.rst
+++ b/docs/qcfractal/source/setup_server.rst
@@ -41,7 +41,6 @@ with the ``start`` command:
 
 The QCFractal server is now ready to accept new connections.
 
-
 Within a Python Script
 ----------------------
 
@@ -86,3 +85,14 @@ than the canonical Python script. To manipulate a server in a Jupyter Notebook a
 
     # Obtain a FractalClient to the server
     >>> client = server.client()
+
+
+Full Server Config Settings
+---------------------------
+
+The full CLI and configs for the Fractal Server can be found on the following pages:
+
+* Fractal Server Config file: :doc:`server_config`
+* ``qcfractal-server init``: :doc:`server_init`
+* ``qcfractal-server start``: :doc:`server_start`
+* ``qcfractal-server upgrade``: :doc:`server_upgrade`

--- a/qcfractal/cli/cli_utils.py
+++ b/qcfractal/cli/cli_utils.py
@@ -7,14 +7,8 @@ import copy
 import importlib
 import json
 import signal
-from enum import Enum
-from functools import partial
-from textwrap import dedent, indent
-from typing import Tuple, Dict
-
 import yaml
-
-from pydantic import BaseModel, BaseSettings, validator, ValidationError
+from functools import partial
 
 
 def import_module(module, package=None):
@@ -106,111 +100,3 @@ def install_signal_handlers(loop, cleanup):
 
     for sig in [signal.SIGINT, signal.SIGTERM]:
         old_handlers[sig] = signal.signal(sig, handle_signal)
-
-
-class _JsonRefModel(BaseModel):
-    """
-    Reference model for Json replacement fillers
-
-    Matches style of:
-
-    ``'allOf': [{'$ref': '#/definitions/something'}]}``
-
-    and will always be a length 1 list
-    """
-    allOf: Tuple[Dict[str, str]]
-
-    @validator("allOf", whole=True)
-    def all_of_entries(cls, v):
-        value = v[0]
-        if len(value) != 1:
-            raise ValueError("Dict must be of length 1")
-        elif '$ref' not in value:
-            raise ValueError("Dict needs to have key $ref")
-        elif not isinstance(value["$ref"], str) or not value["$ref"].startswith('#/'):
-            raise ValueError("$ref should be formatted as #/definitions/...")
-        return v
-
-
-def doc_formatter(target_object):
-    """
-    Set the docstring for a Pydantic object automatically based on the parameters
-
-    This could use improvement.
-    """
-    doc = target_object.__doc__
-
-    # Handle non-pydantic objects
-    if doc is None:
-        new_doc = ''
-    elif 'Parameters\n' in doc or not (issubclass(target_object, BaseSettings) or issubclass(target_object, BaseModel)):
-        new_doc = doc
-    else:
-        type_formatter = {'boolan': 'bool',
-                          'string': 'str',
-                          'integer': 'int'
-                          }
-        # Add the white space
-        if not doc.endswith('\n\n'):
-            doc += "\n\n"
-        new_doc = dedent(doc) + "Parameters\n----------\n"
-        target_schema = target_object.schema()
-        # Go through each property
-        for prop_name, prop in target_schema['properties'].items():
-            # Catch lookups for other Pydantic objects
-            if '$ref' in prop:
-                # Pre 0.28 lookup
-                lookup = prop['$ref'].split('/')[-1]
-                prop = target_schema['definitions'][lookup]
-            elif 'allOf' in prop:
-                # Post 0.28 lookup
-                try:
-                    # Validation, we don't need output, just the object
-                    _JsonRefModel(**prop)
-                    lookup = prop['allOf'][0]['$ref'].split('/')[-1]
-                    prop = target_schema['definitions'][lookup]
-                except ValidationError:
-                    # Doesn't conform, pass on
-                    pass
-            # Get common properties
-            prop_type = prop["type"]
-            new_doc += prop_name + " : "
-            prop_desc = prop['description']
-
-            # Check for enumeration
-            if 'enum' in prop:
-                new_doc += '{' + ', '.join(prop['enum']) + '}'
-
-            # Set the name/type of object
-            else:
-                if prop_type == 'object':
-                    prop_field = prop['title']
-                else:
-                    prop_field = prop_type
-                new_doc += f'{type_formatter[prop_field] if prop_field in type_formatter else prop_field}'
-
-            # Handle Classes so as not to re-copy pydantic descriptions
-            if prop_type == 'object':
-                if not ('required' in target_schema and prop_name in target_schema['required']):
-                    new_doc += ", Optional"
-                prop_desc = f":class:`{prop['title']}`"
-
-            # Handle non-classes
-            else:
-                if 'default' in prop:
-                    default = prop['default']
-                    try:
-                        # Get the explicit default value for enum classes
-                        if issubclass(default, Enum):
-                            default = default.value
-                    except TypeError:
-                        pass
-                    new_doc += f", Default: {default}"
-                elif not ('required' in target_schema and prop_name in target_schema['required']):
-                    new_doc += ", Optional"
-
-            # Finally, write the detailed doc string
-            new_doc += "\n" + indent(prop_desc, "    ") + "\n"
-
-    # Assign the new doc string
-    target_object.__doc__ = new_doc

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -17,6 +17,7 @@ import qcfractal
 from pydantic import BaseModel, BaseSettings, validator, Schema
 
 from . import cli_utils
+from ..util import doc_formatter
 
 __all__ = ["main"]
 
@@ -97,7 +98,7 @@ class CommonManagerSettings(BaseSettings):
         pass
 
 
-cli_utils.doc_formatter(CommonManagerSettings)
+doc_formatter(CommonManagerSettings)
 
 
 class FractalServerSettings(BaseSettings):
@@ -132,7 +133,7 @@ class FractalServerSettings(BaseSettings):
         pass
 
 
-cli_utils.doc_formatter(FractalServerSettings)
+doc_formatter(FractalServerSettings)
 
 
 class QueueManagerSettings(BaseSettings):
@@ -196,7 +197,7 @@ class QueueManagerSettings(BaseSettings):
     )
 
 
-cli_utils.doc_formatter(QueueManagerSettings)
+doc_formatter(QueueManagerSettings)
 
 
 class SchedulerEnum(str, Enum):
@@ -273,7 +274,7 @@ class ClusterSettings(BaseSettings):
         return v.lower()
 
 
-cli_utils.doc_formatter(ClusterSettings)
+doc_formatter(ClusterSettings)
 
 
 class SettingsBlocker(BaseSettings):
@@ -336,7 +337,7 @@ class DaskQueueSettings(SettingsBlocker):
     _forbidden_name = "dask_jobqueue"
 
 
-cli_utils.doc_formatter(DaskQueueSettings)
+doc_formatter(DaskQueueSettings)
 
 
 class ParslExecutorSettings(SettingsBlocker):
@@ -367,7 +368,7 @@ class ParslExecutorSettings(SettingsBlocker):
     _forbidden_name = "the parsl executor"
 
 
-cli_utils.doc_formatter(ParslExecutorSettings)
+doc_formatter(ParslExecutorSettings)
 
 
 class ParslLauncherSettings(BaseSettings):
@@ -428,7 +429,7 @@ class ParslLauncherSettings(BaseSettings):
         pass
 
 
-cli_utils.doc_formatter(ParslLauncherSettings)
+doc_formatter(ParslLauncherSettings)
 
 
 class ParslProviderSettings(SettingsBlocker):
@@ -465,7 +466,7 @@ class ParslProviderSettings(SettingsBlocker):
     _forbidden_name = "parsl's provider"
 
 
-cli_utils.doc_formatter(ParslProviderSettings)
+doc_formatter(ParslProviderSettings)
 
 
 class ParslQueueSettings(BaseSettings):
@@ -486,7 +487,7 @@ class ParslQueueSettings(BaseSettings):
         extra = "allow"
 
 
-cli_utils.doc_formatter(ParslQueueSettings)
+doc_formatter(ParslQueueSettings)
 
 
 class ManagerSettings(BaseModel):
@@ -517,7 +518,7 @@ class ManagerSettings(BaseModel):
         extra = "forbid"
 
 
-cli_utils.doc_formatter(ManagerSettings)
+doc_formatter(ManagerSettings)
 
 
 def parse_args():

--- a/qcfractal/cli/qcfractal_server.py
+++ b/qcfractal/cli/qcfractal_server.py
@@ -56,7 +56,7 @@ def parse_args():
         help="Expert! Can disable periodic update (services, heartbeats) if False. Useful when running behind a proxy."
     )
 
-    fractal_args.add_argument("--disable_ssl",
+    fractal_args.add_argument("--disable-ssl",
                               default=False,
                               type=bool,
                               help="Disables SSL if present, if False a SSL cert will be created for you.")
@@ -73,7 +73,7 @@ def parse_args():
                               help='Creates a local pool QueueManager attached to the server.')
 
     ### Config subcommands
-    config = subparsers.add_parser('config', help="Starts a QCFractal server instance.")
+    config = subparsers.add_parser('config', help="Configure a QCFractal server instance.")
     config.add_argument("--base-folder", **FractalConfig.help_info("base_folder"))
 
     ### Move args around
@@ -130,13 +130,13 @@ def server_init(args, config):
             sys.exit(2)
         else:
             user_required_input = f"REMOVEALLDATA {str(config.database_path)}"
-            print("!WARNING! A QCFractal configuration is currently initalized")
+            print("!WARNING! A QCFractal configuration is currently initialized")
             print(
                 f"!WARNING! Overwriting will delete all current Fractal data, this includes all data in {str(config.database_path)}."
             )
             print("!WARNING! Please use `qcfractal-server config` to alter configuration settings instead.")
             print()
-            print(f"!WARNING! If you are sure you wish to procede please type '{user_required_input}' below.")
+            print(f"!WARNING! If you are sure you wish to proceed please type '{user_required_input}' below.")
 
             inp = input("  > ")
             print()

--- a/qcfractal/config.py
+++ b/qcfractal/config.py
@@ -9,16 +9,19 @@ from typing import Optional
 
 from pydantic import BaseSettings, Schema, validator
 
+from .util import doc_formatter
+
 
 def _str2bool(v):
     if isinstance(v, bool):
-       return v
+        return v
     if v.lower() in ('yes', 'true', 't', 'y', '1'):
         return True
     elif v.lower() in ('no', 'false', 'f', 'n', '0'):
         return False
     else:
         raise argparse.ArgumentTypeError('Boolean value expected.')
+
 
 class SettingsCommonConfig:
     env_prefix = "QCF_"
@@ -54,8 +57,8 @@ class DatabaseSettings(ConfigSettings):
     port: int = Schema(5432, description="The postgresql default port")
     host: str = Schema(
         "localhost",
-        description=
-        "Default location for the postgres server. If not localhost, qcfractal command lines cannot manage the instance."
+        description="Default location for the postgres server. If not localhost, qcfractal command lines cannot manage "
+                    "the instance."
     )
     username: str = Schema(None, description="The postgres username to default to.")
     password: str = Schema(None, description="The postgres password for the give user.")
@@ -63,21 +66,26 @@ class DatabaseSettings(ConfigSettings):
         None, description="The physical location of the QCFractal instance data, defaults to the root folder.")
     default_database: str = Schema("qcfractal_default", description="The default database to connect to.")
     logfile: str = Schema("qcfractal_postgres.log", description="The logfile to write postgres logs.")
-    own: bool = Schema(True, description="If own is True, QCFractal will control the database instance. If False Postgres will expect a booted server at the database specification.")
+    own: bool = Schema(True, description="If own is True, QCFractal will control the database instance. If False "
+                                         "Postgres will expect a booted server at the database specification.")
 
     class Config(SettingsCommonConfig):
         pass
 
 
+doc_formatter(DatabaseSettings)
+
+
 class FractalServerSettings(ConfigSettings):
     """
-    Postgres Database settings
+    Fractal Server settings
     """
 
     name: str = Schema("QCFractal Server", description="The QCFractal server default name.")
     port: int = Schema(7777, description="The QCFractal default port.")
 
-    compress_response: bool = Schema(True, description="Compress REST responses or not, should be True unless behind a proxy.")
+    compress_response: bool = Schema(True, description="Compress REST responses or not, should be True unless behind a "
+                                                       "proxy.")
     allow_read: bool = Schema(True, description="Always allows read access to record tables.")
     security: str = Schema(None, description="Optional security features.")
 
@@ -98,10 +106,17 @@ class FractalServerSettings(ConfigSettings):
         pass
 
 
+doc_formatter(FractalServerSettings)
+
+
 class FractalConfig(ConfigSettings):
+    """
+    Top level configuration headers and options for a QCFractal Configuration File
+    """
 
     base_folder: str = Schema(os.path.expanduser("~/.qca/qcfractal"),
-                              description="The QCFractal base instance to attach to.")
+                              description="The QCFractal base instance to attach to. "
+                                          "Default will be your home directory")
     database: DatabaseSettings = DatabaseSettings()
     fractal: FractalServerSettings = FractalServerSettings()
 
@@ -146,3 +161,6 @@ class FractalConfig(ConfigSettings):
             uri += database
 
         return uri
+
+
+doc_formatter(FractalConfig)

--- a/qcfractal/postgres_harness.py
+++ b/qcfractal/postgres_harness.py
@@ -126,7 +126,7 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
         self._check_psql()
 
         if not self.quiet:
-            logger(f"pqsl command: {cmd}")
+            self.logger(f"pqsl command: {cmd}")
         psql_cmd = [shutil.which("psql"), "-p", str(self.config.database.port), "-c"]
         return self._run(psql_cmd + [cmd])
 
@@ -196,7 +196,6 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
                     "\nEither shut down the other PostgreSQL database or change the `qcfractal-server init --db-port`."
                     "\nStopping."
                 )
-
 
             if not self.is_alive():
                 raise ValueError(f"PostgreSQL is running, but cannot connect to the default port.")

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -563,7 +563,7 @@ class QueueManager:
         task_stats_str = (f"Task Stats: Processed={self.statistics.total_completed_tasks}, "
                           f"Failed={self.statistics.total_failed_tasks}, "
                           f"Success={success_rate:{success_format}}%")
-        worker_stats_str = f"Worker Stats (est.): Core Hours Used={self.statistics.total_core_hours:{float_format}}, "
+        worker_stats_str = f"Worker Stats (est.): Core Hours Used={self.statistics.total_core_hours:{float_format}}"
 
         # Handle efficiency calculations
         if log_efficiency:
@@ -577,7 +577,7 @@ class QueueManager:
                 efficiency_of_running = self.statistics.total_core_hours / self.statistics.total_core_hours_consumed
                 efficiency_of_potential = self.statistics.total_core_hours / self.statistics.total_core_hours_possible
                 efficiency_format = float_format
-            worker_stats_str += f"Core Usage Efficiency: {efficiency_of_running*100:{efficiency_format}}%"
+            worker_stats_str += f", Core Usage Efficiency: {efficiency_of_running*100:{efficiency_format}}%"
             if self.verbose:
                 worker_stats_str += (f", Core Usage vs. Max Resources Requested: "
                                      f"{efficiency_of_potential*100:{efficiency_format}}%")

--- a/qcfractal/queue/parsl_adapter.py
+++ b/qcfractal/queue/parsl_adapter.py
@@ -90,14 +90,17 @@ class ParslAdapter(BaseAdapter):
                 # Efficiency loop break
                 break
 
+        found_readable = False
         for executor_key, executor in self.client.executors.items():
             if hasattr(executor, 'connected_workers'):
                 # Should return an int
                 running += executor.connected_workers
+                found_readable = True
             elif hasattr(executor, 'max_threads') and executor_running_task_map[executor_key]:
                 running += 1
-            else:
-                raise NotImplementedError("Cannot accurately estimate consumption from executors")
+                found_readable = True
+        if not found_readable:
+            raise NotImplementedError("Cannot accurately estimate consumption from executors")
 
         return running
 

--- a/qcfractal/util.py
+++ b/qcfractal/util.py
@@ -3,6 +3,11 @@ Utility functions for QCFractal.
 """
 
 import socket
+from enum import Enum
+from textwrap import dedent, indent
+from typing import Tuple, Dict
+
+from pydantic import BaseModel, BaseSettings, validator, ValidationError
 
 
 def find_port() -> int:
@@ -10,6 +15,7 @@ def find_port() -> int:
     sock.bind(('', 0))
     host, port = sock.getsockname()
     return port
+
 
 def is_port_open(ip: str, port: int) -> bool:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -22,3 +28,111 @@ def is_port_open(ip: str, port: int) -> bool:
         return False
     finally:
         s.close()
+
+
+class _JsonRefModel(BaseModel):
+    """
+    Reference model for Json replacement fillers
+
+    Matches style of:
+
+    ``'allOf': [{'$ref': '#/definitions/something'}]}``
+
+    and will always be a length 1 list
+    """
+    allOf: Tuple[Dict[str, str]]
+
+    @validator("allOf", whole=True)
+    def all_of_entries(cls, v):
+        value = v[0]
+        if len(value) != 1:
+            raise ValueError("Dict must be of length 1")
+        elif '$ref' not in value:
+            raise ValueError("Dict needs to have key $ref")
+        elif not isinstance(value["$ref"], str) or not value["$ref"].startswith('#/'):
+            raise ValueError("$ref should be formatted as #/definitions/...")
+        return v
+
+
+def doc_formatter(target_object):
+    """
+    Set the docstring for a Pydantic object automatically based on the parameters
+
+    This could use improvement.
+    """
+    doc = target_object.__doc__
+
+    # Handle non-pydantic objects
+    if doc is None:
+        new_doc = ''
+    elif 'Parameters\n' in doc or not (issubclass(target_object, BaseSettings) or issubclass(target_object, BaseModel)):
+        new_doc = doc
+    else:
+        type_formatter = {'boolan': 'bool',
+                          'string': 'str',
+                          'integer': 'int'
+                          }
+        # Add the white space
+        if not doc.endswith('\n\n'):
+            doc += "\n\n"
+        new_doc = dedent(doc) + "Parameters\n----------\n"
+        target_schema = target_object.schema()
+        # Go through each property
+        for prop_name, prop in target_schema['properties'].items():
+            # Catch lookups for other Pydantic objects
+            if '$ref' in prop:
+                # Pre 0.28 lookup
+                lookup = prop['$ref'].split('/')[-1]
+                prop = target_schema['definitions'][lookup]
+            elif 'allOf' in prop:
+                # Post 0.28 lookup
+                try:
+                    # Validation, we don't need output, just the object
+                    _JsonRefModel(**prop)
+                    lookup = prop['allOf'][0]['$ref'].split('/')[-1]
+                    prop = target_schema['definitions'][lookup]
+                except ValidationError:
+                    # Doesn't conform, pass on
+                    pass
+            # Get common properties
+            prop_type = prop["type"]
+            new_doc += prop_name + " : "
+            prop_desc = prop['description']
+
+            # Check for enumeration
+            if 'enum' in prop:
+                new_doc += '{' + ', '.join(prop['enum']) + '}'
+
+            # Set the name/type of object
+            else:
+                if prop_type == 'object':
+                    prop_field = prop['title']
+                else:
+                    prop_field = prop_type
+                new_doc += f'{type_formatter[prop_field] if prop_field in type_formatter else prop_field}'
+
+            # Handle Classes so as not to re-copy pydantic descriptions
+            if prop_type == 'object':
+                if not ('required' in target_schema and prop_name in target_schema['required']):
+                    new_doc += ", Optional"
+                prop_desc = f":class:`{prop['title']}`"
+
+            # Handle non-classes
+            else:
+                if 'default' in prop:
+                    default = prop['default']
+                    try:
+                        # Get the explicit default value for enum classes
+                        if issubclass(default, Enum):
+                            default = default.value
+                    except TypeError:
+                        pass
+                    new_doc += f", Default: {default}"
+                elif not ('required' in target_schema and prop_name in target_schema['required']):
+                    new_doc += ", Optional"
+
+            # Finally, write the detailed doc string
+            new_doc += "\n" + indent(prop_desc, "    ") + "\n"
+
+    # Assign the new doc string
+    target_object.__doc__ = new_doc


### PR DESCRIPTION
## Description
This adds the `qcfractal-server` CLU documentation for all its
sub-options: init, start, config, and upgrade. This included using
the auto-doc wrapper for Pydantic `Schema`-rich classes, which had to
be moved higher up in the directory structure for easy imports. If need
be, I can move it back down into the CLI Utils instead of top level
Utils and import from there.

There are also a number of other fixes found in writing these listed
below:

* Fix Sphinx errors about missing `_static` directory
* Removed doc reference to a `database_design.jpg` file which was removed a while ago
* Renamed arg `--disable_ssl` to `--disable-ssl` to match other args (CLI hyphens vs underscore)
* Fixed bug in Parsl Adapter worker efficiency raising when it should not have
* Small typos in docstring fixes
* Fixed logger bug in PostgresHarness

## Status
- [ ] Changelog updated
- [x] Ready to go