### PR TITLE
More Queue Manger QoL additions and testing

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -572,10 +572,14 @@ def parse_args():
                                                                 "config file and exit. This will always show the "
                                                                 "most up-to-date schema. It will be presented in a "
                                                                 "JSON-like format.")
-    optional.add_argument("--skeleton", "--skel", type=str, help="Create a skeleton/example YAML config file at the "
-                                                                 "specified path. This does not start the manager "
-                                                                 "and instead creates a skeleton based on all the "
-                                                                 "options specified.")
+    optional.add_argument("--skeleton", "--skel",
+                          type=str,
+                          const="manager_config.yaml",
+                          default=None,
+                          action='store',
+                          nargs='?',
+                          help="Create a skeleton/example YAML config file at the specified path. This does not start "
+                               "the manager and instead creates a skeleton based on all the options specified.")
 
     # Move into nested namespace
     args = vars(parser.parse_args())

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -193,3 +193,10 @@ def test_cli_managers_schema():
     """Test that qcfractal_manager --schema works"""
     args = ["qcfractal-manager", "--schema"]
     testing.run_process(args, **_options)
+
+
+def test_cli_managers_skel(tmp_path):
+    """Test that qcfractal_manager --skeleton works"""
+    config = tmp_path / "config.yaml"
+    args = ["qcfractal-manager", "--skel", config.as_posix()]
+    testing.run_process(args, **_options)

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -581,13 +581,15 @@ class QueueManager:
                 efficiency_of_potential = "(N/A yet)"
                 efficiency_format = na_format
             else:
-                efficiency_of_running = self.statistics.total_core_hours / self.statistics.total_core_hours_consumed
-                efficiency_of_potential = self.statistics.total_core_hours / self.statistics.total_core_hours_possible
+                efficiency_of_running = (self.statistics.total_core_hours / self.statistics.total_core_hours_consumed
+                                         * 100)
+                efficiency_of_potential = (self.statistics.total_core_hours / self.statistics.total_core_hours_possible
+                                           * 100)
                 efficiency_format = float_format
-            worker_stats_str += f", Core Usage Efficiency: {efficiency_of_running*100:{efficiency_format}}%"
+            worker_stats_str += f", Core Usage Efficiency: {efficiency_of_running:{efficiency_format}}%"
             if self.verbose:
                 worker_stats_str += (f", Core Usage vs. Max Resources Requested: "
-                                     f"{efficiency_of_potential*100:{efficiency_format}}%")
+                                     f"{efficiency_of_potential:{efficiency_format}}%")
 
         self.logger.info(task_stats_str)
         self.logger.info(worker_stats_str)

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -548,13 +548,6 @@ class QueueManager:
 
         open_slots = max(0, self.max_tasks - self.active)
 
-        if (new_tasks is False) or (open_slots == 0):
-            return True
-
-        # Get new tasks
-        payload = self._payload_template()
-        payload["data"]["limit"] = open_slots
-
         # Crunch Statistics
         self.statistics.total_failed_tasks += n_fail
         self.statistics.total_successful_tasks += n_success
@@ -598,6 +591,13 @@ class QueueManager:
         self.logger.info(task_stats_str)
         if worker_stats_str is not None:
             self.logger.info(worker_stats_str)
+
+        if (new_tasks is False) or (open_slots == 0):
+            return True
+
+        # Get new tasks
+        payload = self._payload_template()
+        payload["data"]["limit"] = open_slots
 
         try:
             new_tasks = self.client._automodel_request("queue_manager", "get", payload)

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -562,37 +562,42 @@ class QueueManager:
         na_format = ''
         float_format = ',.2f'
         if self.statistics.total_completed_tasks == 0:
-            success_rate = "(N/A yet)"
-            success_format = na_format
+            task_stats_str = "Task statistics unavailable until first tasks return"
+            worker_stats_str = None
         else:
             success_rate = self.statistics.total_successful_tasks / self.statistics.total_completed_tasks * 100
             success_format = float_format
-        task_stats_str = (f"Task Stats: Processed={self.statistics.total_completed_tasks}, "
-                          f"Failed={self.statistics.total_failed_tasks}, "
-                          f"Success={success_rate:{success_format}}%")
-        worker_stats_str = f"Worker Stats (est.): Core Hours Used={self.statistics.total_core_hours:{float_format}}"
+            task_stats_str = (f"Task Stats: Processed={self.statistics.total_completed_tasks}, "
+                              f"Failed={self.statistics.total_failed_tasks}, "
+                              f"Success={success_rate:{success_format}}%")
+            worker_stats_str = f"Worker Stats (est.): Core Hours Used={self.statistics.total_core_hours:{float_format}}"
 
-        # Handle efficiency calculations
-        if log_efficiency:
-            # Efficiency calculated as:
-            # sum_task(task_wall_time * nthread / task) / sum_time(number_running_worker * nthread / worker * interval)
-            if self.statistics.total_core_hours_consumed == 0 or self.statistics.total_core_hours_possible == 0:
-                efficiency_of_running = "(N/A yet)"
-                efficiency_of_potential = "(N/A yet)"
-                efficiency_format = na_format
-            else:
-                efficiency_of_running = (self.statistics.total_core_hours / self.statistics.total_core_hours_consumed
-                                         * 100)
-                efficiency_of_potential = (self.statistics.total_core_hours / self.statistics.total_core_hours_possible
-                                           * 100)
-                efficiency_format = float_format
-            worker_stats_str += f", Core Usage Efficiency: {efficiency_of_running:{efficiency_format}}%"
-            if self.verbose:
-                worker_stats_str += (f", Core Usage vs. Max Resources Requested: "
-                                     f"{efficiency_of_potential:{efficiency_format}}%")
+            # Handle efficiency calculations
+            if log_efficiency:
+                # Efficiency calculated as:
+                # sum_task(task_wall_time * nthread / task)
+                # -------------------------------------------------------------
+                # sum_time(number_running_worker * nthread / worker * interval)
+                if self.statistics.total_core_hours_consumed == 0 or self.statistics.total_core_hours_possible == 0:
+                    efficiency_of_running = "(N/A yet)"
+                    efficiency_of_potential = "(N/A yet)"
+                    efficiency_format = na_format
+                else:
+                    efficiency_of_running = (self.statistics.total_core_hours /
+                                             self.statistics.total_core_hours_consumed
+                                             * 100)
+                    efficiency_of_potential = (self.statistics.total_core_hours /
+                                               self.statistics.total_core_hours_possible
+                                               * 100)
+                    efficiency_format = float_format
+                worker_stats_str += f", Core Usage Efficiency: {efficiency_of_running:{efficiency_format}}%"
+                if self.verbose:
+                    worker_stats_str += (f", Core Usage vs. Max Resources Requested: "
+                                         f"{efficiency_of_potential:{efficiency_format}}%")
 
         self.logger.info(task_stats_str)
-        self.logger.info(worker_stats_str)
+        if worker_stats_str is not None:
+            self.logger.info(worker_stats_str)
 
         try:
             new_tasks = self.client._automodel_request("queue_manager", "get", payload)

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -12,7 +12,7 @@ import pytest
 
 import qcfractal.interface as ptl
 from qcfractal import FractalServer, queue, testing
-from qcfractal.testing import reset_server_database, test_server
+from qcfractal.testing import reset_server_database, test_server, mark_slow
 
 CLIENT_USERNAME = "test_compute_adapter"
 
@@ -76,6 +76,7 @@ def test_queue_manager_single_tags(compute_adapter_fixture):
         assert manager["username"] == CLIENT_USERNAME
 
 
+@mark_slow
 @testing.using_rdkit
 def test_queue_manager_statistics(compute_adapter_fixture, caplog):
     """Test statistics are correctly generated"""


### PR DESCRIPTION
## Description

Fixes a few issues assigned to me for Manager Quality of Life improvements. 

* Adds skeleton YAML generation for the Queue Manager YAML Config through `--skeleton PATH` or `--skel PATH` flag.
* A couple of different fixes to the Queue Manager stats strings to both de-duplicate the "N/A" string and be more helpful about stats not generated yet.
* Adds a test to do some inspection of the stats logs (Yay pytest `caplog` fixture, boo pytest `caplog` fixture's handler being set higher than the level we need so I have to temporarily set it manually).
    * This may be more generally helpful as well elsewhere, so we can move this function/fixture around if need be.
* I moved the check for if `new_tasks is False` or no empty slots *below* the stats texts, may or may not have been the right call as stats will be computed on every `update` call now. Thoughts?

## Status
- [ ] Changelog updated
- [x] Ready to go