### PR TITLE
Rename list_history to list_records

### DIFF
--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -35,6 +35,8 @@ Enhancements
 
 - (:pr:`400`) Adds Dockerfiles corresponding to builds on `Docker Hub <https://cloud.docker.com/u/molssi/repository/list>`_.
 
+- (:pr:`404`) ``Dataset`` and ``ReactionDataset`` member function ``get_history`` has been renamed to ``get_records``.
+
 Bug Fixes
 +++++++++
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -169,19 +169,53 @@ class Dataset(Collection):
 
         self.data.history.add(tuple(new_history))
 
-    def list_history(self, dftd3: bool=False, get_base: bool=False, pretty: bool=True, **search: Dict[str, Optional[str]]) -> 'DataFrame':
+    def list_history(self,
+                     dftd3: bool = False,
+                     pretty: bool = True,
+                     **search: Dict[str, Optional[str]]) -> 'DataFrame':
         """
         Lists the history of computations completed.
 
         Parameters
         ----------
+        dftd3: bool, optional
+            Include dftd3 program record specifications in addition to composite DFT-D3 record specifications
+        pretty: bool
+            Replace NaN with "None" in returned DataFrame
         **search : Dict[str, Optional[str]]
             Allows searching to narrow down return.
 
         Returns
         -------
         DataFrame
-            The computed keys.
+            Record specifications matching **search.
+
+        """
+        warnings.warn("This function has been renamed to `list_records`.  "
+                      "`list_history` will be removed in 0.11.0", DeprecationWarning)
+
+        return self.list_records(dftd3, pretty, **search)
+
+    def list_records(self,
+                     dftd3: bool = False,
+                     pretty: bool = True,
+                     **search: Dict[str, Optional[str]]) -> 'DataFrame':
+        """
+        Lists specifications of available records, i.e. method, program, basis set, keyword set, driver combinations
+
+        Parameters
+        ----------
+        dftd3: bool, optional
+            Include dftd3 program record specifications in addition to composite DFT-D3 record specifications
+        pretty: bool
+            Replace NaN with "None" in returned DataFrame
+        **search : Dict[str, Optional[str]]
+            Allows searching to narrow down return.
+
+        Returns
+        -------
+        DataFrame
+            Record specifications matching **search.
 
         """
 
@@ -219,7 +253,6 @@ class Dataset(Collection):
             else:
                 raise TypeError(f"Search type {type(value)} not understood.")
 
-
         if show_dftd3 is False:
             ret = ret[ret["program"] != "dftd3"]
 
@@ -251,7 +284,7 @@ class Dataset(Collection):
             If no records match the query
         """
 
-        queries = self.list_history(**search, dftd3=True, pretty=False).reset_index()
+        queries = self.list_records(**search, dftd3=True, pretty=False).reset_index()
         if queries.shape[0] > 10:
             raise TypeError("More than 10 queries formed, please narrow the search.")
 
@@ -312,7 +345,7 @@ class Dataset(Collection):
             else:
                 history.pop(k, None)
 
-        queries = self.list_history(**history, dftd3=True, pretty=False).reset_index()
+        queries = self.list_records(**history, dftd3=True, pretty=False).reset_index()
         if queries.shape[0] > 10:
             raise TypeError("More than 10 queries formed, please narrow the search.")
 

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -207,7 +207,7 @@ class ReactionDataset(Dataset):
             else:
                 history.pop(k, None)
 
-        queries = self.list_history(**history, dftd3=True, pretty=False).reset_index()
+        queries = self.list_records(**history, dftd3=True, pretty=False).reset_index()
         if queries.shape[0] > 10:
             raise TypeError("More than 10 queries formed, please narrow the search.")
 

--- a/qcfractal/interface/tests/test_dataset.py
+++ b/qcfractal/interface/tests/test_dataset.py
@@ -240,7 +240,7 @@ def test_database_history():
     for h in history:
         ds._add_history(driver=h[0], program=h[1], method=h[2], basis=h[3], keywords=h[4])
 
-    assert ds.list_history().shape[0] == 5
-    assert ds.list_history(program="P1").shape[0] == 4
-    assert ds.list_history(basis=None).shape[0] == 3
-    assert ds.list_history(keywords=None).shape[0] == 1
+    assert ds.list_records().shape[0] == 5
+    assert ds.list_records(program="P1").shape[0] == 4
+    assert ds.list_records(basis=None).shape[0] == 3
+    assert ds.list_records(keywords=None).shape[0] == 1

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -362,7 +362,7 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
     assert pytest.approx(0.002447793, 1.e-5) == ds.statistics("MURE", "SCF/sto-3g", floor=10)
 
     assert isinstance(ds.to_json(), dict)
-    assert ds.list_history(keywords=None).shape[0] == 1
+    assert ds.list_records(keywords=None).shape[0] == 1
 
     ds.units = "eV"
     assert pytest.approx(0.00010614635, 1.e-5) == ds.statistics("MURE", "SCF/sto-3g", floor=10)
@@ -404,14 +404,14 @@ def test_compute_reactiondataset_keywords(fractal_compute_server):
     ds.get_values("SCF", "sto-3g", keywords="df").columns[0] == "SCF/sto-3g-df"
     assert pytest.approx(0.38748602675524185, 1.e-5) == ds.df.loc["He2", "SCF/sto-3g-df"]
 
-    assert ds.list_history().shape[0] == 2
-    assert ds.list_history(keywords="DF").shape[0] == 1
-    assert ds.list_history(keywords="DIRECT").shape[0] == 1
+    assert ds.list_records().shape[0] == 2
+    assert ds.list_records(keywords="DF").shape[0] == 1
+    assert ds.list_records(keywords="DIRECT").shape[0] == 1
 
     # Check saved history
     ds = client.get_collection("reactiondataset", "dataset_options")
-    assert ds.list_history().shape[0] == 2
-    assert {"df", "direct"} == set(ds.list_history().reset_index()["keywords"])
+    assert ds.list_records().shape[0] == 2
+    assert {"df", "direct"} == set(ds.list_records().reset_index()["keywords"])
 
     # Check keywords
     kw = ds.get_keywords("df", "psi4")


### PR DESCRIPTION
## Description
This PR renames `Dataset.list_history` to `Dataset.list_records`. It deprecates `Dataset.list_history`.

This PR is part of the ANI-1 Milestone:
<img width="1383" alt="image" src="https://user-images.githubusercontent.com/1508995/65194065-78c32200-da4a-11e9-94f2-30dc2112796a.png">

## Status
- [x] Changelog updated
- [x] Ready to go