### PR TITLE
Dataset view get_molecules

### DIFF
--- a/qcfractal/config.py
+++ b/qcfractal/config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
+
 from pydantic import Schema, validator
 
 from .interface.models import AutodocBaseSettings
@@ -100,7 +101,7 @@ class FractalServerSettings(ConfigSettings):
                                       description="The frequency (in seconds) to check the heartbeat of workers.")
     log_apis: bool = Schema(False,
                             description="True or False. Store API access in the Database. This is an advanced "
-                            "option for servers accessed by extranl users through QCPortal.")
+                            "option for servers accessed by external users through QCPortal.")
     geo_file_path: Optional[str] = Schema(
         None,
         description=

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -12,10 +12,11 @@ from typing import Any, Dict, List, Optional, Set, Union
 import pandas as pd
 
 from ..models import ObjectId, ProtoModel
+from ..client import FractalClient
 
 
 class Collection(abc.ABC):
-    def __init__(self, name: str, client: 'FractalClient' = None, **kwargs: Dict[str, Any]):
+    def __init__(self, name: str, client: FractalClient = None, **kwargs: Dict[str, Any]):
         """
         Initializer for the Collection objects. If no Portal is supplied or the Collection name
         is not present on the server that the Portal is connected to a blank Collection will be
@@ -95,7 +96,6 @@ class Collection(abc.ABC):
     def _check_client(self):
         if self.client is None:
             raise AttributeError("This method requires a FractalClient and no client was set")
-
 
     @property
     def name(self) -> str:
@@ -215,7 +215,6 @@ class Collection(abc.ABC):
         class_name = self.__class__.__name__.lower()
         if self.data.name == "":
             raise AttributeError("Collection:save: {} must have a name!".format(class_name))
-
 
         if client is None:
             self._check_client()

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -74,6 +74,7 @@ class Dataset(Collection):
 
         self._view = None
         self._disable_view: bool = False  # for debugging and testing
+        self._disable_query_limit: bool = False  # for debugging and testing
 
         # Initialize internal data frames and load in contrib
         self.df = pd.DataFrame(index=self.get_index())
@@ -133,6 +134,21 @@ class Dataset(Collection):
         self._form_index()
 
     def get_entries(self, force: bool = False) -> pd.DataFrame:
+        """
+        Provides a list of entries for the dataset
+
+        Parameters
+        ----------
+        force: bool, optional
+            skip cache
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe containing entry names and specifciations.
+            For Dataset, specifications are molecule ids.
+            For ReactionDataset, specifications describe reaction stoichiometry.
+        """
         if self._use_view(force):
             ret = self._view.get_entries()
         else:
@@ -518,7 +534,7 @@ class Dataset(Collection):
                               RuntimeWarning)
             queries = self.list_records(name=name, dftd3=True, pretty=False)
 
-        if queries.shape[0] > 10:
+        if queries.shape[0] > 10 and self._disable_query_limit is False:
             raise TypeError("More than 10 queries formed, please narrow the search.")
         return queries
 
@@ -1236,7 +1252,7 @@ class Dataset(Collection):
         if not merge and len(df) == 1:
             df = df[0]
 
-        if np.all(df.count() == 0):
+        if len(df) == 0:
             raise KeyError("Query matched no records!")
 
         if isinstance(subset, str):

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -73,6 +73,7 @@ class Dataset(Collection):
         self._entry_index = None
 
         self._view = None
+        self._disable_view: bool = False  # for debugging and testing
 
         # Initialize internal data frames and load in contrib
         self.df = pd.DataFrame(index=self.get_index())
@@ -133,9 +134,10 @@ class Dataset(Collection):
 
     def get_entries(self, force: bool = False) -> pd.DataFrame:
         if self._use_view(force):
-            return self._view.get_entries()
+            ret = self._view.get_entries()
         else:
-            return self._entry_index
+            ret = self._entry_index
+        return ret.copy()
 
     def _molecule_indexer(self, subset: Optional[Union[str, Set[str]]] = None,
                           force: bool = False) -> Dict[str, 'ObjectId']:
@@ -1344,7 +1346,7 @@ class Dataset(Collection):
 
     def _use_view(self, force: bool = False):
         """Helper function to decide whether to use a locally available HDF5 view"""
-        return force is False and self._view is not None
+        return (force is False) and (self._view is not None) and (self._disable_view is False)
 
     def _clear_cache(self):
         self.df = pd.DataFrame(index=self.get_index())

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -765,13 +765,15 @@ class Dataset(Collection):
 
         return name, dbkeys, history
 
-    def _get_molecules(self, indexer: Dict[str, 'ObjectId']) -> pd.DataFrame:
+    def _get_molecules(self, indexer: Dict[str, 'ObjectId'], force: bool = False) -> pd.DataFrame:
         """Queries a list of molecules using a molecule indexer
 
         Parameters
         ----------
         indexer : Dict[str, 'ObjectId']
             A key/value index of molecules to query
+        force : bool, optional
+            Force pull of molecules from server
 
         Returns
         -------
@@ -785,7 +787,7 @@ class Dataset(Collection):
         """
 
         molecule_ids = list(set(indexer.values()))
-        if not self._use_view(False):
+        if not self._use_view(force):
             molecules = []
             for i in range(0, len(molecule_ids), self.client.query_limit):
                 molecules.extend(self.client.query_molecules(id=molecule_ids[i:i + self.client.query_limit]))
@@ -1149,13 +1151,16 @@ class Dataset(Collection):
 
         return self.df[column_names]
 
-    def get_molecules(self, subset: Optional[Union[str, Set[str]]] = None) -> Union[pd.DataFrame, 'Molecule']:
+    def get_molecules(self, subset: Optional[Union[str, Set[str]]] = None,
+                      force: bool = False) -> Union[pd.DataFrame, 'Molecule']:
         """Queries full Molecules from the database.
 
         Parameters
         ----------
         subset : Optional[Union[str, Set[str]]], optional
             The index subset to query on
+        force : bool, optional
+            Force pull of molecules from server
 
         Returns
         -------
@@ -1163,7 +1168,7 @@ class Dataset(Collection):
             Either a DataFrame of indexed Molecules or a single Molecule if a single subset string was provided.
         """
         indexer = self._molecule_indexer(subset)
-        df = self._get_molecules(indexer)
+        df = self._get_molecules(indexer, force)
 
         if isinstance(subset, str):
             return df.iloc[0, 0]

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -265,8 +265,16 @@ class Dataset(Collection):
         # Filter
         ret.fillna("None", inplace=True)
         ret = self._filter_records(ret, **spec)
-        ret.set_index(["native"] + list(self.data.history_keys[:-1]), inplace=True)
+
+        # Sort
+        sort_index = ["native"] + list(self.data.history_keys[:-1])
+        if "stoichiometry" in ret.columns:
+            sort_index += ["stoichiometry"]
+        ret.set_index(sort_index, inplace=True)
         ret.sort_index(inplace=True)
+        ret.reset_index(inplace=True)
+        ret.set_index(["native"] + list(self.data.history_keys[:-1]), inplace=True)
+
         return ret
 
     @staticmethod

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -97,9 +97,9 @@ class HDF5View(DatasetView):
         self._entries: pd.DataFrame = None
 
     def list_values(self) -> pd.DataFrame:
-        df = pd.DataFrame()
         with self._read_file() as f:
             history_keys = self._deserialize_field(f.attrs['history_keys'])
+            df = pd.DataFrame(columns=history_keys + ["name", "native"])
             for dataset in f['value'].values():
                 row = {k: self._deserialize_field(dataset.attrs[k]) for k in history_keys}
                 row["name"] = self._deserialize_field(dataset.attrs["name"])
@@ -379,6 +379,8 @@ class HDF5View(DatasetView):
     # Methods for serializing into HDF5 data fields
     @staticmethod
     def _serialize_data(data: Any) -> np.ndarray:
+        # h5py v3 will support bytes,
+        # but for now the workaround is variable-length np unit8
         return np.fromstring(serialize(data, 'msgpack-ext'), dtype='uint8')
 
     @staticmethod

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -5,6 +5,7 @@ import warnings
 from contextlib import contextmanager
 from typing import Any, Dict, List, Tuple, Union
 
+# TODO(mattwelborn): Determine if h5py can/should be optionally imported
 import h5py
 import numpy as np
 import pandas as pd

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -302,7 +302,7 @@ class HDF5View(DatasetView):
                                            dtype=np.dtype("float64"),
                                            **dataset_kwargs)
             else:
-                raise ValueError(f"Unknown entry class ({type(ds.data.records[0])}) while " f"writing HDF5 entries.")
+                raise ValueError(f"Unknown entry class ({type(ds.data.records[0])}) while writing HDF5 entries.")
 
             # Export native data columns
             value_group = f.create_group("value")

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -1,19 +1,19 @@
 import abc
 import distutils
-from qcelemental.util.serialization import serialize, deserialize
+import pathlib
 import warnings
 from contextlib import contextmanager
+from typing import Any, Dict, List, Tuple, Union
 
-from .dataset import Dataset, MoleculeEntry
-from ..models import ObjectId
-from .reaction_dataset import ReactionEntry
-import pathlib
-from typing import Union, List, Tuple, Dict, Any
+import h5py
 import numpy as np
 import pandas as pd
-import h5py
 
-from ..models import Molecule
+from qcelemental.util.serialization import deserialize, serialize
+
+from ..models import Molecule, ObjectId
+from .dataset import Dataset, MoleculeEntry
+from .reaction_dataset import ReactionEntry
 
 
 class DatasetView(abc.ABC):
@@ -162,8 +162,8 @@ class HDF5View(DatasetView):
         with self._read_file() as f:
             mol_schema = f['molecule/schema']
             ret = [
-                Molecule(**self._deserialize_data(mol_schema[int(i) if isinstance(i, ObjectId) else i]))
-                for i in indexes
+                Molecule(**self._deserialize_data(mol_schema[int(i) if isinstance(i, ObjectId) else i]),
+                         validate=False) for i in indexes
             ]
         return ret
 

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -336,8 +336,10 @@ class ReactionDataset(Dataset):
 
         return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind)
 
-    def get_molecules(self, subset: Optional[Union[str, Set[str]]] = None,
-                      stoich: Union[str, List[str]] = "default") -> pd.DataFrame:
+    def get_molecules(self,
+                      subset: Optional[Union[str, Set[str]]] = None,
+                      stoich: Union[str, List[str]] = "default",
+                      force: bool = False) -> pd.DataFrame:
         """Queries full Molecules from the database.
 
         Parameters
@@ -346,6 +348,8 @@ class ReactionDataset(Dataset):
             The index subset to query on
         stoich : Union[str, List[str]], optional
             The stoichiometries to pull from, either a single or multiple stoichiometries
+        force : bool, optional
+            Force pull of molecules from server
 
         Return
         ------
@@ -358,7 +362,7 @@ class ReactionDataset(Dataset):
         self._validate_stoich(stoich)
 
         indexer, names = self._molecule_indexer(stoich, subset)
-        df = self._get_molecules(indexer)
+        df = self._get_molecules(indexer, force=force)
         df.index = pd.MultiIndex.from_tuples(df.index, names=names)
 
         return df

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -15,10 +15,12 @@ from collections import Mapping
 from contextlib import contextmanager
 
 import pytest
+import requests
 from tornado.ioloop import IOLoop
 
 import qcengine as qcng
 
+from .interface import FractalClient
 from .postgres_harness import PostgresHarness, TemporaryPostgres
 from .queue import build_queue_adapter
 from .server import FractalServer
@@ -528,3 +530,13 @@ def socket_fixture(request):
 def sqlalchemy_socket_fixture(request, postgres_server):
 
     yield from build_socket_fixture("sqlalchemy", postgres_server)
+
+
+def live_fractal_or_skip():
+    """Ensure Fractal live connection can be made"""
+    try:
+        import qcfractal.interface
+        requests.get('https://api.qcarchive.molssi.org:443', json={}, timeout=5)
+        return FractalClient()
+    except (requests.exceptions.ConnectionError, ConnectionRefusedError):
+        return pytest.skip("Could not make a connection to central Fractal server")

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -124,10 +124,13 @@ def gradient_dataset_fixture(fractal_compute_server, tmp_path_factory, request):
 
 def test_gradient_dataset_get_molecules(gradient_dataset_fixture):
     client, ds = gradient_dataset_fixture
+    request_made = not ds._use_view(False)
+    ds._clear_cache()
 
     he1_dist = 2.672476322216822
     he2_dist = 2.939723950195864
-    mols = ds.get_molecules()
+    with monitor_requests(client, "molecule", request_made=request_made):
+        mols = ds.get_molecules()
     assert mols.shape == (2, 1)
     assert mols.iloc[0, 0].measure([0, 1]) == pytest.approx(he1_dist)
 

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -437,16 +437,12 @@ def test_reactiondataset_check_state(fractal_compute_server):
 
     ds.save()
 
-    ds.get_records("SCF", "STO-3G")
-
     ds.add_keywords("default", "psi4", ptl.models.KeywordSet(values={"a": 5}))
 
     with pytest.raises(ValueError):
         ds.get_records("SCF", "STO-3G")
 
     ds.save()
-
-    ds.get_records("SCF", "STO-3G")
 
     contrib = {
         "name": "Benchmark",
@@ -527,17 +523,24 @@ def test_rectiondataset_dftd3_records(reactiondataset_dftd3_fixture_fixture):
     assert records.shape == (1, 1)
     assert records.iloc[0, 0].status == "COMPLETE"
 
-    records = ds.get_records("B3LYP", "6-31g", stoich=["cp", "default"])
-    assert records.shape == (2, 1)
+    records = ds.get_records("B3LYP", "6-31g", stoich="default")
+    assert records.shape == (1, 1)
     assert records.iloc[0, 0].status == "COMPLETE"
-    assert records.iloc[0, 0].id == records.iloc[1, 0].id
 
-    records = ds.get_records("B3LYP", "6-31g", stoich=["cp", "default"], subset="HeDimer")
-    assert records.shape == (2, 1)
+    records = ds.get_records("B3LYP", "6-31g", stoich="default", subset="HeDimer")
+    assert records.shape == (1, 1)
 
     # No molecules
     with pytest.raises(KeyError):
-        records = ds.get_records("B3LYP", "6-31g", stoich=["cp", "default"], subset="Gibberish")
+        records = ds.get_records("B3LYP", "6-31g", stoich="default", subset="Gibberish")
+
+    # Bad stoichiometry
+    with pytest.raises(KeyError):
+        ds.get_records("B3LYP", "6-31g", stoich="cp")
+
+    # Wrong method
+    with pytest.raises(KeyError):
+        ds.get_records("Fake Method", "6-31g", stoich="cp")
 
 
 def test_rectiondataset_dftd3_energies(reactiondataset_dftd3_fixture_fixture):

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -847,7 +847,7 @@ def assert_view_identical(ds):
                     if not np.array_equal(df1.iloc[i, j], df2.iloc[i, j]):
                         return False
                 elif isinstance(df1.iloc[i, j], Molecule):
-                    if not df1.iloc[i, j].compare(df2.iloc[i, j]):
+                    if not df1.iloc[i, j].get_hash() == df2.iloc[i, j].get_hash():
                         return False
                 # Because nan != nan
                 elif df1.isna().iloc[i, j]:

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -567,7 +567,11 @@ def test_rectiondataset_dftd3_energies(reactiondataset_dftd3_fixture_fixture):
 def test_rectiondataset_dftd3_molecules(reactiondataset_dftd3_fixture_fixture):
     client, ds = reactiondataset_dftd3_fixture_fixture
 
-    mols = ds.get_molecules()
+    request_made = not ds._use_view(False)
+    ds._clear_cache()
+
+    with monitor_requests(client, "molecule", request_made=request_made):
+        mols = ds.get_molecules()
     assert mols.shape == (1, 1)
     assert np.all(mols.iloc[0, 0].real)  # Should be all real
     assert tuple(mols.index) == (("HeDimer", "default", 0), )

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -8,9 +8,8 @@ import numpy as np
 import pytest
 
 import qcelemental as qcel
-from qcelemental.models import Molecule
-
 import qcfractal.interface as ptl
+from qcelemental.models import Molecule
 from qcfractal import testing
 from qcfractal.testing import fractal_compute_server
 
@@ -762,6 +761,12 @@ def qm3_fixture(request, tmp_path_factory):
     ds = client.get_collection("Dataset", "QM3")
     ds._disable_query_limit = True
 
+    # Trim down dataset for faster test
+    to_remove = {row for row in ds.data.history if row[2].lower() != 'b3lyp'}
+    for row in to_remove:
+        ds.data.history.remove(row)
+    ds._form_index()
+
     # with view
     if request.param:
         view = ptl.collections.HDF5View(pathlib.Path(tmp_path_factory.mktemp('test_collections'), 'ds_qm3.hdf5'))
@@ -779,6 +784,12 @@ def s22_fixture(request, tmp_path_factory):
     client = live_fractal_or_skip()
     ds = client.get_collection("ReactionDataset", "S22")
     ds._disable_query_limit = True
+
+    # Trim down dataset for faster test
+    to_remove = {row for row in ds.data.history if row[2].lower() != 'b3lyp'}
+    for row in to_remove:
+        ds.data.history.remove(row)
+    ds._form_index()
 
     # with view
     if request.param:

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -133,6 +133,7 @@ def test_gradient_dataset_get_molecules(gradient_dataset_fixture):
         mols = ds.get_molecules()
     assert mols.shape == (2, 1)
     assert mols.iloc[0, 0].measure([0, 1]) == pytest.approx(he1_dist)
+    assert mols.iloc[1, 0].measure([0, 1]) == pytest.approx(he2_dist)
 
     mol = ds.get_molecules(subset="He1")
     assert mol.measure([0, 1]) == pytest.approx(he1_dist)


### PR DESCRIPTION
## Description
This PR implements local-view-backed `{Reaction_,}Dataset.get_molecules`. 

Misc changes:
- Added (~very slow~) QCArchive-backed QM3 and S22 test fixtures. ~While painful~, these find lots of edge cases (redundant history columns, missing data, multiple stoichiometries, ...) ~These tests are very slow. They add about 10 minutes to the testing process. We may wish to create a new mark `very_slow`, and not run them in CI.~
- Added `get_entries` function to get the dataset index and molecule ids. `_molecule_indexer` now uses this function. The entry/molecule index is stored in the HDF5, but must be loaded into memory.

![image](https://user-images.githubusercontent.com/1508995/66220047-49dbbb80-e69a-11e9-85c7-4cadedd5c07c.png)


## Benchmarking
These benchmarks were run on the QM9 dataset of 133,885 molecules with 8 energy columns.

![image](https://user-images.githubusercontent.com/1508995/66218109-8a393a80-e696-11e9-8384-0bbc0ed4175b.png)
`list_values` is slightly faster without HDF5 (`force=True`) because the history is stored in memory. However, it's super fast in both cases.

![image](https://user-images.githubusercontent.com/1508995/66218558-6c200a00-e697-11e9-9b0b-498a42a90d94.png)
`get_values` is unsurprisingly wildly faster with the HDF5 view. The server-backed version was killed after 10 minutes.

![image](https://user-images.githubusercontent.com/1508995/66218864-10a24c00-e698-11e9-98fc-d52f4fb21d33.png)
`get_molecules` is faster with the HDF5 view, but not by an extreme amount. This is because the cost is asymptotically dominated by de-serialization of the Molecules. For the same reason, json and msgpack show the same performance.

![image](https://user-images.githubusercontent.com/1508995/66219113-92927500-e698-11e9-89b5-e61bd8896a64.png)
msgpack saves a little space over json. If space is a real concern, the first change that needs to be made is to de-duplicate the geometry in the `molecule/schema` and `molecule/geometry` datasets.

## Todos
- [x] Document `get_entries`
- [x] Document `force` where it was added.

## Questions
- [x] ~Once more, the new tests make CI 10 minutes longer. Is this okay?~

## Status
- [x] Changelog updated - No significant user-facing changes.
- [ ] Ready to go