### PR TITLE
Dataset.list_values and modified get_values interface

### DIFF
--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -24,18 +24,19 @@ New Features
 Enhancements
 ++++++++++++
 
-- (:pr:`385`) ``Dataset`` and ``ReactionDataset`` have three new functions for accessing data.
-  ``get_values`` returns the canonical headline value for a dataset (e.g. the interaction energy for S22) in data columns with caching. This function replaces the now-deprecated ``get_history``.
-  ``get_records`` either returns ``ResultRecord`` or a projection. For the case of ``ReactionDataset``, the results are broken down into component calculcations. The function replaces the now-deprecated ``query``.
+- (:pr:`385`, :pr:`404`, :pr:`411`) ``Dataset`` and ``ReactionDataset`` have five new functions for accessing data.
+  ``get_values`` returns the canonical headline value for a dataset (e.g. the interaction energy for S22) in data columns with caching,
+  both for result-backed values and contributed values. This function replaces the now-deprecated ``get_history`` and ``get_contributed_values``.
+  ``list_values`` returns the list of data columns available from ``get_values``. This function replaces the now-deprecated ``list_history`` and ``list_contributed_values``.
+  ``get_records`` either returns ``ResultRecord`` or a projection. For the case of ``ReactionDataset``, the results are broken down into component calculcations.
+  The function replaces the now-deprecated ``query``.
+  ``list_records`` returns the list of data columns available from ``get_records``.
   ``get_molecules`` returns the ``Molecule`` associated with a dataset.
-  In addition, ``get_contributed_values`` now returns a data column.
 
 - (:pr:`394`) Adds ``tag`` and ``manager`` selector fields to ``client.query_tasks``.
   This is helpful for managing jobs in the queue and detecting failures.
 
 - (:pr:`400`) Adds Dockerfiles corresponding to builds on `Docker Hub <https://cloud.docker.com/u/molssi/repository/list>`_.
-
-- (:pr:`404`) ``Dataset`` and ``ReactionDataset`` member function ``get_history`` has been renamed to ``get_records``.
 
 Bug Fixes
 +++++++++

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1088,6 +1088,8 @@ class Dataset(Collection):
 
         for cv_name, theory_level_details in cvs:
             spec = {"name": cv_name}
+            for k in self.data.history_keys:
+                spec[k] = "Unknown"
             # ReactionDataset uses "default" as a default value for stoich, but many contributed datasets lack a stoich field
             if "stoichiometry" in self.data.history_keys:
                 spec["stoich"] = "default"

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -382,9 +382,7 @@ class Dataset(Collection):
             Contributed (native=False) columns are marked with "(contributed)" and may include units in square brackets
             if their units differ in dimensionality from the Dataset's default units.
         """
-        spec = locals()
-        spec.pop("self")
-        return self._get_values(**spec)
+        return self._get_values(method=method, basis=basis, keywords=keywords, program=program, driver=driver, name=name, native=native, force=force)
 
     def _get_values(self,
                     native: Optional[bool] = None,
@@ -442,9 +440,6 @@ class Dataset(Collection):
         DataFrame
             A DataFrame of the queried parameters
         """
-        spec = locals()
-        spec.pop("force")
-        spec.pop("self")
         # TODO: is this somewhere in elemental?
         au_units = {'energy': 'hartree',
                     'gradient': 'hartree/bohr',
@@ -454,7 +449,7 @@ class Dataset(Collection):
         if len(self.list_records()) == 0:
             return pd.DataFrame(columns=['index']).set_index('index')
 
-        queries = self._form_queries(**spec)
+        queries = self._form_queries(method=method, basis=basis, keywords=keywords, program=program, name=name)
 
         names = []
         for _, query in queries.iterrows():

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -46,8 +46,7 @@ class Dataset(Collection):
     df : pd.DataFrame
         The underlying dataframe for the Dataset object
     """
-
-    def __init__(self, name: str, client: Optional['FractalClient']=None, **kwargs: Dict[str, Any]):
+    def __init__(self, name: str, client: Optional['FractalClient'] = None, **kwargs: Dict[str, Any]):
         """
         Initializer for the Dataset object. If no Portal is supplied or the database name
         is not present on the server that the Portal is connected to a blank database will be
@@ -75,7 +74,6 @@ class Dataset(Collection):
         # Initialize internal data frames and load in contrib
         self.df = pd.DataFrame(index=self.get_index())
         self._column_metadata = {}
-
 
     class DataModel(Collection.DataModel):
 
@@ -206,12 +204,14 @@ class Dataset(Collection):
             A DataFrame of the matching data specifications
         """
         ret = []
-        spec = {"method": method,
-                "basis": basis,
-                "keywords": keywords,
-                "program": program,
-                "name": name,
-                "driver": driver}
+        spec = {
+            "method": method,
+            "basis": basis,
+            "keywords": keywords,
+            "program": program,
+            "name": name,
+            "driver": driver
+        }
 
         if native in {True, None}:
             df = self._list_records(dftd3=False)
@@ -251,9 +251,7 @@ class Dataset(Collection):
                 raise TypeError(f"Search type {type(value)} not understood.")
         return ret
 
-    def list_history(self,
-                     dftd3: bool = False,
-                     pretty: bool = True,
+    def list_history(self, dftd3: bool = False, pretty: bool = True,
                      **search: Dict[str, Optional[str]]) -> 'DataFrame':
         """
         Lists the history of computations completed.
@@ -278,9 +276,7 @@ class Dataset(Collection):
 
         return self.list_records(dftd3, pretty, **search)
 
-    def list_records(self,
-                     dftd3: bool = False,
-                     pretty: bool = True,
+    def list_records(self, dftd3: bool = False, pretty: bool = True,
                      **search: Dict[str, Optional[str]]) -> pd.DataFrame:
         """
         Lists specifications of available records, i.e. method, program, basis set, keyword set, driver combinations
@@ -352,7 +348,8 @@ class Dataset(Collection):
                                                                  basis=row["basis"],
                                                                  keywords=row["keywords"],
                                                                  stoich=row.get("stoichiometry", None),
-                                                                 driver=row["driver"]), axis=1)
+                                                                 driver=row["driver"]),
+                                axis=1)
         if show_dftd3 is False:
             ret = ret[ret["program"] != "dftd3"]
 
@@ -402,20 +399,25 @@ class Dataset(Collection):
         DataFrame
             A DataFrame of values with columns corresponding to methods and rows corresponding to molecule entries.
         """
-        return self._get_values(method=method, basis=basis, keywords=keywords, program=program, driver=driver, name=name, native=native, force=force)
+        return self._get_values(method=method,
+                                basis=basis,
+                                keywords=keywords,
+                                program=program,
+                                driver=driver,
+                                name=name,
+                                native=native,
+                                force=force)
 
-    def _get_values(self,
-                    native: Optional[bool] = None,
-                    force: bool = False,
-                    **spec):
+    def _get_values(self, native: Optional[bool] = None, force: bool = False, **spec):
         ret = []
 
         if native in {True, None}:
             spec_nodriver = spec.copy()
             driver = spec_nodriver.pop("driver")
             if driver is not None and driver != self.data.default_driver:
-                raise KeyError(f"For native values, driver ({driver}) must be the same as the dataset's default driver "
-                               f"({self.data.default_driver}). Consider using get_records instead.")
+                raise KeyError(
+                    f"For native values, driver ({driver}) must be the same as the dataset's default driver "
+                    f"({self.data.default_driver}). Consider using get_records instead.")
             df = self._get_values_from_records(force=force, **spec_nodriver)
             ret.append(df)
 
@@ -428,12 +430,12 @@ class Dataset(Collection):
         return ret
 
     def _get_values_from_records(self,
-                   method: Optional[str] = None,
-                   basis: Optional[str] = None,
-                   keywords: Optional[str] = None,
-                   program: Optional[str] = None,
-                   name: Optional[str] = None,
-                   force: bool = False) -> pd.DataFrame:
+                                 method: Optional[str] = None,
+                                 basis: Optional[str] = None,
+                                 keywords: Optional[str] = None,
+                                 program: Optional[str] = None,
+                                 name: Optional[str] = None,
+                                 force: bool = False) -> pd.DataFrame:
         """Obtains values from the known history from the search parameters provided for the expected `return_result` values. Defaults to the standard
         programs and keywords if not provided.
 
@@ -459,9 +461,7 @@ class Dataset(Collection):
         DataFrame
             A DataFrame of the queried parameters
         """
-        au_units = {'energy': 'hartree',
-                    'gradient': 'hartree/bohr',
-                    'hessian': 'hartree/bohr**2'}
+        au_units = {'energy': 'hartree', 'gradient': 'hartree/bohr', 'hessian': 'hartree/bohr**2'}
 
         # So that datasets with no records do not require a default program and default keywords
         if len(self.list_records()) == 0:
@@ -480,7 +480,10 @@ class Dataset(Collection):
             names.append(name)
             if force or (name not in self.df.columns):
                 self._column_metadata[name] = query
-                data = self.get_records(query.pop("method").upper(), projection={"return_result": True}, merge=True, **query)
+                data = self.get_records(query.pop("method").upper(),
+                                        projection={"return_result": True},
+                                        merge=True,
+                                        **query)
                 self.df[name] = data["return_result"] * constants.conversion_factor(au_units[driver], self.units)
                 self._column_metadata[name].update({"native": True, "units": self.units})
 
@@ -488,11 +491,11 @@ class Dataset(Collection):
 
     def _form_queries(self,
                       method: Optional[str] = None,
-                   basis: Optional[str] = None,
-                   keywords: Optional[str] = None,
-                   program: Optional[str] = None,
-                   stoich: Optional[str] = None,
-                   name: Optional[str] = None):
+                      basis: Optional[str] = None,
+                      keywords: Optional[str] = None,
+                      program: Optional[str] = None,
+                      stoich: Optional[str] = None,
+                      name: Optional[str] = None):
         if name is None:
             _, _, history = self._default_parameters(program, "nan", "nan", keywords, stoich=stoich)
             for k, v in [("method", method), ("basis", basis)]:
@@ -513,11 +516,11 @@ class Dataset(Collection):
         return queries
 
     def get_history(self,
-                    method: Optional[str]=None,
-                    basis: Optional[str]=None,
-                    keywords: Optional[str]=None,
-                    program: Optional[str]=None,
-                    force: bool=False) -> 'DataFrame':
+                    method: Optional[str] = None,
+                    basis: Optional[str] = None,
+                    keywords: Optional[str] = None,
+                    program: Optional[str] = None,
+                    force: bool = False) -> 'DataFrame':
         """ Queries known history from the search paramaters provided. Defaults to the standard
         programs and keywords if not provided.
 
@@ -538,8 +541,9 @@ class Dataset(Collection):
             A DataFrame of the queried parameters
         """
 
-        warnings.warn("This is function is deprecated and will be removed in 0.12.0, "
-                      "please use `get_values(..., )` for a instead.", DeprecationWarning)
+        warnings.warn(
+            "This is function is deprecated and will be removed in 0.12.0, "
+            "please use `get_values(..., )` for a instead.", DeprecationWarning)
 
         # Get default program/keywords
         return self.get_values(method=method, basis=basis, keywords=keywords, program=program, force=force)
@@ -548,7 +552,7 @@ class Dataset(Collection):
                    metric,
                    bench,
                    query: Dict[str, Optional[str]],
-                   groupby: Optional[str]=None,
+                   groupby: Optional[str] = None,
                    return_figure=None,
                    digits=3,
                    kind="bar") -> 'plotly.Figure':
@@ -634,12 +638,11 @@ class Dataset(Collection):
                 elif groupby:
                     record[groupby] = None
 
-                index_name = self._canonical_name(
-                    record["program"],
-                    record["method"],
-                    record["basis"],
-                    record["keywords"],
-                    stoich=record.get("stoich"))
+                index_name = self._canonical_name(record["program"],
+                                                  record["method"],
+                                                  record["basis"],
+                                                  record["keywords"],
+                                                  stoich=record.get("stoich"))
 
                 col_names[k] = index_name
 
@@ -660,15 +663,15 @@ class Dataset(Collection):
             return violin_plot(series[0], negative=negative, title=title, ylabel=ylabel, return_figure=return_figure)
 
     def visualize(self,
-                  method: Optional[str]=None,
-                  basis: Optional[str]=None,
-                  keywords: Optional[str]=None,
-                  program: Optional[str]=None,
-                  groupby: Optional[str]=None,
-                  metric: str="UE",
-                  bench: Optional[str]=None,
-                  kind: str="bar",
-                  return_figure: Optional[bool]=None) -> 'plotly.Figure':
+                  method: Optional[str] = None,
+                  basis: Optional[str] = None,
+                  keywords: Optional[str] = None,
+                  program: Optional[str] = None,
+                  groupby: Optional[str] = None,
+                  metric: str = "UE",
+                  bench: Optional[str] = None,
+                  kind: str = "bar",
+                  return_figure: Optional[bool] = None) -> 'plotly.Figure':
         """
         Parameters
         ----------
@@ -703,12 +706,12 @@ class Dataset(Collection):
         return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind)
 
     def _canonical_name(self,
-                        program: Optional[str]=None,
-                        method: Optional[str]=None,
-                        basis: Optional[str]=None,
-                        keywords: Optional[str]=None,
-                        stoich: Optional[str]=None,
-                        driver: Optional[str]=None) -> str:
+                        program: Optional[str] = None,
+                        method: Optional[str] = None,
+                        basis: Optional[str] = None,
+                        keywords: Optional[str] = None,
+                        stoich: Optional[str] = None,
+                        driver: Optional[str] = None) -> str:
         """
         Attempts to build a canonical name for a DataFrame column
         """
@@ -741,7 +744,7 @@ class Dataset(Collection):
                             method: str,
                             basis: Optional[str],
                             keywords: Optional[str],
-                            stoich: Optional[str]=None) -> Tuple[str, str, str, str]:
+                            stoich: Optional[str] = None) -> Tuple[str, str, str, str]:
         """
         Takes raw input parsed parameters and applies defaults to them.
         """
@@ -873,7 +876,7 @@ class Dataset(Collection):
                 records.extend(self.client.query_results(**query_set))
 
             if projection is None:
-                records = [{"molecule" : x.molecule, "record": x} for x in records]
+                records = [{"molecule": x.molecule, "record": x} for x in records]
 
             records = pd.DataFrame.from_dict(records)
 
@@ -913,12 +916,11 @@ class Dataset(Collection):
         Internal compute function
         """
 
-        name, dbkeys, history = self._default_parameters(
-            compute_keys["program"],
-            compute_keys["method"],
-            compute_keys["basis"],
-            compute_keys["keywords"],
-            stoich=compute_keys.get("stoich", None))
+        name, dbkeys, history = self._default_parameters(compute_keys["program"],
+                                                         compute_keys["method"],
+                                                         compute_keys["basis"],
+                                                         compute_keys["keywords"],
+                                                         stoich=compute_keys.get("stoich", None))
 
         self._check_client()
         self._check_state()
@@ -932,15 +934,14 @@ class Dataset(Collection):
 
             for i in range(0, len(umols), self.client.query_limit):
                 chunk_mols = umols[i:i + self.client.query_limit]
-                ret = self.client.add_compute(
-                    compute_set["program"],
-                    compute_set["method"],
-                    compute_set["basis"],
-                    compute_set["driver"],
-                    compute_set["keywords"],
-                    chunk_mols,
-                    tag=tag,
-                    priority=priority)
+                ret = self.client.add_compute(compute_set["program"],
+                                              compute_set["method"],
+                                              compute_set["basis"],
+                                              compute_set["driver"],
+                                              compute_set["keywords"],
+                                              chunk_mols,
+                                              tag=tag,
+                                              priority=priority)
 
                 ids.extend(ret.ids)
                 submitted.extend(ret.submitted)
@@ -990,7 +991,7 @@ class Dataset(Collection):
         self.data.__dict__["default_benchmark"] = benchmark
         return True
 
-    def add_keywords(self, alias: str, program: str, keyword: 'KeywordSet', default: bool=False) -> bool:
+    def add_keywords(self, alias: str, program: str, keyword: 'KeywordSet', default: bool = False) -> bool:
         """
         Adds an option alias to the dataset. Not that keywords are not present
         until a save call has been completed.
@@ -1098,7 +1099,8 @@ class Dataset(Collection):
         """
         ret = pd.DataFrame(columns=self.data.history_keys + tuple(["name"]))
 
-        cvs = ((cv_data.name, cv_data.theory_level_details) for (cv_name, cv_data) in self.data.contributed_values.items())
+        cvs = ((cv_data.name, cv_data.theory_level_details)
+               for (cv_name, cv_data) in self.data.contributed_values.items())
 
         for cv_name, theory_level_details in cvs:
             spec = {"name": cv_name}
@@ -1114,7 +1116,8 @@ class Dataset(Collection):
         return ret
 
     def _get_contributed_values(self, force: bool = False, **spec) -> pd.DataFrame:
-        queries = self._filter_records(self._list_contributed_values().rename(columns={'stoichiometry': 'stoich'}), **spec).to_dict("records")
+        queries = self._filter_records(self._list_contributed_values().rename(columns={'stoichiometry': 'stoich'}),
+                                       **spec).to_dict("records")
 
         column_names = []
         for query in queries:
@@ -1137,8 +1140,7 @@ class Dataset(Collection):
                 # Convert to numeric
                 metadata = {"native": False}
                 try:
-                    self.df[column_name] *= constants.conversion_factor(
-                        data.units, self.units)
+                    self.df[column_name] *= constants.conversion_factor(data.units, self.units)
                     metadata["units"] = self.units
                 except ValueError as e:
                     # This is meant to catch pint.errors.DimensionalityError without importing pint, which is too slow
@@ -1172,14 +1174,14 @@ class Dataset(Collection):
             return df
 
     def get_records(self,
-              method: str,
-              basis: Optional[str]=None,
-              *,
-              keywords: Optional[str]=None,
-              program: Optional[str]=None,
-              projection: Optional[Dict[str, bool]]=None,
-              subset: Optional[Union[str, Set[str]]] = None,
-              merge: bool = False) -> Union[pd.DataFrame, 'ResultRecord']:
+                    method: str,
+                    basis: Optional[str] = None,
+                    *,
+                    keywords: Optional[str] = None,
+                    program: Optional[str] = None,
+                    projection: Optional[Dict[str, bool]] = None,
+                    subset: Optional[Union[str, Set[str]]] = None,
+                    merge: bool = False) -> Union[pd.DataFrame, 'ResultRecord']:
         """Queries full ResultRecord objects from the database.
 
         Parameters
@@ -1238,12 +1240,12 @@ class Dataset(Collection):
 
     def query(self,
               method: str,
-              basis: Optional[str]=None,
+              basis: Optional[str] = None,
               *,
-              keywords: Optional[str]=None,
-              program: Optional[str]=None,
-              field: str=None,
-              force: bool=False) -> str:
+              keywords: Optional[str] = None,
+              program: Optional[str] = None,
+              field: str = None,
+              force: bool = False) -> str:
         """
         Queries the local Portal for the requested keys.
 
@@ -1274,8 +1276,9 @@ class Dataset(Collection):
 
         """
 
-        warnings.warn("This is function is deprecated and will be removed in 0.12.0, "
-                      "please `get_records(..., projection='return_result')` for a similar result", DeprecationWarning)
+        warnings.warn(
+            "This is function is deprecated and will be removed in 0.12.0, "
+            "please `get_records(..., projection='return_result')` for a similar result", DeprecationWarning)
 
         name, dbkeys, history = self._default_parameters(program, method, basis, keywords)
 
@@ -1295,7 +1298,8 @@ class Dataset(Collection):
         tmp_idx = self._get_records(indexer, history, projection={field: True}, merge=True)
         tmp_idx.rename(columns={field: name}, inplace=True)
 
-        tmp_idx[tmp_idx.select_dtypes(include=['number']).columns] *= constants.conversion_factor('hartree', self.units)
+        tmp_idx[tmp_idx.select_dtypes(include=['number']).columns] *= constants.conversion_factor(
+            'hartree', self.units)
 
         # Apply to df
         self.df[tmp_idx.columns] = tmp_idx
@@ -1304,12 +1308,12 @@ class Dataset(Collection):
 
     def compute(self,
                 method: str,
-                basis: Optional[str]=None,
+                basis: Optional[str] = None,
                 *,
-                keywords: Optional[str]=None,
-                program: Optional[str]=None,
-                tag: Optional[str]=None,
-                priority: Optional[str]=None) -> ComputeResponse:
+                keywords: Optional[str] = None,
+                program: Optional[str] = None,
+                tag: Optional[str] = None,
+                priority: Optional[str] = None) -> ComputeResponse:
         """Executes a computational method for all reactions in the Dataset.
         Previously completed computations are not repeated.
 
@@ -1358,7 +1362,7 @@ class Dataset(Collection):
         return [x.name for x in self.data.records]
 
     # Statistical quantities
-    def statistics(self, stype: str, value: str, bench: Optional[str]=None, **kwargs: Dict[str, Any]):
+    def statistics(self, stype: str, value: str, bench: Optional[str] = None, **kwargs: Dict[str, Any]):
         """Provides statistics for various columns in the underlying dataframe.
 
         Parameters

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
-import pint
 
 from qcelemental import constants
 
@@ -1154,8 +1153,12 @@ class Dataset(Collection):
             try:
                 ret[column_name] *= constants.conversion_factor(
                     data.units, self.units)
-            except pint.errors.DimensionalityError:
-                ret.rename(columns={column_name: f"{column_name} [{data.units}]"}, inplace=True)
+            except ValueError as e:
+                # This is meant to catch pint.errors.DimensionalityError without importing pint, which is too slow
+                if e.__class__.__name__ == "DimensionalityError":
+                    ret.rename(columns={column_name: f"{column_name} [{data.units}]"}, inplace=True)
+                else:
+                    raise
         ret.set_index("index", inplace=True)
         return ret
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -439,7 +439,6 @@ class Dataset(Collection):
         DataFrame
             A DataFrame of the queried parameters
         """
-        # TODO: is this somewhere in elemental?
         au_units = {'energy': 'hartree',
                     'gradient': 'hartree/bohr',
                     'hessian': 'hartree/bohr**2'}

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -192,7 +192,7 @@ class Dataset(Collection):
         driver : Optional[str], optional
             The type of calculation (e.g. energy, gradient, hessian, dipole...)
         name : Optional[str], optional
-            The name of the data column
+            The canonical name of the data column
         native: Optional[bool], optional
             True: only include data computed with QCFractal
             False: only include data contributed from outside sources
@@ -348,39 +348,39 @@ class Dataset(Collection):
                    native: Optional[bool] = None,
                    force: bool = False) -> pd.DataFrame:
         """
-       Obtains values from the known history from the search paramaters provided for the expected `return_result` values.
-       Defaults to the standard programs and keywords if not provided.
+        Obtains values from the known history from the search paramaters provided for the expected `return_result` values.
+        Defaults to the standard programs and keywords if not provided.
 
-       Note that unlike `get_records`, `get_values` will automatically expand searches and return multiple method
-       and basis combinations simultaneously.
+        Note that unlike `get_records`, `get_values` will automatically expand searches and return multiple method
+        and basis combinations simultaneously.
 
-       Parameters
-       ----------
-       method : Optional[str], optional
-           The computational method (B3LYP)
-       basis : Optional[str], optional
-           The computational basis (6-31G)
-       keywords : Optional[str], optional
-           The keyword alias
-       program : Optional[str], optional
-           The underlying QC program
-       driver : Optional[str], optional
-           The type of calculation (e.g. energy, gradient, hessian, dipole...)
-       name : Optional[str], optional
-           The name of the data column.
-       native: Optional[bool], optional
-           True: only include data computed with QCFractal
-           False: only include data contributed from outside sources
-           None: include both
-       force : bool, optional
-           Data is typically cached, forces a new query if True
+        Parameters
+        ----------
+        method : Optional[str], optional
+            The computational method (B3LYP)
+        basis : Optional[str], optional
+            The computational basis (6-31G)
+        keywords : Optional[str], optional
+            The keyword alias
+        program : Optional[str], optional
+            The underlying QC program
+        driver : Optional[str], optional
+            The type of calculation (e.g. energy, gradient, hessian, dipole...)
+        name : Optional[str], optional
+            Canonical name of the record. Overrides the above selectors.
+        native: Optional[bool], optional
+            True: only include data computed with QCFractal
+            False: only include data contributed from outside sources
+            None: include both
+        force : bool, optional
+            Data is typically cached, forces a new query if True
 
-       Returns
-       -------
-       DataFrame
-           A DataFrame of values with columns corresponding to methods and rows corresponding to molecule entries.
-           Contributed (native=False) columns are marked with "(contributed)" and may include units in square brackets
-           if their units differ in dimensionality from the Dataset's default units.
+        Returns
+        -------
+        DataFrame
+            A DataFrame of values with columns corresponding to methods and rows corresponding to molecule entries.
+            Contributed (native=False) columns are marked with "(contributed)" and may include units in square brackets
+            if their units differ in dimensionality from the Dataset's default units.
         """
         spec = locals()
         spec.pop("self")
@@ -432,6 +432,8 @@ class Dataset(Collection):
             The keyword alias for the requested compute
         program : Optional[str], optional
             The underlying QC program
+        name : Optional[str], optional
+            Canonical name of the record. Overrides the above selectors.
         force : bool, optional
             Data is typically cached, forces a new query if True.
 
@@ -1046,7 +1048,8 @@ class Dataset(Collection):
             return self.client.query_keywords([kwid])[0]
 
     def add_contributed_values(self, contrib: ContributedValues, overwrite=False) -> None:
-        """Adds a ContributedValues to the database.
+        """
+        Adds a ContributedValues to the database. Be sure to call save() to commit changes to the server.
 
         Parameters
         ----------
@@ -1054,6 +1057,13 @@ class Dataset(Collection):
             The ContributedValues to add.
         overwrite : bool, optional
             Overwrites pre-existing values
+
+        Raises
+        ------
+        ValueError:
+            If contrib's indexes do not match those of the dataset's entries
+        KeyError:
+            If values with the same name already exist, and overwrite is False.
         """
 
         # Convert and validate

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1069,13 +1069,6 @@ class Dataset(Collection):
             The ContributedValues to add.
         overwrite : bool, optional
             Overwrites pre-existing values
-
-        Raises
-        ------
-        ValueError:
-            If contrib's indexes do not match those of the dataset's entries
-        KeyError:
-            If values with the same name already exist, and overwrite is False.
         """
 
         # Convert and validate

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -268,6 +268,7 @@ class ReactionDataset(Dataset):
                 data = data_complex - data_monomer
 
                 self.df[name] = data * constants.conversion_factor('hartree', self.units)
+                self._column_metadata[name].update({"native": True, "units": self.units})
 
         return self.df[names]
 
@@ -790,7 +791,6 @@ class ReactionDataset(Dataset):
             raise TypeError("Passed in reaction_results not understood.")
 
         rxn = ReactionEntry(**rxn_dict)
-
         self._new_records.append(rxn)
 
         return rxn

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -182,6 +182,8 @@ class ReactionDataset(Dataset):
         Note that unlike `get_records`, `get_values` will automatically expand searches and return multiple method
         and basis combinations simultaneously.
 
+        `None` is a wildcard selector. To search for `None`, use `"None"`.
+
         Parameters
         ----------
         method : Optional[str], optional

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -171,7 +171,10 @@ class ReactionDataset(Dataset):
                    keywords: Optional[str] = None,
                    program: Optional[str] = None,
                    stoich: str = "default",
-                   force: bool = False) -> 'DataFrame':
+                   driver: Optional[str] = None,
+                   name: Optional[str] = None,
+                   native: Optional[bool] = None,
+                   force: bool = False) -> pd.DataFrame:
         """Obtains values from the known history from the search paramaters provided for the expected `return_result` values. Defaults to the standard
         programs and keywords if not provided.
 
@@ -189,6 +192,14 @@ class ReactionDataset(Dataset):
             The underlying QC program
         stoich : str, optional
             The given stoichiometry to compute.
+        driver : Optional[str], optional
+            The type of calculation (e.g. energy, gradient, hessian, dipole...)
+        name : Optional[str], optional
+            The name of the data column. This parameter is only applied to contributed (native = False) columns.
+        native: Optional[bool], optional
+            True: only include data computed with QCFractal
+            False: only include data contributed from outside sources
+            None: include both
 
         Returns
         -------

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -237,7 +237,7 @@ class ReactionDataset(Dataset):
         for name, query in queries.iterrows():
 
             query = query.replace({np.nan: None}).to_dict()
-            name = self._canonical_name(**query)
+            name = query.pop("name")
 
             if force or (name not in self.df.columns):
                 self._column_metadata[name] = query

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -47,7 +47,6 @@ class ReactionDataset(Dataset):
     rxn_index : pd.Index
         The unrolled reaction index for all reactions in the Dataset
     """
-
     def __init__(self, name, client=None, ds_type="rxn", **kwargs):
         """
         Initializer for the Dataset object. If no Portal is supplied or the database name
@@ -214,23 +213,36 @@ class ReactionDataset(Dataset):
            Contributed (native=False) columns are marked with "(contributed)" and may include units in square brackets
            if their units differ in dimensionality from the ReactionDataset's default units.
         """
-        return self._get_values(method=method, basis=basis, keywords=keywords, program=program, driver=driver, stoich=stoich, name=name, native=native, force=force)
+        return self._get_values(method=method,
+                                basis=basis,
+                                keywords=keywords,
+                                program=program,
+                                driver=driver,
+                                stoich=stoich,
+                                name=name,
+                                native=native,
+                                force=force)
 
     def _get_values_from_records(self,
-                                     method: Optional[str] = None,
-                                     basis: Optional[str] = None,
-                                     keywords: Optional[str] = None,
-                                     program: Optional[str] = None,
-                                     stoich: Optional[str] = None,
-                                     name: Optional[str] = None,
-                                     force: bool = False) -> pd.DataFrame:
+                                 method: Optional[str] = None,
+                                 basis: Optional[str] = None,
+                                 keywords: Optional[str] = None,
+                                 program: Optional[str] = None,
+                                 stoich: Optional[str] = None,
+                                 name: Optional[str] = None,
+                                 force: bool = False) -> pd.DataFrame:
         self._validate_stoich(stoich)
 
         # So that datasets with no records do not require a default program and default keywords
         if len(self.list_records()) == 0:
             return pd.DataFrame(columns=['index']).set_index('index')
 
-        queries = self._form_queries(method=method, basis=basis, keywords=keywords, program=program, stoich=stoich, name=name)
+        queries = self._form_queries(method=method,
+                                     basis=basis,
+                                     keywords=keywords,
+                                     program=program,
+                                     stoich=stoich,
+                                     name=name)
 
         stoich_complex = queries.pop("stoichiometry")
         stoich_monomer = ''.join([x for x in stoich if not x.isdigit()]) + '1'

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -212,9 +212,7 @@ class ReactionDataset(Dataset):
            Contributed (native=False) columns are marked with "(contributed)" and may include units in square brackets
            if their units differ in dimensionality from the ReactionDataset's default units.
         """
-        spec = locals()
-        spec.pop("self")
-        return self._get_values(**spec)
+        return self._get_values(method=method, basis=basis, keywords=keywords, program=program, driver=driver, stoich=stoich, name=name, native=native, force=force)
 
     def _get_values_from_records(self,
                                      method: Optional[str] = None,
@@ -226,15 +224,11 @@ class ReactionDataset(Dataset):
                                      force: bool = False) -> pd.DataFrame:
         self._validate_stoich(stoich)
 
-        spec = locals()
-        spec.pop("force")
-        spec.pop("self")
-
         # So that datasets with no records do not require a default program and default keywords
         if len(self.list_records()) == 0:
             return pd.DataFrame(columns=['index']).set_index('index')
 
-        queries = self._form_queries(**spec)
+        queries = self._form_queries(method=method, basis=basis, keywords=keywords, program=program, stoich=stoich, name=name)
 
         stoich_complex = queries.pop("stoichiometry")
         stoich_monomer = ''.join([x for x in stoich if not x.isdigit()]) + '1'

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -176,34 +176,34 @@ class ReactionDataset(Dataset):
                    native: Optional[bool] = None,
                    force: bool = False) -> pd.DataFrame:
         """
-       Obtains values from the known history from the search paramaters provided for the expected `return_result` values.
-       Defaults to the standard programs and keywords if not provided.
+        Obtains values from the known history from the search paramaters provided for the expected `return_result` values.
+        Defaults to the standard programs and keywords if not provided.
 
-       Note that unlike `get_records`, `get_values` will automatically expand searches and return multiple method
-       and basis combinations simultaneously.
+        Note that unlike `get_records`, `get_values` will automatically expand searches and return multiple method
+        and basis combinations simultaneously.
 
-       Parameters
-       ----------
-       method : Optional[str], optional
-           The computational method (B3LYP)
-       basis : Optional[str], optional
-           The computational basis (6-31G)
-       keywords : Optional[str], optional
-           The keyword alias
-       program : Optional[str], optional
-           The underlying QC program
-       driver : Optional[str], optional
-           The type of calculation (e.g. energy, gradient, hessian, dipole...)
-       stoich : str, optional
+        Parameters
+        ----------
+        method : Optional[str], optional
+            The computational method (B3LYP)
+        basis : Optional[str], optional
+            The computational basis (6-31G)
+        keywords : Optional[str], optional
+            The keyword alias
+        program : Optional[str], optional
+            The underlying QC program
+        driver : Optional[str], optional
+            The type of calculation (e.g. energy, gradient, hessian, dipole...)
+        stoich : str, optional
             Stoichiometry of the reaction.
-       name : Optional[str], optional
-           The name of the data column.
-       native: Optional[bool], optional
-           True: only include data computed with QCFractal
-           False: only include data contributed from outside sources
-           None: include both
-       force : bool, optional
-           Data is typically cached, forces a new query if True
+        name : Optional[str], optional
+            Canonical name of the record. Overrides the above selectors.
+        native: Optional[bool], optional
+            True: only include data computed with QCFractal
+            False: only include data contributed from outside sources
+            None: include both
+        force : bool, optional
+            Data is typically cached, forces a new query if True
 
        Returns
        -------

--- a/qcfractal/interface/statistics.py
+++ b/qcfractal/interface/statistics.py
@@ -47,11 +47,10 @@ _stats_dict['MURE'] = mean_unsigned_relative_error
 _return_series = ['ME', 'MUE', 'MURE', 'WMURE']
 
 
-def wrap_statistics(description, df, value, bench, **kwargs):
-
+def wrap_statistics(description, ds, value, bench, **kwargs):
     # Get benchmark
     if isinstance(bench, str):
-        rbench = df[bench]
+        rbench = ds.get_values(name=bench).iloc[:, 0]
     elif isinstance(bench, (np.ndarray, pd.Series)):
         if len(bench.shape) != 1:
             raise ValueError('Only 1D numpy arrays can be passed to statistical quantities.')
@@ -60,7 +59,7 @@ def wrap_statistics(description, df, value, bench, **kwargs):
         raise TypeError('Benchmark must be a column of the dataframe or a 1D numpy array.')
 
     if isinstance(value, str):
-        rvalue = df[value]
+        rvalue = ds.get_values(name=value).iloc[:, 0]
         return _stats_dict[description](rvalue, rbench, **kwargs)
 
     elif isinstance(value, pd.Series):
@@ -78,7 +77,7 @@ def wrap_statistics(description, df, value, bench, **kwargs):
 
         method = _stats_dict[description]
         for col in value:
-            ret[col] = method(df[col], rbench, **kwargs)
+            ret[col] = method(ds.get_values(name=col), rbench, **kwargs)
         return ret
 
     else:

--- a/qcfractal/interface/statistics.py
+++ b/qcfractal/interface/statistics.py
@@ -60,6 +60,13 @@ def wrap_statistics(description, ds, value, bench, **kwargs):
 
     if isinstance(value, str):
         rvalue = ds.get_values(name=value).iloc[:, 0]
+        print("rvalue", rvalue)
+        print(ds.get_values(name=value))
+        print("------------")
+        print("rbecnch", rbench)
+        print(f"What is bench ({bench}) and value ({value})")
+        print(ds.get_values(name=bench))
+        print("------------")
         return _stats_dict[description](rvalue, rbench, **kwargs)
 
     elif isinstance(value, pd.Series):

--- a/qcfractal/interface/statistics.py
+++ b/qcfractal/interface/statistics.py
@@ -50,7 +50,7 @@ _return_series = ['ME', 'MUE', 'MURE', 'WMURE']
 def wrap_statistics(description, ds, value, bench, **kwargs):
     # Get benchmark
     if isinstance(bench, str):
-        rbench = ds.get_values(name=bench).iloc[:, 0]
+        rbench = ds.get_values(name=bench)[bench]
     elif isinstance(bench, (np.ndarray, pd.Series)):
         if len(bench.shape) != 1:
             raise ValueError('Only 1D numpy arrays can be passed to statistical quantities.')
@@ -59,7 +59,7 @@ def wrap_statistics(description, ds, value, bench, **kwargs):
         raise TypeError('Benchmark must be a column of the dataframe or a 1D numpy array.')
 
     if isinstance(value, str):
-        rvalue = ds.get_values(name=value).iloc[:, 0]
+        rvalue = ds.get_values(name=value)[value]
         return _stats_dict[description](rvalue, rbench, **kwargs)
 
     elif isinstance(value, pd.Series):

--- a/qcfractal/interface/statistics.py
+++ b/qcfractal/interface/statistics.py
@@ -60,13 +60,6 @@ def wrap_statistics(description, ds, value, bench, **kwargs):
 
     if isinstance(value, str):
         rvalue = ds.get_values(name=value).iloc[:, 0]
-        print("rvalue", rvalue)
-        print(ds.get_values(name=value))
-        print("------------")
-        print("rbecnch", rbench)
-        print(f"What is bench ({bench}) and value ({value})")
-        print(ds.get_values(name=bench))
-        print("------------")
         return _stats_dict[description](rvalue, rbench, **kwargs)
 
     elif isinstance(value, pd.Series):

--- a/qcfractal/interface/tests/test_dataset.py
+++ b/qcfractal/interface/tests/test_dataset.py
@@ -231,15 +231,15 @@ def test_nbody_rxn(nbody_ds):
 def test_database_history():
     ds = portal.collections.Dataset("history_test")
     history = [("energy", "p3", "m1", "b2", "o1"),
-               ("energy", "p1", "m1", "", "o1"),
-               ("energy", "p1", "m1", "", "o2"),
+               ("energy", "p1", "m1", None, "o1"),
+               ("energy", "p1", "m1", None, "o2"),
                ("energy", "p1", "m2", "b3", "o1"),
-               ("gradient", "p1", "m2", "", "")] # yapf: disable
+               ("gradient", "p1", "m2", None, None)]  # yapf: disable
 
     for h in history:
         ds._add_history(driver=h[0], program=h[1], method=h[2], basis=h[3], keywords=h[4])
 
     assert ds.list_records().shape[0] == 5
     assert ds.list_records(program="P1").shape[0] == 4
-    assert ds.list_records(basis="").shape[0] == 3
-    assert ds.list_records(keywords="").shape[0] == 1
+    assert ds.list_records(basis="None").shape[0] == 3
+    assert ds.list_records(keywords="None").shape[0] == 1

--- a/qcfractal/interface/tests/test_dataset.py
+++ b/qcfractal/interface/tests/test_dataset.py
@@ -28,7 +28,6 @@ def _compare_rxn_stoichs(ref, new):
     assert th.compare_lists(keys, keys_other)
 
     for k in keys:
-        # print(k)
         _compare_stoichs(stoich[k], stoich_other[k])
 
     return True
@@ -232,15 +231,15 @@ def test_nbody_rxn(nbody_ds):
 def test_database_history():
     ds = portal.collections.Dataset("history_test")
     history = [("energy", "p3", "m1", "b2", "o1"),
-               ("energy", "p1", "m1", None, "o1"),
-               ("energy", "p1", "m1", None, "o2"),
+               ("energy", "p1", "m1", "", "o1"),
+               ("energy", "p1", "m1", "", "o2"),
                ("energy", "p1", "m2", "b3", "o1"),
-               ("gradient", "p1", "m2", None, None)] # yapf: disable
+               ("gradient", "p1", "m2", "", "")] # yapf: disable
 
     for h in history:
         ds._add_history(driver=h[0], program=h[1], method=h[2], basis=h[3], keywords=h[4])
 
     assert ds.list_records().shape[0] == 5
     assert ds.list_records(program="P1").shape[0] == 4
-    assert ds.list_records(basis=None).shape[0] == 3
-    assert ds.list_records(keywords=None).shape[0] == 1
+    assert ds.list_records(basis="").shape[0] == 3
+    assert ds.list_records(keywords="").shape[0] == 1

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -10,6 +10,7 @@ from qcfractal import testing
 from qcfractal.testing import fractal_compute_server
 import qcelemental as qcel
 
+
 def test_collection_query(fractal_compute_server):
     client = ptl.FractalClient(fractal_compute_server)
 
@@ -151,7 +152,10 @@ def test_gradient_dataset_get_values(gradient_dataset_fixture):
     df = ds.get_values()
     assert df.shape == (len(ds.get_index()), 4)
     for entry in ds.get_index():
-        assert (df.loc[entry, "HF/sto-3g"] == ds.get_records(subset=entry, method="hf", basis="sto-3g", projection={'return_result': True})).all()
+        assert (df.loc[entry, "HF/sto-3g"] == ds.get_records(subset=entry,
+                                                             method="hf",
+                                                             basis="sto-3g",
+                                                             projection={'return_result': True})).all()
 
     assert ds.get_values(method="NotInDataset").shape[1] == 0  # 0-length DFs can cause exceptions
 
@@ -212,6 +216,7 @@ def test_gradient_dataset_statistics(gradient_dataset_fixture):
     assert pytest.approx(stats.loc["He1"].mean(), 1.e-5) == 0.01635020639
     assert pytest.approx(stats.loc["He2"].mean(), 1.e-5) == 0.00333333333
 
+
 @pytest.fixture(scope="module")
 def contributed_dataset_fixture(fractal_compute_server):
     """ Fixture for testing rich contributed datasets with many properties and molecules of different sizes"""
@@ -220,8 +225,7 @@ def contributed_dataset_fixture(fractal_compute_server):
     testing.check_has_module("psi4")
 
     # Build a dataset
-    ds = ptl.collections.Dataset("ds_contributed",
-                                 client)
+    ds = ptl.collections.Dataset("ds_contributed", client)
 
     ds.add_entry("He1", ptl.Molecule.from_data("He -1 0 0\n--\nHe 0 0 1"))
     ds.add_entry("He", ptl.Molecule.from_data("He -1.1 0 0"))
@@ -321,10 +325,14 @@ def contributed_dataset_fixture(fractal_compute_server):
 def test_dataset_contributed_units(contributed_dataset_fixture):
     _, ds = contributed_dataset_fixture
 
-    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(name="Fake Energy").columns[0]]["units"]) == qcel.constants.ureg("kcal / mol")
-    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(name="Fake Gradient").columns[0]]["units"]) == qcel.constants.ureg("hartree/bohr")
-    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(name="Fake Hessian").columns[0]]["units"]) == qcel.constants.ureg("hartree/bohr**2")
-    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(name="Fake Dipole").columns[0]]["units"]) == qcel.constants.ureg("e * bohr")
+    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(
+        name="Fake Energy").columns[0]]["units"]) == qcel.constants.ureg("kcal / mol")
+    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(
+        name="Fake Gradient").columns[0]]["units"]) == qcel.constants.ureg("hartree/bohr")
+    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(
+        name="Fake Hessian").columns[0]]["units"]) == qcel.constants.ureg("hartree/bohr**2")
+    assert qcel.constants.ureg(
+        ds._column_metadata[ds.get_values(name="Fake Dipole").columns[0]]["units"]) == qcel.constants.ureg("e * bohr")
 
 
 def test_dataset_contributed_mixed_values(contributed_dataset_fixture):
@@ -449,6 +457,7 @@ def reactiondataset_dftd3_fixture_fixture(fractal_compute_server):
 
     yield client, ds
 
+
 def test_rectiondataset_dftd3_records(reactiondataset_dftd3_fixture_fixture):
     client, ds = reactiondataset_dftd3_fixture_fixture
 
@@ -467,6 +476,7 @@ def test_rectiondataset_dftd3_records(reactiondataset_dftd3_fixture_fixture):
     # No molecules
     with pytest.raises(KeyError):
         records = ds.get_records("B3LYP", "6-31g", stoich=["cp", "default"], subset="Gibberish")
+
 
 def test_rectiondataset_dftd3_energies(reactiondataset_dftd3_fixture_fixture):
     client, ds = reactiondataset_dftd3_fixture_fixture
@@ -661,8 +671,7 @@ def test_compute_reactiondataset_keywords(fractal_compute_server):
     assert kw.values["scf_type"] == "df"
 
 
-def test_dataset_list_get_values(gradient_dataset_fixture,
-                                 contributed_dataset_fixture,
+def test_dataset_list_get_values(gradient_dataset_fixture, contributed_dataset_fixture,
                                  reactiondataset_dftd3_fixture_fixture):
     """ Tests that the output of list_values can be used as input to get_values"""
     for dataset_fixture in locals().values():

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -374,9 +374,6 @@ def test_reactiondataset_check_state(fractal_compute_server):
         "name": "Benchmark",
         "doi": None,
         "theory_level": "very high",
-        "theory_level_details": {
-            "stoich": "default"
-        },
         "values": {
             "He1": 0.0009608501557,
             "He2": -0.00001098794749
@@ -555,9 +552,6 @@ def test_compute_reactiondataset_regression(fractal_compute_server):
         "name": "Benchmark",
         "doi": None,
         "theory_level": "very high",
-        "theory_level_details": {
-            "stoich": "default"
-        },
         "values": {
             "He1": 0.0009608501557,
             "He2": -0.00001098794749

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -8,7 +8,7 @@ import pytest
 import qcfractal.interface as ptl
 from qcfractal import testing
 from qcfractal.testing import fractal_compute_server
-
+import qcelemental as qcel
 
 def test_collection_query(fractal_compute_server):
     client = ptl.FractalClient(fractal_compute_server)
@@ -321,10 +321,10 @@ def contributed_dataset_fixture(fractal_compute_server):
 def test_dataset_contributed_units(contributed_dataset_fixture):
     _, ds = contributed_dataset_fixture
 
-    assert ds._column_metadata[ds.get_values(name="Fake Energy").columns[0]]["units"] == "kcal / mol"
-    assert ds._column_metadata[ds.get_values(name="Fake Gradient").columns[0]]["units"] == "hartree/bohr"
-    assert ds._column_metadata[ds.get_values(name="Fake Hessian").columns[0]]["units"] == "hartree/bohr**2"
-    assert ds._column_metadata[ds.get_values(name="Fake Dipole").columns[0]]["units"] == "e * bohr"
+    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(name="Fake Energy").columns[0]]["units"]) == qcel.constants.ureg("kcal / mol")
+    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(name="Fake Gradient").columns[0]]["units"]) == qcel.constants.ureg("hartree/bohr")
+    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(name="Fake Hessian").columns[0]]["units"]) == qcel.constants.ureg("hartree/bohr**2")
+    assert qcel.constants.ureg(ds._column_metadata[ds.get_values(name="Fake Dipole").columns[0]]["units"]) == qcel.constants.ureg("e * bohr")
 
 
 def test_dataset_contributed_mixed_values(contributed_dataset_fixture):

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -231,9 +231,8 @@ def test_gradient_dataset_get_records(gradient_dataset_fixture):
 def test_gradient_dataset_get_values(gradient_dataset_fixture):
     client, ds = gradient_dataset_fixture
 
-    cols = set(ds.get_values().reset_index().columns)
+    cols = set(ds.get_values().columns.str.replace(' (contributed)', '', regex=False))
     names = set(ds.list_values().reset_index()['name'])
-    cols -= {'index'}
     assert cols == names
 
     df = ds.get_values()
@@ -361,8 +360,9 @@ def test_reactiondataset_check_state(fractal_compute_server):
     with pytest.raises(ValueError):
         ds.get_records("SCF", "STO-3G")
 
-    assert "benchmark" == ds._list_contributed_values()["name"][0]
+    assert "benchmark" == ds.list_values(native=False).reset_index()["name"][0].lower()
     ds.units = "hartree"
+    print(ds.get_values())
     bench = ds.get_values(name="benchmark", native=False)
     assert "(contributed)" in bench.columns[0]
     assert bench["He1"] == contrib["values"]["He1"]

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -288,11 +288,27 @@ def contributed_dataset_fixture(fractal_compute_server):
         },
         "units": "e * bohr"
     }
+    energy_FF = {
+        "name": "Fake FF Energy",
+        "theory_level": "some force field",
+        "values": {
+            "He1": 0.5,
+            "He": 42.
+        },
+        "theory_level_details": {
+            "driver": "energy",
+            "program": "fake_program",
+            "basis": None,
+            "method": "fake_method"
+        },
+        "units": "hartree"
+    }
 
     ds.add_contributed_values(energy)
     ds.add_contributed_values(gradient)
     ds.add_contributed_values(hessian)
     ds.add_contributed_values(dipole)
+    ds.add_contributed_values(energy_FF)
 
     with pytest.raises(KeyError):
         ds.add_contributed_values(energy)
@@ -315,9 +331,12 @@ def test_dataset_contributed_mixed_values(contributed_dataset_fixture):
     _, ds = contributed_dataset_fixture
 
     unselected_values = ds.get_values()
-    assert(unselected_values.shape == (2, 4))
+    assert unselected_values.shape == (2, 5)
     selected_values = ds.get_values(program='fake_program')
-    assert(selected_values.shape == (2, 4))
+    assert selected_values.shape == (2, 5)
+    selected_values = ds.get_values(basis="None")
+    assert selected_values.shape == (2, 1)
+    assert selected_values.columns[0] == "Fake FF Energy"
 
 
 def test_dataset_compute_response(fractal_compute_server):


### PR DESCRIPTION
## Description
This PR introduces a new `list_values` function for datasets to replace `list_history` and `list_contributed_values`. It also changes `get_values` to return contributed values in addition to native values (controlled by the `native` argument).

In addition, this PR:
- Adds a `name` selector to `get_values`.
- Adds rudimentary units support to `get_values`.
- Bumps deprecation warnings to version v0.12

## Todos
- [x] Run yapf
- [x] check for things that depend on _column_metadata 

## Status
- [x] Changelog updated
- [ ] Ready to go