### PR TITLE
Fix some typos

### DIFF
--- a/docs/qcfractal/source/database_design.rst
+++ b/docs/qcfractal/source/database_design.rst
@@ -3,7 +3,7 @@ Database Design
 
 .. warning:: Final MongoDB Supported Version: 0.7.0
 
-    **0.7.0 is the last major release which support MongoDB.** Fractal is moving towards a PostgreSQL for database to
+    **0.7.0 is the last major release which support MongoDB.** Fractal is moving towards a PostgreSQL database to
     make upgrades more stable and because it is more suited to the nature of QCArchive Data. The upgrade path from
     MongoDB to PostgreSQL will be provided by the Fractal developers in the next release. Due to the complex nature
     of the upgrade, the PostgreSQL upgrade will through scripts which will be provided. After the PostgreSQL upgrade,
@@ -110,7 +110,7 @@ number of completed tasks, submissions, and failures.
 
 The database only keeps track of what :term:`Tasks<Task>` have been handed out to
 each :term:`Manager` and maintains a heartbeat to ensure the :term:`Manager` is still connected. More information about
-the configuration and executation of managers can be found here: :doc:`managers`.
+the configuration and execution of managers can be found here: :doc:`managers`.
 
 
 .. _QCSchema: https://github.com/MolSSI/QC_JSON_Schema

--- a/docs/qcfractal/source/install.rst
+++ b/docs/qcfractal/source/install.rst
@@ -42,6 +42,8 @@ dependencies you would like to keep up to date:
 
 *   ``pip install qcfractal``
 
+.. XXX: only one option is listed here. 
+
 Install from Source
 -------------------
 

--- a/docs/qcfractal/source/install.rst
+++ b/docs/qcfractal/source/install.rst
@@ -37,12 +37,9 @@ The environments must be installed as new environments and cannot be installed i
 Pip
 ---
 
-To install qcfractal with ``pip`` there are a few options, depending on which
-dependencies you would like to keep up to date:
+qcfractal may be installed with ``pip``::
 
-*   ``pip install qcfractal``
-
-.. XXX: only one option is listed here. 
+    pip install qcfractal
 
 Install from Source
 -------------------

--- a/docs/qcfractal/source/quickstart.ipynb
+++ b/docs/qcfractal/source/quickstart.ipynb
@@ -27,8 +27,8 @@
     "## Importing QCFractal\n",
     "\n",
     "First let us import two items from the ecosystem:\n",
-    " - `FractalSnowflakeHandler` - This is a `FractalServer` that is temporary and is used for trying out new things.\n",
-    " - `qcfractal.interface` is the `qcportal` module, but if using `qcfractal` it is best to import it locally.\n",
+    " * `FractalSnowflakeHandler` - This is a `FractalServer` that is temporary and is used for trying out new things.\n",
+    " * `qcfractal.interface` is the `qcportal` module, but if using `qcfractal` it is best to import it locally.\n",
     " \n",
     "Typically we alias `qcportal` as `ptl`. We will do the same for `qcfractal.interface` so that the code can be used anywhere."
    ]
@@ -233,7 +233,7 @@
    "source": [
     "## Evaluating a Geometry Optimization\n",
     "\n",
-    "We orginally installed `psi4` and `geometric`, so we can use these programs to perform a geometry optimization. In QCFractal, we call a geometry optimization a `procedure`, where `procedure` is a generic term for a higher level operation that will run multiple individual quantum chemistry energy, gradient, or Hessian evaluations. Other `procedure` examples are finite-difference computations, n-body computations, and torsiondrives.\n",
+    "We originally installed `psi4` and `geometric`, so we can use these programs to perform a geometry optimization. In QCFractal, we call a geometry optimization a `procedure`, where `procedure` is a generic term for a higher level operation that will run multiple individual quantum chemistry energy, gradient, or Hessian evaluations. Other `procedure` examples are finite-difference computations, n-body computations, and torsiondrives.\n",
     "\n",
     "We provide a JSON-like input to the `client.add_procedure` command to specify the method, basis, and program to be used. The `qc_spec` field is used in all procedures to determine the underlying quantum chemistry method behind the individual procedure. In this way, we can use any program or method that returns a energy or gradient quantity to run our geometry optimization!"
    ]

--- a/docs/qcfractal/source/quickstart.ipynb
+++ b/docs/qcfractal/source/quickstart.ipynb
@@ -233,9 +233,9 @@
    "source": [
     "## Evaluating a Geometry Optimization\n",
     "\n",
-    "We orginally installed `psi4` and `geometric`, so we can use these programs to perform a geometry optimization. In QCFractal we call a geometry optimization a `procedure`, where`procedure` is a generic term for a higher level operation that will run multiple individual quantum chemistry energy, gradient, or Hessian evaluations. Other `procedure` examples are finite-difference computations, n-body computations, and torsiondrives.\n",
+    "We orginally installed `psi4` and `geometric`, so we can use these programs to perform a geometry optimization. In QCFractal, we call a geometry optimization a `procedure`, where `procedure` is a generic term for a higher level operation that will run multiple individual quantum chemistry energy, gradient, or Hessian evaluations. Other `procedure` examples are finite-difference computations, n-body computations, and torsiondrives.\n",
     "\n",
-    "We provide a JSON-like input to the `client.add_procedure` command to specify the method, basis, and program to be used. The `qc_spec` field is used in all procedures to determine the underlying quantum chemistry method behind the individual procedure. In this way we can use any program or method that returns a energy or gradient quantity to run our geometry optimization!"
+    "We provide a JSON-like input to the `client.add_procedure` command to specify the method, basis, and program to be used. The `qc_spec` field is used in all procedures to determine the underlying quantum chemistry method behind the individual procedure. In this way, we can use any program or method that returns a energy or gradient quantity to run our geometry optimization!"
    ]
   },
   {


### PR DESCRIPTION
## Description
This PR corrects some typos that I encountered while reading the docs. 

## Todos
Notable points that this PR has either accomplished or will accomplish.

## Questions
- [x]  docs/qcfractal/source/install.rst has a pip install section that hints at multiple options but provides only one. This is probably an artifact of editing, but I don't know enough to confidently change it. 

## Status
- [ ] Changelog updated
- [ ] Ready to go