### PR TITLE
Fix bug in Dataset._compute

### DIFF
--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -616,9 +616,9 @@ class Dataset(Collection):
                     tag=tag,
                     priority=priority)
 
-            ids.extend(ret.ids)
-            submitted.extend(ret.submitted)
-            existing.extend(ret.existing)
+                ids.extend(ret.ids)
+                submitted.extend(ret.submitted)
+                existing.extend(ret.existing)
 
             qhistory = history.copy()
             qhistory["program"] = compute_set["program"]


### PR DESCRIPTION
## Description
This PR fixes a bug in Dataset._compute that was caused by an indentation error. The bug causes the returned ComputeResponse to be truncated when the number of calculations is larger than the `query_limit`. A test has been added. 

## Status
- [ ] Changelog updated
- [x] Ready to go