### PR TITLE
Allow Retries as Engine Option, Error trap doc formatter

### DIFF
--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -35,7 +35,7 @@ dependencies:
   - parsl>=0.8.0
 
 # QCArchive includes
-  - qcengine>=0.6.2
+  - qcengine>=0.8.1
   - qcelemental>=0.5.0
 
 # Pip includes

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -26,5 +26,5 @@ dependencies:
   - codecov
 
 # QCArchive includes
-  - qcengine>=0.6.2
+  - qcengine>=0.8.1
   - qcelemental>=0.5.0

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -35,7 +35,7 @@ dependencies:
   - pytest-cov
   - codecov
 """
-qca_ecosystem_template = ["qcengine>=0.6.2", "qcelemental>=0.5.0"]
+qca_ecosystem_template = ["qcengine>=0.8.1", "qcelemental>=0.5.0"]
 
 pip_depends_template = []
 

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -33,5 +33,5 @@ dependencies:
   - torsiondrive
 
 # QCArchive includes
-  - qcengine>=0.6.2
+  - qcengine>=0.8.1
   - qcelemental>=0.5.0

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -547,6 +547,7 @@ def parse_args():
     common.add_argument("--cores-per-worker", type=int, help="The number of process for each executor's Workers")
     common.add_argument("--memory-per-worker", type=int, help="The total amount of memory on the system in GB")
     common.add_argument("--scratch-directory", type=str, help="Scratch directory location")
+    common.add_argument("--retries", type=int, help="Number of RandomError retries per task before failing the task")
     common.add_argument("-v", "--verbose", action="store_true", help="Increase verbosity of the logger.")
 
     # FractalClient options

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -84,6 +84,13 @@ class CommonManagerSettings(BaseSettings):
                     "This must be a positive, non zero integer.",
         gt=0
     )
+    retries: int = Schema(
+        2,
+        description="Number of retries that QCEngine will attempt for RandomErrors detected when running "
+                    "its computations. After this many attempts (or on any other type of error), the "
+                    "error will be raised.",
+        ge=0
+    )
     scratch_directory: Optional[str] = Schema(
         None,
         description="Scratch directory for Engine execution jobs."
@@ -588,7 +595,7 @@ def parse_args():
     # Stupid we cannot inspect groups
     data = {
         "common": _build_subset(args, {"adapter", "tasks_per_worker", "cores_per_worker", "memory_per_worker",
-                                       "scratch_directory", "verbose"}),
+                                       "scratch_directory", "retries", "verbose"}),
         "server": _build_subset(args, {"fractal_uri", "password", "username", "verify"}),
         "manager": _build_subset(args, {"max_queued_tasks", "manager_name", "queue_tag", "log_file_prefix",
                                         "update_frequency", "test", "ntests"}),
@@ -832,6 +839,7 @@ def main(args=None):
         cores_per_task=cores_per_task,
         memory_per_task=memory_per_task,
         scratch_directory=settings.common.scratch_directory,
+        retries=settings.common.retries,
         verbose=settings.common.verbose
     )
 

--- a/qcfractal/cli/tests/manager_boot_template.yaml
+++ b/qcfractal/cli/tests/manager_boot_template.yaml
@@ -5,6 +5,7 @@ common:
   memory_per_worker: 1
   max_workers: 1
   scratch_directory: "$TMPDIR"
+  retries: 1
   verbose: true
 
 server:

--- a/qcfractal/queue/base_adapter.py
+++ b/qcfractal/queue/base_adapter.py
@@ -19,6 +19,7 @@ class BaseAdapter(abc.ABC):
                  cores_per_task: Optional[int] = None,
                  memory_per_task: Optional[float] = None,
                  scratch_directory: Optional[str] = None,
+                 retries: Optional[int] = 2,
                  verbose: bool = False,
                  **kwargs):
         """
@@ -43,6 +44,10 @@ class BaseAdapter(abc.ABC):
         scratch_directory: str, optional, Default: None
             Location of the scratch directory to compute QCEngine tasks in
             It is up to the specific Adapter implementation to handle this option
+        retries : int, optional, Default: 2
+            Number of retries that QCEngine will attempt for RandomErrors detected when running
+            its computations. After this many attempts (or on any other type of error), the
+            error will be raised.
         verbose: bool, Default: True
             Increase verbosity of the logger
         """
@@ -54,6 +59,7 @@ class BaseAdapter(abc.ABC):
         self.cores_per_task = cores_per_task
         self.memory_per_task = memory_per_task
         self.scratch_directory = scratch_directory
+        self.retries = retries
         self.verbose = verbose
         if self.verbose:
             self.logger.setLevel("DEBUG")
@@ -108,6 +114,8 @@ class BaseAdapter(abc.ABC):
             local_options["ncores"] = self.cores_per_task
         if self.scratch_directory is not None:
             local_options["scratch_directory"] = self.scratch_directory
+        if self.retries is not None:
+            local_options["retries"] = self.retries
         return local_options
 
     def submit_tasks(self, tasks: List[Dict[str, Any]]) -> List[str]:

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -87,7 +87,8 @@ class QueueManager:
                  stale_update_limit: Optional[int] = 10,
                  cores_per_task: Optional[int] = None,
                  memory_per_task: Optional[Union[int, float]] = None,
-                 scratch_directory: Optional[str] = None):
+                 scratch_directory: Optional[str] = None,
+                 retries: Optional[int] = 2):
         """
         Parameters
         ----------
@@ -123,9 +124,13 @@ class QueueManager:
         memory_per_task: int, optional, Default: None
             How much memory, in GiB, per computation task to allocate for QCEngine
             None indicates "use however much you can consume"
-        scratch_directory: str, optional, Default: None
+        scratch_directory : str, optional, Default: None
             Scratch directory location to do QCEngine compute
             None indicates "wherever the system default is"'
+        retries : int, optional, Default: 2
+            Number of retries that QCEngine will attempt for RandomErrors detected when running
+            its computations. After this many attempts (or on any other type of error), the
+            error will be raised.
         """
 
         # Setup logging
@@ -141,11 +146,13 @@ class QueueManager:
         self.cores_per_task = cores_per_task
         self.memory_per_task = memory_per_task
         self.scratch_directory = scratch_directory
+        self.retries = retries
         self.queue_adapter = build_queue_adapter(queue_client,
                                                  logger=self.logger,
                                                  cores_per_task=self.cores_per_task,
                                                  memory_per_task=self.memory_per_task,
                                                  scratch_directory=self.scratch_directory,
+                                                 retries=self.retries,
                                                  verbose=verbose)
         self.max_tasks = max_tasks
         self.queue_tag = queue_tag

--- a/qcfractal/util.py
+++ b/qcfractal/util.py
@@ -68,71 +68,76 @@ def doc_formatter(target_object):
     elif 'Parameters\n' in doc or not (issubclass(target_object, BaseSettings) or issubclass(target_object, BaseModel)):
         new_doc = doc
     else:
-        type_formatter = {'boolan': 'bool',
-                          'string': 'str',
-                          'integer': 'int'
-                          }
-        # Add the white space
-        if not doc.endswith('\n\n'):
-            doc += "\n\n"
-        new_doc = dedent(doc) + "Parameters\n----------\n"
-        target_schema = target_object.schema()
-        # Go through each property
-        for prop_name, prop in target_schema['properties'].items():
-            # Catch lookups for other Pydantic objects
-            if '$ref' in prop:
-                # Pre 0.28 lookup
-                lookup = prop['$ref'].split('/')[-1]
-                prop = target_schema['definitions'][lookup]
-            elif 'allOf' in prop:
-                # Post 0.28 lookup
-                try:
-                    # Validation, we don't need output, just the object
-                    _JsonRefModel(**prop)
-                    lookup = prop['allOf'][0]['$ref'].split('/')[-1]
+        try:
+            new_doc = doc
+            type_formatter = {'boolan': 'bool',
+                              'string': 'str',
+                              'integer': 'int'
+                              }
+            # Add the white space
+            if not new_doc.endswith('\n\n'):
+                new_doc += "\n\n"
+            new_doc = dedent(new_doc) + "Parameters\n----------\n"
+            target_schema = target_object.schema()
+            # Go through each property
+            for prop_name, prop in target_schema['properties'].items():
+                # Catch lookups for other Pydantic objects
+                if '$ref' in prop:
+                    # Pre 0.28 lookup
+                    lookup = prop['$ref'].split('/')[-1]
                     prop = target_schema['definitions'][lookup]
-                except ValidationError:
-                    # Doesn't conform, pass on
-                    pass
-            # Get common properties
-            prop_type = prop["type"]
-            new_doc += prop_name + " : "
-            prop_desc = prop['description']
-
-            # Check for enumeration
-            if 'enum' in prop:
-                new_doc += '{' + ', '.join(prop['enum']) + '}'
-
-            # Set the name/type of object
-            else:
-                if prop_type == 'object':
-                    prop_field = prop['title']
-                else:
-                    prop_field = prop_type
-                new_doc += f'{type_formatter[prop_field] if prop_field in type_formatter else prop_field}'
-
-            # Handle Classes so as not to re-copy pydantic descriptions
-            if prop_type == 'object':
-                if not ('required' in target_schema and prop_name in target_schema['required']):
-                    new_doc += ", Optional"
-                prop_desc = f":class:`{prop['title']}`"
-
-            # Handle non-classes
-            else:
-                if 'default' in prop:
-                    default = prop['default']
+                elif 'allOf' in prop:
+                    # Post 0.28 lookup
                     try:
-                        # Get the explicit default value for enum classes
-                        if issubclass(default, Enum):
-                            default = default.value
-                    except TypeError:
+                        # Validation, we don't need output, just the object
+                        _JsonRefModel(**prop)
+                        lookup = prop['allOf'][0]['$ref'].split('/')[-1]
+                        prop = target_schema['definitions'][lookup]
+                    except ValidationError:
+                        # Doesn't conform, pass on
                         pass
-                    new_doc += f", Default: {default}"
-                elif not ('required' in target_schema and prop_name in target_schema['required']):
-                    new_doc += ", Optional"
+                # Get common properties
+                prop_type = prop["type"]
+                new_doc += prop_name + " : "
+                prop_desc = prop['description']
 
-            # Finally, write the detailed doc string
-            new_doc += "\n" + indent(prop_desc, "    ") + "\n"
+                # Check for enumeration
+                if 'enum' in prop:
+                    new_doc += '{' + ', '.join(prop['enum']) + '}'
+
+                # Set the name/type of object
+                else:
+                    if prop_type == 'object':
+                        prop_field = prop['title']
+                    else:
+                        prop_field = prop_type
+                    new_doc += f'{type_formatter[prop_field] if prop_field in type_formatter else prop_field}'
+
+                # Handle Classes so as not to re-copy pydantic descriptions
+                if prop_type == 'object':
+                    if not ('required' in target_schema and prop_name in target_schema['required']):
+                        new_doc += ", Optional"
+                    prop_desc = f":class:`{prop['title']}`"
+
+                # Handle non-classes
+                else:
+                    if 'default' in prop:
+                        default = prop['default']
+                        try:
+                            # Get the explicit default value for enum classes
+                            if issubclass(default, Enum):
+                                default = default.value
+                        except TypeError:
+                            pass
+                        new_doc += f", Default: {default}"
+                    elif not ('required' in target_schema and prop_name in target_schema['required']):
+                        new_doc += ", Optional"
+
+                # Finally, write the detailed doc string
+                new_doc += "\n" + indent(prop_desc, "    ") + "\n"
+        except:
+            # For any reason, this fails, fall back
+            new_doc = doc
 
     # Assign the new doc string
     target_object.__doc__ = new_doc

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
             'psycopg2',
 
             # QCArchive depends
-            'qcengine>=0.6.2',
+            'qcengine>=0.8.1',
             'qcelemental>=0.5.0',
 
             # Testing


### PR DESCRIPTION
## Description
Allows the `retries` options to be passed to the Engine 0.8 feature.
Pins the Engine version to a minimum of 0.8.1.

The `doc_formatter` function is now wrapped in a `try...except` block
which catches all errors for now. A refactor will be post 0.8

## Status
- [ ] Changelog updated
- [x] Ready to go