### PR TITLE
On-Demand BaseModel Doc Generation

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -17,7 +17,7 @@ import qcfractal
 from pydantic import BaseModel, BaseSettings, validator, Schema
 
 from . import cli_utils
-from ..interface.util import doc_formatter
+from ..interface.util import auto_gen_docs_on_demand
 
 __all__ = ["main"]
 
@@ -105,7 +105,7 @@ class CommonManagerSettings(BaseSettings):
         pass
 
 
-doc_formatter(CommonManagerSettings)
+auto_gen_docs_on_demand(CommonManagerSettings)
 
 
 class FractalServerSettings(BaseSettings):
@@ -140,7 +140,7 @@ class FractalServerSettings(BaseSettings):
         pass
 
 
-doc_formatter(FractalServerSettings)
+auto_gen_docs_on_demand(FractalServerSettings)
 
 
 class QueueManagerSettings(BaseSettings):
@@ -204,7 +204,7 @@ class QueueManagerSettings(BaseSettings):
     )
 
 
-doc_formatter(QueueManagerSettings)
+auto_gen_docs_on_demand(QueueManagerSettings)
 
 
 class SchedulerEnum(str, Enum):
@@ -281,7 +281,7 @@ class ClusterSettings(BaseSettings):
         return v.lower()
 
 
-doc_formatter(ClusterSettings)
+auto_gen_docs_on_demand(ClusterSettings)
 
 
 class SettingsBlocker(BaseSettings):
@@ -344,7 +344,7 @@ class DaskQueueSettings(SettingsBlocker):
     _forbidden_name = "dask_jobqueue"
 
 
-doc_formatter(DaskQueueSettings)
+auto_gen_docs_on_demand(DaskQueueSettings)
 
 
 class ParslExecutorSettings(SettingsBlocker):
@@ -375,7 +375,7 @@ class ParslExecutorSettings(SettingsBlocker):
     _forbidden_name = "the parsl executor"
 
 
-doc_formatter(ParslExecutorSettings)
+auto_gen_docs_on_demand(ParslExecutorSettings)
 
 
 class ParslLauncherSettings(BaseSettings):
@@ -436,7 +436,7 @@ class ParslLauncherSettings(BaseSettings):
         pass
 
 
-doc_formatter(ParslLauncherSettings)
+auto_gen_docs_on_demand(ParslLauncherSettings)
 
 
 class ParslProviderSettings(SettingsBlocker):
@@ -473,7 +473,7 @@ class ParslProviderSettings(SettingsBlocker):
     _forbidden_name = "parsl's provider"
 
 
-doc_formatter(ParslProviderSettings)
+auto_gen_docs_on_demand(ParslProviderSettings)
 
 
 class ParslQueueSettings(BaseSettings):
@@ -494,7 +494,7 @@ class ParslQueueSettings(BaseSettings):
         extra = "allow"
 
 
-doc_formatter(ParslQueueSettings)
+auto_gen_docs_on_demand(ParslQueueSettings)
 
 
 class ManagerSettings(BaseModel):
@@ -516,7 +516,7 @@ class ManagerSettings(BaseModel):
         extra = "forbid"
 
 
-doc_formatter(ManagerSettings)
+auto_gen_docs_on_demand(ManagerSettings)
 
 
 def parse_args():

--- a/qcfractal/config.py
+++ b/qcfractal/config.py
@@ -10,7 +10,7 @@ from typing import Optional
 from pydantic import BaseSettings, Schema, validator
 import yaml
 
-from .interface.util import doc_formatter
+from .interface.util import auto_gen_docs_on_demand
 
 
 def _str2bool(v):
@@ -74,7 +74,7 @@ class DatabaseSettings(ConfigSettings):
         pass
 
 
-doc_formatter(DatabaseSettings)
+auto_gen_docs_on_demand(DatabaseSettings)
 
 
 class FractalServerSettings(ConfigSettings):
@@ -117,7 +117,7 @@ class FractalServerSettings(ConfigSettings):
         pass
 
 
-doc_formatter(FractalServerSettings)
+auto_gen_docs_on_demand(FractalServerSettings)
 
 
 class FractalConfig(ConfigSettings):
@@ -203,4 +203,4 @@ class FractalConfig(ConfigSettings):
             return os.path.join(self.base_folder, self.fractal._default_geo_filename)
 
 
-doc_formatter(FractalConfig)
+auto_gen_docs_on_demand(FractalConfig)

--- a/qcfractal/interface/models/__init__.py
+++ b/qcfractal/interface/models/__init__.py
@@ -12,11 +12,11 @@ from .records import OptimizationRecord, ResultRecord
 from .task_models import PythonComputeSpec, TaskRecord, TaskStatusEnum, ManagerStatusEnum
 from .torsiondrive import TorsionDriveInput, TorsionDriveRecord
 
-from ..util import doc_formatter
+from ..util import auto_gen_docs_on_demand
+
 
 for model in (ComputeResponse, KeywordSet, Molecule, OptimizationRecord, QCSpecification,
-              GridOptimizationInput, GridOptimizationRecord,
-              OptimizationRecord, ResultRecord,
+              GridOptimizationInput, GridOptimizationRecord, ResultRecord,
               PythonComputeSpec, TaskRecord,
               TorsionDriveInput, TorsionDriveRecord):
-    doc_formatter(model)
+    auto_gen_docs_on_demand(model)


### PR DESCRIPTION
## Description
This changes the behavior of the auto-doc formatting of BaseModels
(and their subclasses) to instead be on-demand when `__doc__` is called
by assigning `__doc__` to be a descriptor instead of a string.

In theory, this should make the speed of importing faster, but I'm not quite sure what the best way to profile it is. I could write a cPython timer `with` inside the `__init__` and see what it returns after a bunch of trials, that would reduce the noise of importing everything else, but it may also just not be worth it.

Yes, this does abuse the __doc__ method by making it not technically read only, but this does avoid having to deal with fancy meta-classing.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Figure out the correct way to time this process without the noise of importing everything else (optional)

## Questions
  - [ ] Should I make the `auto_gen_docs_on_demand` and `AutoPydanticDocGenerator` fault tolerant?

## Status
- [ ] Changelog updated
- [x] Ready to go