### PR TITLE
Minor typos in QCFractal docs

### DIFF
--- a/docs/qcfractal/README.md
+++ b/docs/qcfractal/README.md
@@ -3,7 +3,8 @@
 The docs for this project are built with Sphinx. To compile the docs, first ensure that Sphinx and the ReadTheDocs theme are installed.
 
 ```
-conda install sphinx sphinx_rtd_theme 
+conda install sphinx sphinx_rtd_theme nbsphinx
+pip install sphinx_automodapi
 ```
 
 Once installed, you can use the Makefile in this directory to compile static HTML pages by

--- a/docs/qcfractal/source/quickstart.ipynb
+++ b/docs/qcfractal/source/quickstart.ipynb
@@ -26,8 +26,8 @@
    "source": [
     "## Importing QCFractal\n",
     "\n",
-    "First let us import two items from the ecosystem:\n",
-    " * `FractalSnowflakeHandler` - This is a `FractalServer` that is temporary and is used for trying out new things.\n",
+    "First let us import two items from the ecosystem:\n\n",
+    " * `FractalSnowflakeHandler` - This is a `FractalServer` that is temporary and is used for trying out new things.\n\n",
     " * `qcfractal.interface` is the `qcportal` module, but if using `qcfractal` it is best to import it locally.\n",
     " \n",
     "Typically we alias `qcportal` as `ptl`. We will do the same for `qcfractal.interface` so that the code can be used anywhere."

--- a/docs/qcfractal/source/services.rst
+++ b/docs/qcfractal/source/services.rst
@@ -29,7 +29,7 @@ The service technology allows the ``FractalServer`` to complete very complex
 workflows of arbitrary design. To see a pictorial representation of this
 process, please see the
 :ref:`flowchart showing the pseudo-calls <flowchart_add_procedure>` when a
-service is added to the ``FractalServrer``
+service is added to the ``FractalServer``
 
 
 .. toctree::


### PR DESCRIPTION
## Description
Fix of two small typos/formatting errors in the QCFractal docs.
Added two dependencies in `docs/qcfractal/README.md` required to build the docs, `nbsphinx` and `sphinx_automodapi`, the second of which seems to only be available on pip, not conda.