### PR TITLE
Overhauls Dataset get/query fields

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+"""
+Add various markers for test suite
+"""
+
+# Ensure fixtures are loaded
+pytest_plugins = [
+   "qcfractal.testing",
+]

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,0 @@
-"""
-Add various markers for test suite
-"""
-
-# Ensure fixtures are loaded
-pytest_plugins = [
-   "qcfractal.testing",
-]

--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -23,8 +23,16 @@ New Features
 
 Enhancements
 ++++++++++++
-- (:pr:`394`) Adds `tag` and `manager` selector fields to client.query_tasks.
+
+- (:pr:`385`) ``Dataset`` and ``ReactionDataset`` have three new functions for accessing data.
+  ``get_values`` returns the canonical headline value for a dataset (e.g. the interaction energy for S22) in data columns with caching. This function replaces the now-deprecated ``get_history``.
+  ``get_records`` either returns ``ResultRecord`` or a projection. For the case of ``ReactionDataset``, the results are broken down into component calculcations. The function replaces the now-deprecated ``query``.
+  ``get_molecules`` returns the ``Molecule`` associated with a dataset.
+  In addition, ``get_contributed_values`` now returns a data column.
+
+- (:pr:`394`) Adds ``tag`` and ``manager`` selector fields to ``client.query_tasks``.
   This is helpful for managing jobs in the queue and detecting failures.
+
 - (:pr:`400`) Adds Dockerfiles corresponding to builds on `Docker Hub <https://cloud.docker.com/u/molssi/repository/list>`_.
 
 Bug Fixes

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -92,6 +92,11 @@ class Collection(abc.ABC):
     def __repr__(self) -> str:
         return f"<{self}>"
 
+    def _check_client(self):
+        if self.client is None:
+            raise AttributeError("This method requires a FractalClient and no client was set")
+
+
     @property
     def name(self) -> str:
         return self.data.name
@@ -211,10 +216,9 @@ class Collection(abc.ABC):
         if self.data.name == "":
             raise AttributeError("Collection:save: {} must have a name!".format(class_name))
 
+
         if client is None:
-            if self.client is None:
-                raise AttributeError("Collection:save: {} does not own a Storage Database "
-                                     "instance and one was not passed in.".format(class_name))
+            self._check_client()
             client = self.client
 
         self._pre_save_prep(client)

--- a/qcfractal/interface/collections/collection_utils.py
+++ b/qcfractal/interface/collections/collection_utils.py
@@ -101,7 +101,7 @@ def composition_planner(program=None, method=None, basis=None, driver=None, keyw
 
     if ("-d3" in method.lower()) and ("dftd3" != program.lower()) and ("hessian" != driver.lower()):
         dftd3keys = {"program": "dftd3", "method": method, "basis": None, "driver": driver, "keywords": None}
-        base["method"] = method.split("-D3")[0]
+        base["method"] = method.lower().split("-d3")[0]
 
         return [dftd3keys, base]
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1,18 +1,19 @@
 """
 QCPortal Database ODM
 """
+import warnings
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
-import warnings
+
 from qcelemental import constants
 
-from .collection import Collection
-from .collection_utils import composition_planner, register_collection
 from ..models import ComputeResponse, Molecule, ObjectId, ProtoModel
 from ..statistics import wrap_statistics
 from ..visualization import bar_plot, violin_plot
+from .collection import Collection
+from .collection_utils import composition_planner, register_collection
 
 
 class MoleculeEntry(ProtoModel):
@@ -257,9 +258,8 @@ class Dataset(Collection):
                 query["stoich"] = query.pop("stoichiometry")
             name = self._canonical_name(**query)
             if force or (name not in self.df.columns):
-                self.df[name] = self.get_records(query.pop("method").upper(),
-                                                 projection={"return_result": True},
-                                                 **query)["return_result"]
+                data = self.get_records(query.pop("method").upper(), projection={"return_result": True}, **query)
+                self.df[name] = data["return_result"] * constants.conversion_factor('hartree', self.units)
             ret.append(self.df[name])
 
         return pd.concat(ret, axis=1)

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -541,6 +541,7 @@ class Dataset(Collection):
         Series
             A Series of the data results
         """
+        self._check_client()
         self._check_state()
 
         field = field.lower()
@@ -592,10 +593,8 @@ class Dataset(Collection):
             compute_keys["keywords"],
             stoich=compute_keys.get("stoich", None))
 
+        self._check_client()
         self._check_state()
-
-        if self.client is None:
-            raise AttributeError("Dataset: Compute: Client was not set.")
 
         umols = list(set(molecules))
 
@@ -712,8 +711,7 @@ class Dataset(Collection):
             The requested KeywordSet
 
         """
-        if self.client is None:
-            raise AttributeError("Dataset: Client was not set.")
+        self._check_client()
 
         alias = alias.lower()
         program = program.lower()
@@ -878,8 +876,7 @@ class Dataset(Collection):
         if (name in self.df) and (force is False):
             return name
 
-        if self.client is None:
-            raise AttributeError("DataBase: FractalClient was not set.")
+        self._check_client()
 
         # # If reaction results
         indexer = {e.name: e.molecule_id for e in self.data.records}

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -413,7 +413,7 @@ class Dataset(Collection):
 
 
             if (groupby == "d3"):
-                full_history = self.get_history(**query)
+                full_history = self.get_values(**query)
                 full_history["base"] = [x.split("-d3")[0] for x in full_history["method"]]
                 full_history["d3"] = [
                     method.replace(base, "").replace("-d", "d")
@@ -440,14 +440,14 @@ class Dataset(Collection):
                     gb_query = query.copy()
                     gb_query[groupby] = gb
 
-                    queries.append(self.get_history(**gb_query))
+                    queries.append(self.get_values(**gb_query))
                     query_names.append(self._canonical_name(**{groupby: gb}))
 
             if (kind == "violin") and (len(queries) != 2):
                 raise KeyError(f"Groupby option for violin plots must have two entries.")
 
         else:
-            queries = [self.get_history(**query)]
+            queries = [self.get_values(**query)]
             query_names = ["Stats"]
 
         title = f"{self.data.name} Dataset Statistics"

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -683,7 +683,6 @@ class Dataset(Collection):
         for query_set in plan:
 
             query_set["keywords"] = self.get_keywords(query_set["keywords"], query_set["program"], return_id=True)
-
             # Set the index to remove duplicates
             molecules = list(set(indexer.values()))
             if projection:
@@ -1010,8 +1009,7 @@ class Dataset(Collection):
         """
         name, dbkeys, history = self._default_parameters(program, method, basis, keywords)
         indexer = self._molecule_indexer(subset)
-        df = self._get_records(indexer, dbkeys, projection=projection, merge=False)
-
+        df = self._get_records(indexer, history, projection=projection, merge=False)
         if len(df) == 1:
             df = df[0]
 
@@ -1094,7 +1092,7 @@ class Dataset(Collection):
         # # If reaction results
         indexer = {e.name: e.molecule_id for e in self.data.records}
 
-        tmp_idx = self._get_records(indexer, dbkeys, projection={field: True}, merge=True)
+        tmp_idx = self._get_records(indexer, history, projection={field: True}, merge=True)
         tmp_idx.rename(columns={field: name}, inplace=True)
 
         tmp_idx[tmp_idx.select_dtypes(include=['number']).columns] *= constants.conversion_factor('hartree', self.units)

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -330,6 +330,9 @@ class Dataset(Collection):
 
             ret.append(self.df[name])
 
+        if len(ret) == 0:
+            raise KeyError("Query matched no records!")
+
         return pd.concat(ret, axis=1)
 
     def get_history(self,
@@ -1013,6 +1016,9 @@ class Dataset(Collection):
 
         if len(df) == 1:
             df = df[0]
+
+        if np.all(df.count() == 0):
+            raise KeyError("Query matched no records!")
 
         if isinstance(subset, str):
             return df.iloc[0, 0]

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -680,8 +680,6 @@ class Dataset(Collection):
         """
         self._check_client()
         self._check_state()
-        print(self.client.query_results(program="psi4", status=None))
-        print(self.client.query_results(program="dftd3", status=None))
 
         ret = []
         plan = composition_planner(**query)
@@ -692,7 +690,9 @@ class Dataset(Collection):
                 raise KeyError(raise_on_plan)
 
         for query_set in plan:
-            print(query_set)
+
+            if isinstance(query_set["keywords"], str):
+                query_set["keywords"] = self.data.alias_keywords[query_set["program"]][query_set["keywords"]]
 
             # Set the index to remove duplicates
             molecules = list(set(indexer.values()))
@@ -702,7 +702,6 @@ class Dataset(Collection):
                 query_set["projection"] = proj
 
             # Chunk up the queries
-            print(self.client.query_results(**query_set))
             records = []
             for i in range(0, len(molecules), self.client.query_limit):
                 query_set["molecule"] = molecules[i:i + self.client.query_limit]
@@ -730,8 +729,6 @@ class Dataset(Collection):
 
             df.set_index("index", inplace=True)
             df.drop("molecule", axis=1, inplace=True)
-            print(df)
-            print('---')
 
             ret.append(df)
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -243,6 +243,11 @@ class Dataset(Collection):
         -------
         DataFrame
             A DataFrame of the queried values
+
+        Raises
+        ------
+        KeyError
+            If no records match the query
         """
 
         queries = self.list_history(**search, dftd3=True, pretty=False).reset_index()
@@ -261,6 +266,9 @@ class Dataset(Collection):
                 data = self.get_records(query.pop("method").upper(), projection={"return_result": True}, **query)
                 self.df[name] = data["return_result"] * constants.conversion_factor('hartree', self.units)
             ret.append(self.df[name])
+
+        if len(ret) == 0:
+            raise KeyError("Query matched 0 records.")
 
         return pd.concat(ret, axis=1)
 
@@ -594,6 +602,11 @@ class Dataset(Collection):
         -------
         pd.Series
             A series of Molecules
+
+        Raises
+        ------
+        KeyError
+            If no records match the query
         """
 
         molecules = []
@@ -602,6 +615,8 @@ class Dataset(Collection):
             molecules.extend(self.client.query_molecules(id=molecule_ids[i:i + self.client.query_limit]))
 
         molecules = pd.DataFrame.from_dict([{"molecule_id": x.id, "molecule": x} for x in molecules])
+        if len(molecules) == 0:
+            raise KeyError("Query matched 0 records.")
 
         df = pd.DataFrame.from_dict(indexer, orient="index", columns=["molecule_id"])
         df.reset_index(inplace=True)
@@ -636,6 +651,11 @@ class Dataset(Collection):
         -------
         Series
             A Series of the data results
+
+        Raises
+        ------
+        KeyError
+            If no records match the query
         """
         self._check_client()
         self._check_state()
@@ -669,6 +689,9 @@ class Dataset(Collection):
             df.set_index("index", inplace=True)
             df.drop("molecule", axis=1, inplace=True)
             ret.append(df)
+
+        if len(molecules) == 0:
+            raise KeyError("Query matched 0 records.")
 
         if merge:
             retdf = ret[0]

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -407,11 +407,11 @@ class ReactionDataset(Dataset):
         ret = []
         for s in stoich:
             name, dbkeys, history = self._default_parameters(program, method, basis, keywords, stoich=s)
-
+            history.pop('stoichiometry')
             indexer, names = self._molecule_indexer(s, subset)
             df = self._get_records(
                 indexer,
-                dbkeys,
+                history,
                 projection=projection,
                 merge=False,
                 raise_on_plan=

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -334,7 +334,7 @@ class ReactionDataset(Dataset):
         return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind)
 
     def get_molecules(self, subset: Optional[Union[str, Set[str]]] = None,
-                      stoich: Union[str, List[str]] = "default") -> Union[pd.DataFrame, 'Molecule']:
+                      stoich: Union[str, List[str]] = "default") -> pd.DataFrame:
         """Queries full Molecules from the database.
 
         Parameters
@@ -344,10 +344,10 @@ class ReactionDataset(Dataset):
         stoich : Union[str, List[str]], optional
             The stoichiometries to pull from, either a single or multiple stoichiometries
 
-        Returns
-        -------
-        Union[pd.DataFrame, 'Molecule']
-            Either a DataFrame of indexed Molecules or a single Molecule if a single subset string was provided.
+        Return
+        ------
+        pd.DataFrame
+            Indexed Molecules which match the stoich and subset string.
         """
 
         self._check_client()
@@ -358,10 +358,7 @@ class ReactionDataset(Dataset):
         df = self._get_molecules(indexer)
         df.index = pd.MultiIndex.from_tuples(df.index, names=names)
 
-        if isinstance(subset, str) and isinstance(stoich, str):
-            return df.iloc[0, 0]
-        else:
-            return df
+        return df
 
     def get_records(self,
                     method,

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -396,10 +396,6 @@ class ReactionDataset(Dataset):
 
         """
 
-        warnings.warn(
-            "This is function is deprecated and will be removed in 0.11.0, please `get_records(..., projection='return_result')` for a similar result",
-            DeprecationWarning)
-
         self._check_client()
         self._check_state()
         self._validate_stoich(stoich)

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -284,11 +284,9 @@ class ReactionDataset(Dataset):
 
 
         """
+        self._check_client()
         self._check_state()
         method = method.upper()
-
-        if self.client is None:
-            raise AttributeError("DataBase: FractalClient was not set.")
 
         self._validate_stoich(stoich)
         name, dbkeys, history = self._default_parameters(program, method, basis, keywords, stoich=stoich)
@@ -363,10 +361,8 @@ class ReactionDataset(Dataset):
               - existing: A list of ObjectId's of tasks already in the database
 
         """
+        self._check_client()
         self._check_state()
-
-        if self.client is None:
-            raise AttributeError("Dataset: Compute: Client was not set.")
 
         self._validate_stoich(stoich)
         compute_keys = {"program": program, "method": method, "basis": basis, "keywords": keywords, "stoich": stoich}

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -123,8 +123,9 @@ class ReactionDataset(Dataset):
         if isinstance(stoich, str):
             stoich = [stoich]
 
-        pattern = "(^" + "$)|(^".join(stoich) + "$)"
-        matched_rows = self.rxn_index[self.rxn_index["stoichiometry"].str.match(pattern)]
+        matched_rows = self.rxn_index[np.in1d(self.rxn_index["stoichiometry"], stoich)]
+        if subset:
+            matched_rows = matched_rows[np.in1d(matched_rows["name"], subset)]
 
         names = ("name", "stoichiometry", "idx")
         if coefficients:
@@ -284,47 +285,6 @@ class ReactionDataset(Dataset):
 
         # Get default program/keywords
         return self.get_values(method=method, basis=basis, keywords=keywords, program=program, force=force)
-
-    def get_history(self,
-                    method: Optional[str] = None,
-                    basis: Optional[str] = None,
-                    keywords: Optional[str] = None,
-                    program: Optional[str] = None,
-                    stoich: str = "default") -> 'DataFrame':
-        """ Queries known history from the search paramaters provided. Defaults to the standard
-        programs and keywords if not provided.
-
-        Parameters
-        ----------
-        method : Optional[str]
-            The computational method to compute (B3LYP)
-        basis : Optional[str], optional
-            The computational basis to compute (6-31G)
-        keywords : Optional[str], optional
-            The keyword alias for the requested compute
-        program : Optional[str], optional
-            The underlying QC program
-        stoich : str, optional
-            The given stoichiometry to compute.
-
-        Returns
-        -------
-        DataFrame
-            A DataFrame of the queried parameters
-        """
-
-        self._validate_stoich(stoich)
-
-        name, dbkeys, history = self._default_parameters(program, "nan", "nan", keywords, stoich=stoich)
-
-        for k, v in [("method", method), ("basis", basis)]:
-
-            if v is not None:
-                history[k] = v
-            else:
-                history.pop(k, None)
-
-        return self._get_history(**history)
 
     def visualize(self,
                   method: Optional[str] = None,

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -135,7 +135,7 @@ class ReactionDataset(Dataset):
         tmp_idx = tmp_idx.reset_index(drop=True)
 
         indexer = {x: x for x in tmp_idx["molecule"]}
-        results = self._query(indexer, keys, field=field)
+        results = self._get_records(indexer, keys, field=field)
         tmp_idx = tmp_idx.join(results, on="molecule", how="left")
 
         # Apply stoich values

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -135,7 +135,7 @@ class ReactionDataset(Dataset):
         tmp_idx = tmp_idx.reset_index(drop=True)
 
         indexer = {x: x for x in tmp_idx["molecule"]}
-        results = self._get_records(indexer, keys, field=field)
+        results = self._get_records(indexer, dbkeys, projection={field: True}, merge=True)
         tmp_idx = tmp_idx.join(results, on="molecule", how="left")
 
         # Apply stoich values
@@ -318,7 +318,7 @@ class ReactionDataset(Dataset):
         # Apply to df
         self.df[name] = tmp_idx[name]
 
-        return name
+        return tmp_idx
 
     def compute(self,
                 method: Optional[str],

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -240,6 +240,7 @@ class ReactionDataset(Dataset):
             name = self._canonical_name(**query)
 
             if force or (name not in self.df.columns):
+                self._column_metadata[name] = query
 
                 data_complex = _query_apply_coeffients(stoich_complex, query)
                 data_monomer = _query_apply_coeffients(stoich_monomer, query)
@@ -291,7 +292,7 @@ class ReactionDataset(Dataset):
                   basis: Optional[str] = None,
                   keywords: Optional[str] = None,
                   program: Optional[str] = None,
-                  stoich: Optional[str] = None,
+                  stoich: str = "default",
                   groupby: Optional[str] = None,
                   metric: str = "UE",
                   bench: Optional[str] = None,
@@ -308,7 +309,7 @@ class ReactionDataset(Dataset):
             Keyword aliases to query
         program : Optional[str], optional
             Programs aliases to query
-        stoich : Optional[str], optional
+        stoich : str, optional
             Stoichiometry to query
         groupby : Optional[str], optional
             Groups the plot by this index.
@@ -327,7 +328,7 @@ class ReactionDataset(Dataset):
             The requested figure.
         """
 
-        query = {"method": method, "basis": basis, "keywords": keywords, "program": program, "stoich": stoich}
+        query = {"method": method, "basis": basis, "keywords": keywords, "program": program, "stoichiometry": stoich}
         query = {k: v for k, v in query.items() if v is not None}
 
         return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind)
@@ -395,10 +396,6 @@ class ReactionDataset(Dataset):
         -------
         Union[pd.DataFrame, 'ResultRecord']
             The name of the queried column
-
-        Examples
-        --------
-        ds.query("B3LYP", "aug-cc-pVDZ", stoich="cp", prefix="cp-")
 
         """
 
@@ -472,13 +469,6 @@ class ReactionDataset(Dataset):
         -------
         str
             The name of the queried column
-
-
-        Examples
-        --------
-
-        ds.query("B3LYP", "aug-cc-pVDZ", stoich="cp", prefix="cp-")
-
 
         """
         warnings.warn(
@@ -660,10 +650,6 @@ class ReactionDataset(Dataset):
             - Molecule string - Molecule will be converted to a Molecule class and the same process as the above will occur.
 
 
-        Examples
-        --------
-
-
         """
 
         ret = {}
@@ -736,9 +722,6 @@ class ReactionDataset(Dataset):
 
         Notes
         -----
-
-        Examples
-        --------
 
         Returns
         -------
@@ -850,9 +833,6 @@ class ReactionDataset(Dataset):
 
         Notes
         -----
-
-        Examples
-        --------
 
         Returns
         -------

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -284,6 +284,8 @@ class ReactionDataset(Dataset):
 
 
         """
+        warnings.warn("This is function is deprecated and will be removed in 0.11.0, please `get_records(..., projection='return_result')` for a similar result", DeprecationWarning)
+
         self._check_client()
         self._check_state()
         method = method.upper()

--- a/qcfractal/interface/tests/test_visualization.py
+++ b/qcfractal/interface/tests/test_visualization.py
@@ -21,8 +21,9 @@ def live_fractal_or_skip():
     """Ensure Fractal live connection can be made"""
 
     try:
+        requests.get('https://api.qcarchive.molssi.org:443', json={}, timeout=5)
         return portal.FractalClient()
-    except requests.exceptions.ConnectionError:
+    except (requests.exceptions.ConnectionError, ConnectionRefusedError):
         return pytest.skip("Could not make a connection to central Fractal server")
 
 

--- a/qcfractal/interface/tests/test_visualization.py
+++ b/qcfractal/interface/tests/test_visualization.py
@@ -39,13 +39,13 @@ def S22Fixture():
 
 
 @using_plotly
-@pytest.mark.parametrize("kind", ["violin", "bar"])
+@pytest.mark.parametrize("kind", ["bar", "violin"])
 def test_plot_dataset(S22Fixture, kind):
 
     client, S22 = S22Fixture
 
     fig = S22.visualize(
-        method=["b2plyp", "b3lyp", "pbe"],
+        method=["b2plyp", "pbe"],
         basis=["def2-svp", "def2-TZVP"],
         return_figure=True,
         bench="S22a",

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -244,17 +244,27 @@ class SQLAlchemySocket:
         """TODO: needs more testing"""
 
         with self.session_scope() as session:
+            # Metadata
+            session.query(VersionsORM).delete(synchronize_session=False)
+
+            # Task and services
             session.query(TaskQueueORM).delete(synchronize_session=False)
+            session.query(QueueManagerORM).delete(synchronize_session=False)
             session.query(ServiceQueueORM).delete(synchronize_session=False)
-            session.query(GridOptimizationProcedureORM).delete(synchronize_session=False)
+
+            # Collections
+            session.query(CollectionORM).delete(synchronize_session=False)
+
+            # Records
             session.query(TorsionDriveProcedureORM).delete(synchronize_session=False)
+            session.query(GridOptimizationProcedureORM).delete(synchronize_session=False)
             session.query(OptimizationProcedureORM).delete(synchronize_session=False)
             session.query(ResultORM).delete(synchronize_session=False)
             session.query(BaseResultORM).delete(synchronize_session=False)
-            session.query(MoleculeORM).delete(synchronize_session=False)
+
+            # Auxiliary tables
             session.query(KVStoreORM).delete(synchronize_session=False)
-            session.query(CollectionORM).delete(synchronize_session=False)
-            session.query(VersionsORM).delete(synchronize_session=False)
+            session.query(MoleculeORM).delete(synchronize_session=False)
 
     def get_project_name(self) -> str:
         return self._project_name

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -476,6 +476,7 @@ def fractal_compute_server(postgres_server):
                           reset_database=True,
                           start_server=False) as server:
         reset_server_database(server)
+        server.await_results() # Force a heartbeat after database clean.
         yield server
 
 

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -475,7 +475,7 @@ def fractal_compute_server(postgres_server):
                           storage_uri=postgres_server.database_uri(),
                           reset_database=True,
                           start_server=False) as server:
-        # reset_server_database(server)
+        reset_server_database(server)
         yield server
 
 

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -359,6 +359,10 @@ def reset_server_database(server):
 
     server.storage._delete_DB_data(server.storage._project_name)
 
+    # Force a heartbeat after database clean if a manager is present.
+    if server.queue_socket:
+        server.await_results()
+
 
 @pytest.fixture(scope="module")
 def test_server(request, postgres_server):
@@ -476,7 +480,6 @@ def fractal_compute_server(postgres_server):
                           reset_database=True,
                           start_server=False) as server:
         reset_server_database(server)
-        server.await_results() # Force a heartbeat after database clean.
         yield server
 
 

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -104,6 +104,11 @@ _programs["dftd3"] = "dftd3" in qcng.list_available_programs()
 def has_module(name):
     return _programs[name]
 
+def check_has_module(program):
+    import_message = "Not detecting module {}. Install package if necessary to enable tests."
+    if has_module(program) is False:
+        pytest.skip(import_message.format(program))
+
 
 def _build_pytest_skip(program):
     import_message = "Not detecting module {}. Install package if necessary to enable tests."

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -62,26 +62,40 @@ def gradient_dataset_fixture(fractal_compute_server):
     yield client, client.get_collection("dataset", "ds_gradient")
 
 
+def test_gradient_dataset_get_molecules(gradient_dataset_fixture):
+    client, ds = gradient_dataset_fixture
+
+    he1_dist = 2.672476322216822
+    mols = ds.get_molecules()
+    assert mols.shape == (2, 1)
+    assert mols.iloc[0, 0].measure([0, 1]) == pytest.approx(he1_dist)
+
+    mol = ds.get_molecules(subset="He1")
+    assert mol.measure([0, 1]) == pytest.approx(he1_dist)
+
+    mols_subset = ds.get_molecules(subset=["He1"])
+    assert mols_subset.iloc[0, 0].measure([0, 1]) == pytest.approx(he1_dist)
+
+
 def test_gradient_dataset_get_records(gradient_dataset_fixture):
     client, ds = gradient_dataset_fixture
 
     records = ds.get_records("HF", "sto-3g")
+    assert records.shape == (2, 1)
     assert records.iloc[0, 0].status == "COMPLETE"
     assert records.iloc[1, 0].status == "COMPLETE"
-    assert records.shape == (2, 1)
 
     records_subset1 = ds.get_records("HF", "sto-3g", subset="He2")
     assert records_subset1.status == "COMPLETE"
 
     records_subset2 = ds.get_records("HF", "sto-3g", subset=["He2"])
-    assert records_subset2.iloc[0,0].status == "COMPLETE"
     assert records_subset2.shape == (1, 1)
+    assert records_subset2.iloc[0, 0].status == "COMPLETE"
 
     rec_proj = ds.get_records("HF", "sto-3g", projection={"extras": True, "return_result": True})
-    assert set(rec_proj.columns) == {"extras", "return_result"}
     assert rec_proj.shape == (2, 2)
+    assert set(rec_proj.columns) == {"extras", "return_result"}
 
-# def test_gradient_dataset_get_molecules(gradient_dataset_fixture):
 
 def test_gradient_dataset_statistics(gradient_dataset_fixture):
     client, ds = gradient_dataset_fixture

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -157,11 +157,6 @@ def test_reactiondataset_check_state(fractal_compute_server):
     ds = ptl.collections.ReactionDataset("check_state", client, ds_type="ie", default_program="rdkit")
     ds.add_ie_rxn("He1", ptl.Molecule.from_data("He -3 0 0\n--\nNe 0 0 2"))
 
-    ds.save()
-    print()
-    print(ds.get_molecules(stoich=["default1", "default"]))
-    raise Exception()
-
     with pytest.raises(ValueError):
         ds.compute("SCF", "STO-3G")
 
@@ -169,7 +164,7 @@ def test_reactiondataset_check_state(fractal_compute_server):
         ds.get_records("SCF", "STO-3G")
 
     ds.save()
-    assert ds.get_values("SCF", "STO-3G")
+    assert ds.get_records("SCF", "STO-3G")
 
     ds.add_keywords("default", "psi4", ptl.models.KeywordSet(values={"a": 5}))
 
@@ -213,11 +208,11 @@ def reactiondataset_dftd3_fixture_fixture(fractal_compute_server):
 
     ds.save()
 
-    ncomp1 = ds.compute("B3LYP-D3", "6-31G")
+    ncomp1 = ds.compute("B3LYP-D3", "6-31g")
     assert len(ncomp1.ids) == 4
     assert len(ncomp1.submitted) == 4
 
-    ncomp2 = ds.compute("B3LYP-D3(BJ)", "6-31G")
+    ncomp2 = ds.compute("B3LYP-D3(BJ)", "6-31g")
     assert len(ncomp2.ids) == 4
     assert len(ncomp2.submitted) == 2
 
@@ -227,6 +222,15 @@ def reactiondataset_dftd3_fixture_fixture(fractal_compute_server):
 
 def test_rectiondataset_dftd3_records(reactiondataset_dftd3_fixture_fixture):
     client, ds = reactiondataset_dftd3_fixture_fixture
+
+    records = ds.get_records("B3LYP", "6-31g")
+    assert records.shape == (1, 1)
+    assert records.iloc[0, 0].status == "COMPLETE"
+
+    records = ds.get_records("B3LYP", "6-31g", stoich=["cp", "default"])
+    assert records.shape == (2, 1)
+    assert records.iloc[0, 0].status == "COMPLETE"
+    assert records.iloc[0, 0].id == records.iloc[1, 0].id
 
 def test_rectiondataset_dftd3_energies(reactiondataset_dftd3_fixture_fixture):
     client, ds = reactiondataset_dftd3_fixture_fixture

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -66,12 +66,16 @@ def test_gradient_dataset_get_molecules(gradient_dataset_fixture):
     client, ds = gradient_dataset_fixture
 
     he1_dist = 2.672476322216822
+    he2_dist = 2.939723950195864
     mols = ds.get_molecules()
     assert mols.shape == (2, 1)
     assert mols.iloc[0, 0].measure([0, 1]) == pytest.approx(he1_dist)
 
     mol = ds.get_molecules(subset="He1")
     assert mol.measure([0, 1]) == pytest.approx(he1_dist)
+
+    mol = ds.get_molecules(subset="He2")
+    assert mol.measure([0, 1]) == pytest.approx(he2_dist)
 
     mols_subset = ds.get_molecules(subset=["He1"])
     assert mols_subset.iloc[0, 0].measure([0, 1]) == pytest.approx(he1_dist)

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -142,13 +142,18 @@ def test_dataset_compute_response(fractal_compute_server):
 def test_reactiondataset_check_state(fractal_compute_server):
     client = ptl.FractalClient(fractal_compute_server)
     ds = ptl.collections.ReactionDataset("check_state", client, ds_type="ie", default_program="rdkit")
-    ds.add_ie_rxn("He1", ptl.Molecule.from_data("He -3 0 0\n--\nHe 0 0 2"))
+    ds.add_ie_rxn("He1", ptl.Molecule.from_data("He -3 0 0\n--\nNe 0 0 2"))
+
+    ds.save()
+    print()
+    print(ds.get_molecules(stoich=["default1", "default"]))
+    raise Exception()
 
     with pytest.raises(ValueError):
         ds.compute("SCF", "STO-3G")
 
     with pytest.raises(ValueError):
-        ds.get_values("SCF", "STO-3G")
+        ds.get_records("SCF", "STO-3G")
 
     ds.save()
     assert ds.get_values("SCF", "STO-3G")
@@ -156,10 +161,10 @@ def test_reactiondataset_check_state(fractal_compute_server):
     ds.add_keywords("default", "psi4", ptl.models.KeywordSet(values={"a": 5}))
 
     with pytest.raises(ValueError):
-        ds.get_values("SCF", "STO-3G")
+        ds.get_records("SCF", "STO-3G")
 
     ds.save()
-    assert ds.get_values("SCF", "STO-3G")
+    assert ds.get_records("SCF", "STO-3G")
 
     contrib = {
         "name": "Benchmark",
@@ -173,10 +178,11 @@ def test_reactiondataset_check_state(fractal_compute_server):
     }
     ds.add_contributed_values(contrib)
     with pytest.raises(ValueError):
-        ds.get_values("SCF", "STO-3G")
+        ds.get_records("SCF", "STO-3G")
 
     assert "benchmark" in ds.list_contributed_values()
     assert ds.get_contributed_values("benchmark").name == "Benchmark"
+
 
 @testing.using_psi4
 @testing.using_dftd3

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -100,7 +100,9 @@ def test_gradient_dataset_get_records(gradient_dataset_fixture):
 def test_gradient_dataset_statistics(gradient_dataset_fixture):
     client, ds = gradient_dataset_fixture
 
-    ds.get_history()
+    df = ds.get_values()
+    assert df.shape == (2, 1)
+    assert np.sum(df.loc["He2", "HF/sto-3g"]) == pytest.approx(0.0)
 
     # Test out some statistics
     stats = ds.statistics("MUE", "HF/sto-3g", "Gradient")

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -52,6 +52,8 @@ def gradient_dataset_fixture(fractal_compute_server):
         "units": "hartree"
     }
     ds.add_contributed_values(contrib)
+
+    ds.add_keywords("scf_default", "psi4", ptl.models.KeywordSet(values={}), default=True)
     ds.save()
 
     ds.compute("HF", "sto-3g")
@@ -177,6 +179,7 @@ def test_reactiondataset_check_state(fractal_compute_server):
         ds.get_records("SCF", "STO-3G")
 
     ds.save()
+
     ds.get_records("SCF", "STO-3G")
 
     contrib = {
@@ -211,6 +214,7 @@ def reactiondataset_dftd3_fixture_fixture(fractal_compute_server):
     HeDimer = ptl.Molecule.from_data([[2, 0, 0, -4.123], [2, 0, 0, 4.123]], dtype="numpy", units="bohr", frags=[1])
     ds.add_ie_rxn("HeDimer", HeDimer, attributes={"r": 4})
     ds.set_default_program("psi4")
+    ds.add_keywords("scf_default", "psi4", ptl.models.KeywordSet(values={}), default=True)
 
     ds.save()
 

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -148,18 +148,18 @@ def test_reactiondataset_check_state(fractal_compute_server):
         ds.compute("SCF", "STO-3G")
 
     with pytest.raises(ValueError):
-        ds.query("SCF", "STO-3G")
+        ds.get_values("SCF", "STO-3G")
 
     ds.save()
-    assert ds.query("SCF", "STO-3G")
+    assert ds.get_values("SCF", "STO-3G")
 
     ds.add_keywords("default", "psi4", ptl.models.KeywordSet(values={"a": 5}))
 
     with pytest.raises(ValueError):
-        ds.query("SCF", "STO-3G")
+        ds.get_values("SCF", "STO-3G")
 
     ds.save()
-    assert ds.query("SCF", "STO-3G")
+    assert ds.get_values("SCF", "STO-3G")
 
     contrib = {
         "name": "Benchmark",
@@ -173,15 +173,15 @@ def test_reactiondataset_check_state(fractal_compute_server):
     }
     ds.add_contributed_values(contrib)
     with pytest.raises(ValueError):
-        ds.query("SCF", "STO-3G")
+        ds.get_values("SCF", "STO-3G")
 
     assert "benchmark" in ds.list_contributed_values()
     assert ds.get_contributed_values("benchmark").name == "Benchmark"
 
-
 @testing.using_psi4
 @testing.using_dftd3
-def test_compute_reactiondataset_dftd3(fractal_compute_server):
+@pytest.fixture(scope="module")
+def reactiondataset_dftd3_fixture_fixture(fractal_compute_server):
 
     client = ptl.FractalClient(fractal_compute_server)
     ds_name = "He_DFTD3"
@@ -203,9 +203,20 @@ def test_compute_reactiondataset_dftd3(fractal_compute_server):
     assert len(ncomp2.submitted) == 2
 
     fractal_compute_server.await_results()
-    assert ds.query("B3LYP", "6-31G")
-    assert ds.query("B3LYP-D3", "6-31G")
-    assert ds.query("B3LYP-D3(BJ)", "6-31G")
+
+    yield client, ds
+
+def test_rectiondataset_dftd3_records(reactiondataset_dftd3_fixture_fixture):
+    client, ds = reactiondataset_dftd3_fixture_fixture
+
+def test_rectiondataset_dftd3_energies(reactiondataset_dftd3_fixture_fixture):
+    client, ds = reactiondataset_dftd3_fixture_fixture
+
+    assert ds.get_values("B3LYP", "6-31G")
+    assert ds.get_values("B3LYP-D3", "6-31G")
+    assert ds.get_values("B3LYP-D3(BJ)", "6-31G")
+
+    # Should be in ds.df now as wells
 
     for key, value in {"B3LYP/6-31g": -0.002135, "B3LYP-D3/6-31g": -0.005818, "B3LYP-D3(BJ)/6-31g": -0.005636}.items():
 

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -355,7 +355,7 @@ def test_compute_reactiondataset_keywords(fractal_compute_server):
 
     r = ds.compute("SCF", "sto-3g", keywords="df")
     fractal_compute_server.await_results()
-    ds.get_values("SCF", "sto-3g", keywords="df") == "SCF/sto-3g-df"
+    ds.get_values("SCF", "sto-3g", keywords="df").columns[0] == "SCF/sto-3g-df"
     assert pytest.approx(0.38748602675524185, 1.e-5) == ds.df.loc["He2", "SCF/sto-3g-df"]
 
     assert ds.list_history().shape[0] == 2

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -267,6 +267,28 @@ def test_rectiondataset_dftd3_energies(reactiondataset_dftd3_fixture_fixture):
     for key, value in bench.items():
         assert value == ds.df.loc["HeDimer", key]
 
+
+def test_rectiondataset_dftd3_molecules(reactiondataset_dftd3_fixture_fixture):
+    client, ds = reactiondataset_dftd3_fixture_fixture
+
+    mols = ds.get_molecules()
+    assert mols.shape == (1, 1)
+    assert np.all(mols.iloc[0, 0].real)  # Should be all real
+    assert tuple(mols.index) == (("HeDimer", "default", 0), )
+
+    mols = ds.get_molecules(stoich="cp1")
+    assert mols.shape == (1, 1)
+    assert not np.all(mols.iloc[0, 0].real)  # Should be half real
+    assert tuple(mols.index) == (("HeDimer", "cp1", 0), )
+
+    stoichs = ["cp1", "default1", "cp", "default"]
+    mols = ds.get_molecules(stoich=stoichs)
+    assert mols.shape == (4, 1)
+
+    mols = mols.reset_index()
+    assert set(stoichs) == set(mols["stoichiometry"])
+
+
 @testing.using_psi4
 def test_compute_reactiondataset_regression(fractal_compute_server):
     """
@@ -340,6 +362,13 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
 
     ds.units = "eV"
     assert pytest.approx(0.00010614635, 1.e-5) == ds.statistics("MURE", "SCF/sto-3g", floor=10)
+
+    # Check get_molecules
+    mols = ds.get_molecules()
+    assert mols.shape == (2, 1)
+
+    mols = ds.get_molecules(stoich="cp1")
+    assert mols.shape == (2, 1)
 
 
 @testing.using_psi4

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -26,10 +26,11 @@ def test_collection_query(fractal_compute_server):
     assert ds.name == "CAPITAL"
 
 
-@testing.using_psi4
 @pytest.fixture(scope="module")
 def gradient_dataset_fixture(fractal_compute_server):
     client = ptl.FractalClient(fractal_compute_server)
+
+    testing.check_has_module("psi4")
 
     # Build a dataset
     ds = ptl.collections.Dataset("ds_gradient",
@@ -196,10 +197,11 @@ def test_reactiondataset_check_state(fractal_compute_server):
     assert "Benchmark" in ds.get_contributed_values("benchmark").columns
 
 
-@testing.using_psi4
-@testing.using_dftd3
 @pytest.fixture(scope="module")
 def reactiondataset_dftd3_fixture_fixture(fractal_compute_server):
+
+    testing.check_has_module("psi4")
+    testing.check_has_module("dftd3")
 
     client = ptl.FractalClient(fractal_compute_server)
     ds_name = "He_DFTD3"

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -76,6 +76,9 @@ def test_gradient_dataset_get_molecules(gradient_dataset_fixture):
     mols_subset = ds.get_molecules(subset=["He1"])
     assert mols_subset.iloc[0, 0].measure([0, 1]) == pytest.approx(he1_dist)
 
+    with pytest.raises(KeyError):
+        ds.get_molecules(subset="NotInDataset")
+
 
 def test_gradient_dataset_get_records(gradient_dataset_fixture):
     client, ds = gradient_dataset_fixture
@@ -95,6 +98,16 @@ def test_gradient_dataset_get_records(gradient_dataset_fixture):
     rec_proj = ds.get_records("HF", "sto-3g", projection={"extras": True, "return_result": True})
     assert rec_proj.shape == (2, 2)
     assert set(rec_proj.columns) == {"extras", "return_result"}
+
+    with pytest.raises(KeyError):
+        ds.get_records(method="NotInDataset")
+
+
+def test_gradient_dataset_get_values_no_match(gradient_dataset_fixture):
+    client, ds = gradient_dataset_fixture
+
+    with pytest.raises(KeyError):
+        ds.get_values(method="NotInDataset")
 
 
 def test_gradient_dataset_statistics(gradient_dataset_fixture):

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -236,6 +236,13 @@ def test_rectiondataset_dftd3_records(reactiondataset_dftd3_fixture_fixture):
     assert records.iloc[0, 0].status == "COMPLETE"
     assert records.iloc[0, 0].id == records.iloc[1, 0].id
 
+    records = ds.get_records("B3LYP", "6-31g", stoich=["cp", "default"], subset="HeDimer")
+    assert records.shape == (2, 1)
+
+    # No molecules
+    with pytest.raises(KeyError):
+        records = ds.get_records("B3LYP", "6-31g", stoich=["cp", "default"], subset="Gibberish")
+
 def test_rectiondataset_dftd3_energies(reactiondataset_dftd3_fixture_fixture):
     client, ds = reactiondataset_dftd3_fixture_fixture
 

--- a/qcfractal/tests/test_server.py
+++ b/qcfractal/tests/test_server.py
@@ -33,14 +33,14 @@ def test_molecule_socket(test_server):
     water_json = json.loads(water.json())
     # Add a molecule
     r = requests.post(mol_api_addr, json={"meta": {}, "data": [water_json]})
-    assert r.status_code == 200
+    assert r.status_code == 200, r.reason
 
     pdata = r.json()
     assert pdata["meta"].keys() == meta_set
 
     # Retrieve said molecule
     r = requests.get(mol_api_addr, json={"meta": {}, "data": {"id": pdata["data"][0]}})
-    assert r.status_code == 200
+    assert r.status_code == 200, r.reason
 
     gdata = r.json()
     assert isinstance(gdata["data"], list)
@@ -49,7 +49,7 @@ def test_molecule_socket(test_server):
 
     # Retrieve said molecule via hash
     r = requests.get(mol_api_addr, json={"meta": {}, "data": {"molecule_hash": water.get_hash()}})
-    assert r.status_code == 200
+    assert r.status_code == 200, r.reason
 
     gdata = r.json()
     assert isinstance(gdata["data"], list)
@@ -63,7 +63,7 @@ def test_keywords_socket(test_server):
     opts = {"values": {"opt": "a"}}
     # Add a molecule
     r = requests.post(opt_api_addr, json={"meta": {}, "data": [opts]})
-    assert r.status_code == 200
+    assert r.status_code == 200, r.reason
 
     pdata = r.json()
     assert pdata["meta"].keys() == meta_set
@@ -72,13 +72,13 @@ def test_keywords_socket(test_server):
     data_payload = {"id": pdata["data"][0]}
 
     r = requests.get(opt_api_addr, json={"meta": {}, "data": data_payload})
-    assert r.status_code == 200
+    assert r.status_code == 200, r.reason
 
     assert r.json()["data"][0]["values"] == opts["values"]
 
     # Try duplicates
     r = requests.post(opt_api_addr, json={"meta": {}, "data": [opts]})
-    assert r.status_code == 200
+    assert r.status_code == 200, r.reason
     assert len(r.json()["meta"]["duplicates"]) == 1
 
 
@@ -90,7 +90,7 @@ def test_storage_socket(test_server):
     storage['collection'] = storage['collection'].lower()
 
     r = requests.post(storage_api_addr, json={"meta": {}, "data": storage})
-    assert r.status_code == 200
+    assert r.status_code == 200, r.reason
 
     pdata = r.json()
     assert pdata["meta"].keys() == meta_set
@@ -104,7 +104,7 @@ def test_storage_socket(test_server):
                              "name": storage["name"]
                          }
                      })
-    assert r.status_code == 200
+    assert r.status_code == 200, r.reason
 
     pdata = r.json()
     del pdata["data"][0]["id"]

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -52,7 +52,12 @@ class APIHandler(tornado.web.RequestHandler):
             self.authenticate(self._required_auth)
 
         try:
-            self.data = deserialize(self.request.body, self.encoding)
+            if (self.encoding == "json") and isinstance(self.request.body, bytes):
+                blob = self.request.body.decode()
+            else:
+                blob = self.request.body
+
+            self.data = deserialize(blob, self.encoding)
         except:
             raise tornado.web.HTTPError(status_code=401, reason="Could not deserialize body.")
 


### PR DESCRIPTION
## Description
From discussion with @mattwelborn we decided to overhaul the `get/query` functionality in the Dataset collection. This renaming is as follows:
- `get_records` will return either full ResultRecords or a project, no caching. Replaces `query`.
- `get_molecules` will return the Molecule objects for the Dataset.
- `get_values` will return the canonical values in data columns. Replaces `get_history`, but also always returns the view of the query. So `get_values("B3LYP", "sto-3g")` will now return that column while also caching it internally for speed.
- `get_contributed_values` will now return a column rather than the object representation.

The ReactionDataset tech is still being overhauled.

## Status
- [x] Changelog updated
- [x] Ready to go