### PR TITLE
Skip broken intel-openmp

### DIFF
--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -31,7 +31,7 @@ dependencies:
   - rdkit
   - geometric>=0.9.3
   - torsiondrive
-  - intel-openmp!=2019.5-281
+  - intel-openmp!=2019.5
 
 # QCArchive includes
   - qcengine>=0.9.0

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -31,6 +31,7 @@ dependencies:
   - rdkit
   - geometric>=0.9.3
   - torsiondrive
+  - intel-openmp!=2019.5-281
 
 # QCArchive includes
   - qcengine>=0.9.0


### PR DESCRIPTION
## Description
This PR skips intel-openmp version 2019.5-281, which breaks geometric+psi4. See also, https://github.com/ContinuumIO/anaconda-issues/issues/11294.