### PR TITLE
Add tests for docker images

### DIFF
--- a/devtools/docker/qcarchive_worker_openff/Dockerfile
+++ b/devtools/docker/qcarchive_worker_openff/Dockerfile
@@ -1,5 +1,5 @@
 FROM continuumio/miniconda3
-RUN conda install -c psi4/label/dev -c conda-forge psi4 dftd3 mp2d qcengine qcfractal rdkit geometric 
+RUN conda install -c psi4/label/dev -c conda-forge psi4 dftd3 mp2d qcengine qcfractal rdkit geometric pytest
 RUN groupadd -g 999 qcfractal && \
     useradd -m -r -u 999 -g qcfractal qcfractal
 USER qcfractal

--- a/devtools/docker/qcarchive_worker_openff/docker-compose.test.yml
+++ b/devtools/docker/qcarchive_worker_openff/docker-compose.test.yml
@@ -1,3 +1,3 @@
 sut:
   build: .
-  command: pytest -v -rsx --runslow
+  command: pytest -v -rsx --runslow --pyargs qcfractal

--- a/devtools/docker/qcarchive_worker_openff/docker-compose.test.yml
+++ b/devtools/docker/qcarchive_worker_openff/docker-compose.test.yml
@@ -1,3 +1,4 @@
 sut:
   build: .
+  working_dir: /home/qcfractal
   command: pytest -v -rsx --runslow --pyargs qcfractal

--- a/devtools/docker/qcarchive_worker_openff/docker-compose.test.yml
+++ b/devtools/docker/qcarchive_worker_openff/docker-compose.test.yml
@@ -1,0 +1,3 @@
+sut:
+  build: .
+  command: pytest -v -rsx --runslow

--- a/devtools/docker/qcfractal/Dockerfile
+++ b/devtools/docker/qcfractal/Dockerfile
@@ -1,5 +1,5 @@
 FROM continuumio/miniconda3
-RUN conda install -c conda-forge qcfractal
+RUN conda install -c conda-forge qcfractal pytest
 RUN groupadd -g 999 qcfractal && \
     useradd -m -r -u 999 -g qcfractal qcfractal
 USER qcfractal

--- a/devtools/docker/qcfractal/docker-compose.test.yml
+++ b/devtools/docker/qcfractal/docker-compose.test.yml
@@ -1,3 +1,3 @@
 sut:
   build: .
-  command: pytest -v -rsx --runslow
+  command: pytest -v -rsx --runslow --pyargs qcfractal

--- a/devtools/docker/qcfractal/docker-compose.test.yml
+++ b/devtools/docker/qcfractal/docker-compose.test.yml
@@ -1,3 +1,4 @@
 sut:
   build: .
+  working_dir: /home/qcfractal
   command: pytest -v -rsx --runslow --pyargs qcfractal

--- a/devtools/docker/qcfractal/docker-compose.test.yml
+++ b/devtools/docker/qcfractal/docker-compose.test.yml
@@ -1,0 +1,3 @@
+sut:
+  build: .
+  command: pytest -v -rsx --runslow

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -856,7 +856,7 @@ class FractalClient(object):
         -------
         List[Dict[str, Any]]
             A dictionary of each match that contains the current status
-            and, if an error has occured, the error message.
+            and, if an error has occurred, the error message.
 
         Examples
         --------

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -404,11 +404,11 @@ def test_queue_query_tag(fractal_compute_server):
 
     tasks_tag_none = client.query_tasks()
     assert len(tasks_tag_none) == 3
+    assert {task.base_result.id for task in tasks_tag_none} == {ret1, ret2, ret3}
 
     tasks_tagged = client.query_tasks(tag=["test", "test2"])
-    assert tasks_tagged[0].base_result.id == ret2
-    assert tasks_tagged[1].base_result.id == ret3
     assert len(tasks_tagged) == 2
+    assert {task.base_result.id for task in tasks_tagged} == {ret2, ret3}
 
 
 def test_queue_query_manager(fractal_compute_server):


### PR DESCRIPTION
## Description
This PR adds tests for Docker images, prompted by the intel-openmp bug. This PR also attempts to resolve #405.

# TODO
- [x] Check tests pass on Dockerhub

## Status
- [x] Changelog updated
- [x] Ready to go