### PR TITLE
Add tag and manager selector fields to client.query_tasks

### DIFF
--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -15,6 +15,21 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+X.Y.0 / 2019-MM-DD
+-------------------
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+- (:pr:`394`) Adds `tag` and `manager` selector fields to client.query_tasks.
+  This is helpful for managing jobs in the queue and detecting failures.
+
+Bug Fixes
++++++++++
+
+
 0.10.0 / 2019-08-26
 -------------------
 

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -819,6 +819,8 @@ class FractalClient(object):
                     program: 'QueryStr' = None,
                     status: 'QueryStr' = None,
                     base_result: 'QueryStr' = None,
+                    tag: 'QueryStr' = None,
+                    manager: 'QueryStr' = None,
                     limit: Optional[int] = None,
                     skip: int = 0,
                     projection: 'QueryProjection' = None,
@@ -837,6 +839,10 @@ class FractalClient(object):
             Queries the Tasks ``status`` field.
         base_result : QueryStr, optional
             Queries the Tasks ``base_result`` field.
+        tag : QueryStr, optional
+            Queries the Tasks ``tag`` field.
+        manager : QueryStr, optional
+            Queries the Tasks ``manager`` field.
         limit : Optional[int], optional
             The maximum number of Tasks to query
         skip : int, optional
@@ -872,7 +878,9 @@ class FractalClient(object):
                 "hash_index": hash_index,
                 "program": program,
                 "status": status,
-                "base_result": base_result
+                "base_result": base_result,
+                "tag": tag,
+                "manager": manager
             }
         }
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -812,7 +812,7 @@ class Dataset(Collection):
         return tmp_idx
 
     def add_entry(self, name: str, molecule: Molecule, **kwargs: Dict[str, Any]):
-        """Adds a new entry to the Datset
+        """Adds a new entry to the Dataset
 
         Parameters
         ----------
@@ -821,7 +821,7 @@ class Dataset(Collection):
         molecule : Molecule
             The Molecule associated with this record
         **kwargs : Dict[str, Any]
-            Additional arguements to pass to the record
+            Additional arguments to pass to the record
         """
         mhash = molecule.get_hash()
         self._new_molecules[mhash] = molecule

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -678,7 +678,7 @@ class TaskQueueGETBody(ProtoModel):
         )
         program: QueryStr = Schema(
             None,
-            description="Tasks will be searched based on the program which is responsible for executing this task."
+            description="Tasks will be searched based on the program responsible for executing this task."
         )
         status: QueryStr = Schema(
             None,
@@ -690,6 +690,14 @@ class TaskQueueGETBody(ProtoModel):
             description="The exact Id of the Result which this Task is linked to. If this is set as a "
                         "search condition, there is no reason to set anything else as this will be unique in the "
                         "database, if it exists. See also :class:`ResultRecord`."
+        )
+        tag: QueryStr = Schema(
+            None,
+            description="Tasks will be searched based on their associated tag."
+        )
+        manager: QueryStr = Schema(
+            None,
+            description="Tasks will be searched based on the manager responsible for executing the task."
         )
 
     meta: QueryMetaProjection = Schema(

--- a/qcfractal/storage_sockets/models/sql_models.py
+++ b/qcfractal/storage_sockets/models/sql_models.py
@@ -167,7 +167,7 @@ class TaskQueueORM(Base):
     """A queue of tasks corresponding to a procedure
 
        Notes: don't sort query results without having the index sorted
-              will impact the performce
+              will impact the performance
     """
 
     __tablename__ = "task_queue"

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1608,6 +1608,8 @@ class SQLAlchemySocket:
                   program=None,
                   status: str = None,
                   base_result: str = None,
+                  tag=None,
+                  manager=None,
                   projection=None,
                   limit: int = None,
                   skip: int = 0,
@@ -1650,7 +1652,9 @@ class SQLAlchemySocket:
                              id=id,
                              hash_index=hash_index,
                              status=status,
-                             base_result_id=base_result)
+                             base_result_id=base_result,
+                             tag=tag,
+                             manager=manager)
 
         data = []
         try:

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -383,3 +383,43 @@ def test_queue_order_procedure_priority(fractal_compute_server):
     assert queue_id1 == ret2
     assert queue_id2 == ret3
     assert queue_id3 == ret1
+
+
+def test_queue_query_tag_manager(fractal_compute_server):
+    reset_server_database(fractal_compute_server)
+
+    client = ptl.FractalClient(fractal_compute_server)
+
+    mol1 = ptl.Molecule.from_data("He 0 0 0\nHe 0 0 1.1")
+    mol2 = ptl.Molecule.from_data("He 0 0 0\nHe 0 0 2.2")
+    mol3 = ptl.Molecule.from_data("He 0 0 0\nHe 0 0 3.3")
+
+    ret1 = client.add_compute("rdkit", "uff", "", "energy", None, mol1).ids[0]
+    ret2 = client.add_compute("RDKIT", "UFF", "", "energy", None, mol2, tag="test").ids[0]
+    ret3 = client.add_compute("RDKIT", "UFF", "", "energy", None, mol3, tag="test2").ids[0]
+
+    tasks_tag_test = client.query_tasks(tag="test")
+    assert len(tasks_tag_test) == 1
+    assert tasks_tag_test[0].id == ret2
+
+    tasks_tag_none = client.query_tasks()
+    assert len(tasks_tag_none) == 3
+
+    tasks_tagged = client.query_tasks(tag=["test", "test2"])
+    assert len(tasks_tagged) == 2
+
+    manager = get_manager_name(fractal_compute_server)
+    fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0].base_result.id
+    tasks_manager = client.query_tasks(manager=manager)
+    assert len(tasks_manager) == 1
+    assert tasks_manager[0].id == ret1
+
+    fractal_compute_server.storage.queue_get_next(manager, ["RDkit"], [], limit=1)[0].base_result.id
+    tasks_manager_tag = client.query_tasks(manager=manager, tag="test")
+    assert len(tasks_manager_tag) == 1
+    assert tasks_manager_tag[0].id == ret2
+
+    fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], [], limit=1)[0].base_result.id
+
+    tasks_manager = client.query_tasks(manager=manager)
+    assert len(tasks_manager) == 3

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -385,7 +385,7 @@ def test_queue_order_procedure_priority(fractal_compute_server):
     assert queue_id3 == ret1
 
 
-def test_queue_query_tag_manager(fractal_compute_server):
+def test_queue_query_tag(fractal_compute_server):
     reset_server_database(fractal_compute_server)
 
     client = ptl.FractalClient(fractal_compute_server)
@@ -400,26 +400,37 @@ def test_queue_query_tag_manager(fractal_compute_server):
 
     tasks_tag_test = client.query_tasks(tag="test")
     assert len(tasks_tag_test) == 1
-    assert tasks_tag_test[0].id == ret2
+    assert tasks_tag_test[0].base_result.id == ret2
 
     tasks_tag_none = client.query_tasks()
     assert len(tasks_tag_none) == 3
 
     tasks_tagged = client.query_tasks(tag=["test", "test2"])
+    assert tasks_tagged[0].base_result.id == ret2
+    assert tasks_tagged[1].base_result.id == ret3
     assert len(tasks_tagged) == 2
 
+
+def test_queue_query_manager(fractal_compute_server):
+    reset_server_database(fractal_compute_server)
+
+    client = ptl.FractalClient(fractal_compute_server)
+
+    mol1 = ptl.Molecule.from_data("He 0 0 0\nHe 0 0 1.1")
+    mol2 = ptl.Molecule.from_data("He 0 0 0\nHe 0 0 2.2")
+    mol3 = ptl.Molecule.from_data("He 0 0 0\nHe 0 0 3.3")
+
+    ret1 = client.add_compute("rdkit", "uff", "", "energy", None, mol1).ids[0]
+    ret2 = client.add_compute("RDKIT", "UFF", "", "energy", None, mol2).ids[0]
+    ret3 = client.add_compute("RDKIT", "UFF", "", "energy", None, mol3).ids[0]
+
     manager = get_manager_name(fractal_compute_server)
-    fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0].base_result.id
+    fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0]
     tasks_manager = client.query_tasks(manager=manager)
     assert len(tasks_manager) == 1
-    assert tasks_manager[0].id == ret1
+    assert tasks_manager[0].base_result.id == ret1
 
-    fractal_compute_server.storage.queue_get_next(manager, ["RDkit"], [], limit=1)[0].base_result.id
-    tasks_manager_tag = client.query_tasks(manager=manager, tag="test")
-    assert len(tasks_manager_tag) == 1
-    assert tasks_manager_tag[0].id == ret2
-
-    fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], [], limit=1)[0].base_result.id
-
+    fractal_compute_server.storage.queue_get_next(manager, ["RDkit"], [], limit=1)[0]
+    fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], [], limit=1)[0]
     tasks_manager = client.query_tasks(manager=manager)
     assert len(tasks_manager) == 3

--- a/qcfractal/tests/test_storage.py
+++ b/qcfractal/tests/test_storage.py
@@ -619,7 +619,6 @@ def test_queue_submit_many_order(storage_results):
         "parser": "",
     }
 
-
     task1 = ptl.models.TaskRecord(**task_template, base_result=dict(ref='result', id=results[3]['id']))
     task2 = ptl.models.TaskRecord(**task_template, base_result=dict(ref='result', id=results[4]['id']))
     task3 = ptl.models.TaskRecord(**task_template, base_result=dict(ref='result', id=results[5]['id']))


### PR DESCRIPTION
## Description
This PR adds `tag` and `manager` selector fields to `client.query_tasks`. This is helpful for managing jobs in the queue and detecting failures. See issue #392. 

## Questions
- [x] @doaa-altarawy or @dgasmith could you please carefully check that I changed the correct objects and did so in the right way? I think I'm missing something, since this breaks `qcfractal/tests/test_storage.py::test_queue_submit_many_order`. (But only on my machine; not on Travis.)
- [x] There's something I don't understand about how the `fractal_compute_server` fixture works. I can get my new test qcfractal/tests/test_compute.py::test_queue_query_tag_manager to work if run on it's own, but not as part of the full suite. (BUT this only happens in the OpenFF pipeline...). FIXED.
- [x] Are the tests in the right place? Am I testing the right things? 

## TODO
- [x] Fix tests

## Status
- [x] Changelog updated
- [x] Ready to go