### PR TITLE
Portal type hints

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -12,17 +12,17 @@ import requests
 from pydantic import ValidationError
 
 from .collections import collection_factory, collections_name_map
-from .models import (GridOptimizationInput, KeywordSet, Molecule, ObjectId, ResultRecord, TorsionDriveInput,
-                     build_procedure)
+from .models import build_procedure
+from .models.rest_models import rest_model
 
 if TYPE_CHECKING:
     from qcfractal import FractalServer
 
     from .collections.collection import Collection
-    from .models import TaskRecord
+    from .models import GridOptimizationInput, KeywordSet, Molecule, ObjectId, ResultRecord, TaskRecord, TorsionDriveInput
     from .models.rest_models import (CollectionGETResponse, ComputeResponse, KeywordGETResponse, MoleculeGETResponse,
                                      ProcedureGETResponse, QueryObjectId, QueryProjection, QueryStr, ResultGETResponse,
-                                     ServiceQueueGETResponse, TaskQueueGETResponse, rest_model)
+                                     ServiceQueueGETResponse, TaskQueueGETResponse)
 
 ### Common docs
 
@@ -347,7 +347,7 @@ class FractalClient(object):
                         molecular_formula: Optional['QueryStr'] = None,
                         limit: Optional[int] = None,
                         skip: int = 0,
-                        full_return: bool = False) -> Union['MoleculeGETResponse', List[Molecule]]:
+                        full_return: bool = False) -> Union['MoleculeGETResponse', List['Molecule']]:
         """Queries molecules from the database.
 
         Parameters
@@ -385,7 +385,7 @@ class FractalClient(object):
         response = self._automodel_request("molecule", "get", payload, full_return=full_return)
         return response
 
-    def add_molecules(self, mol_list: List[Molecule], full_return: bool = False) -> List[str]:
+    def add_molecules(self, mol_list: List['Molecule'], full_return: bool = False) -> List[str]:
         """Adds molecules to the Server.
 
         Parameters
@@ -412,7 +412,7 @@ class FractalClient(object):
                        hash_index: Optional['QueryStr'] = None,
                        limit: Optional[int] = None,
                        skip: int = 0,
-                       full_return: bool = False) -> Union['KeywordGETResponse', List[KeywordSet]]:
+                       full_return: bool = False) -> Union['KeywordGETResponse', List['KeywordSet']]:
         """Obtains KeywordSets from the server using keyword ids.
 
         Parameters
@@ -533,7 +533,7 @@ class FractalClient(object):
             raise KeyError("Collection '{}:{}' not found.".format(collection_type, name))
 
     def add_collection(self, collection: Dict[str, Any], overwrite: bool = False,
-                       full_return: bool = False) -> Union['CollectionGETResponse', List[ObjectId]]:
+                       full_return: bool = False) -> Union['CollectionGETResponse', List['ObjectId']]:
         """Adds a new Collection to the server.
 
         Parameters
@@ -575,7 +575,7 @@ class FractalClient(object):
                       limit: Optional[int] = None,
                       skip: int = 0,
                       projection: Optional['QueryProjection'] = None,
-                      full_return: bool = False) -> Union['ResultGETResponse', List[ResultRecord], Dict[str, Any]]:
+                      full_return: bool = False) -> Union['ResultGETResponse', List['ResultRecord'], Dict[str, Any]]:
         """Queries ResultRecords from the server.
 
         Parameters
@@ -719,8 +719,8 @@ class FractalClient(object):
                     method: str,
                     basis: str,
                     driver: str,
-                    keywords: Union[ObjectId, None],
-                    molecule: Union[ObjectId, Molecule, List[Union[str, Molecule]]],
+                    keywords: Union['ObjectId', None],
+                    molecule: Union['ObjectId', 'Molecule', List[Union[str, 'Molecule']]],
                     priority: Optional[str] = None,
                     tag: Optional[str] = None,
                     full_return: bool = False) -> 'ComputeResponse':
@@ -784,7 +784,7 @@ class FractalClient(object):
                       procedure: str,
                       program: str,
                       program_options: Dict[str, Any],
-                      molecule: Union[ObjectId, Molecule, List[Union[str, Molecule]]],
+                      molecule: Union['ObjectId', 'Molecule', List[Union[str, 'Molecule']]],
                       priority: Optional[str] = None,
                       tag: Optional[str] = None,
                       full_return: bool = False) -> 'ComputeResponse':
@@ -957,7 +957,7 @@ class FractalClient(object):
 
     def add_service(
             self,  # lgtm [py/similar-function]
-            service: Union[GridOptimizationInput, TorsionDriveInput],
+            service: Union['GridOptimizationInput', 'TorsionDriveInput'],
             tag: Optional[str] = None,
             priority: Optional[str] = None,
             full_return: bool = False) -> 'ComputeResponse':

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -15,14 +15,15 @@ from .collections import collection_factory, collections_name_map
 from .models import build_procedure
 from .models.rest_models import rest_model
 
-if TYPE_CHECKING:
-    from qcfractal import FractalServer
+if TYPE_CHECKING:  # pragma: no cover
+    from qcfractal import FractalServer  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
 
-    from .collections.collection import Collection
+    from .collections.collection import Collection  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
     from .models import GridOptimizationInput, KeywordSet, Molecule, ObjectId, ResultRecord, TaskRecord, TorsionDriveInput
     from .models.rest_models import (CollectionGETResponse, ComputeResponse, KeywordGETResponse, MoleculeGETResponse,
                                      ProcedureGETResponse, QueryObjectId, QueryProjection, QueryStr, ResultGETResponse,
-                                     ServiceQueueGETResponse, TaskQueueGETResponse)
+                                     ServiceQueueGETResponse, TaskQueueGETResponse
+                                     )  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
 
 ### Common docs
 
@@ -957,7 +958,7 @@ class FractalClient(object):
 
     def add_service(
             self,  # lgtm [py/similar-function]
-            service: Union['GridOptimizationInput', 'TorsionDriveInput'],
+            service: Union[List['GridOptimizationInput'], List['TorsionDriveInput']],
             tag: Optional[str] = None,
             priority: Optional[str] = None,
             full_return: bool = False) -> 'ComputeResponse':

--- a/qcfractal/interface/collections/__init__.py
+++ b/qcfractal/interface/collections/__init__.py
@@ -4,9 +4,9 @@ Python init for QCPortal collections
 
 from .collection_utils import collection_factory, collections_name_map, list_known_collections, register_collection
 from .dataset import Dataset
+from .dataset_view import DatasetView, HDF5View
 from .generic import Generic
 from .gridoptimization_dataset import GridOptimizationDataset
 from .optimization_dataset import OptimizationDataset
 from .reaction_dataset import ReactionDataset
 from .torsiondrive_dataset import TorsionDriveDataset
-from .dataset_view import HDF5View

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -478,7 +478,7 @@ class BaseProcedureDataset(Collection):
 
         return submitted
 
-    def query(self, specification: str, force: bool = False) -> None:
+    def query(self, specification: str, force: bool = False) -> str:
         """Queries a given specification from the server
 
         Parameters

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -7,15 +7,19 @@ Helper
 import abc
 import copy
 import json
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import pandas as pd
 
-from ..models import ObjectId, ProtoModel
+from ..models import ProtoModel
+
+if TYPE_CHECKING:
+    from .. import FractalClient
+    from ..models import ObjectId
 
 
 class Collection(abc.ABC):
-    def __init__(self, name: str, client: Optional['FractalClient'] = None, **kwargs: Dict[str, Any]):
+    def __init__(self, name: str, client: Optional['FractalClient'] = None, **kwargs: Any):
         """
         Initializer for the Collection objects. If no Portal is supplied or the Collection name
         is not present on the server that the Portal is connected to a blank Collection will be
@@ -55,9 +59,9 @@ class Collection(abc.ABC):
         additional data defined by the Collection
         """
         name: str
-        collection: str = None
+        collection: Optional[str] = None
         provenance: Dict[str, str] = {}
-        tagline: str = None
+        tagline: Optional[str] = None
         tags: List[str] = []
         id: str = 'local'
 
@@ -196,7 +200,7 @@ class Collection(abc.ABC):
         """
 
     # Setters
-    def save(self, client: 'FractalClient' = None) -> 'ObjectId':
+    def save(self, client: Optional['FractalClient'] = None) -> 'ObjectId':
         """Uploads the overall structure of the Collection (indices, options, new molecules, etc)
         to the server.
 
@@ -268,7 +272,7 @@ class BaseProcedureDataset(Collection):
             pass
 
     @abc.abstractmethod
-    def _internal_compute_add(self, spec: Any, entry: Any, tag: str, priority: str) -> ObjectId:
+    def _internal_compute_add(self, spec: Any, entry: Any, tag: str, priority: str) -> 'ObjectId':
         pass
 
     def _pre_save_prep(self, client: 'FractalClient') -> None:
@@ -298,7 +302,7 @@ class BaseProcedureDataset(Collection):
         self.data.specs[lname] = spec
         self.save()
 
-    def _get_procedure_ids(self, spec: str, sieve: Optional[List[str]] = None) -> Dict[str, ObjectId]:
+    def _get_procedure_ids(self, spec: str, sieve: Optional[List[str]] = None) -> Dict[str, 'ObjectId']:
         """Aquires the
 
         Parameters
@@ -349,7 +353,7 @@ class BaseProcedureDataset(Collection):
         except KeyError:
             raise KeyError(f"Specification '{name}' not found.")
 
-    def list_specifications(self, description=True) -> Union[List[str], 'DataFrame']:
+    def list_specifications(self, description=True) -> Union[List[str], pd.DataFrame]:
         """Lists all available specifications
 
         Parameters
@@ -388,7 +392,7 @@ class BaseProcedureDataset(Collection):
         if save:
             self.save()
 
-    def get_entry(self, name: str) -> 'Record':
+    def get_entry(self, name: str) -> Any:
         """Obtains a record from the Dataset
 
         Parameters
@@ -498,7 +502,7 @@ class BaseProcedureDataset(Collection):
         query_ids = list(mapper.values())
 
         # Chunk up the queries
-        procedures = []
+        procedures: List[Dict[str, Any]] = []
         for i in range(0, len(query_ids), self.client.query_limit):
             chunk_ids = query_ids[i:i + self.client.query_limit]
             procedures.extend(self.client.query_procedures(id=chunk_ids))
@@ -520,7 +524,7 @@ class BaseProcedureDataset(Collection):
         return spec.name
 
     def status(self, specs: Union[str, List[str]] = None, collapse: bool = True,
-               status: Optional[str] = None) -> 'DataFrame':
+               status: Optional[str] = None) -> pd.DataFrame:
         """Returns the status of all current specifications.
 
         Parameters

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -13,9 +13,9 @@ import pandas as pd
 
 from ..models import ProtoModel
 
-if TYPE_CHECKING:
-    from .. import FractalClient
-    from ..models import ObjectId
+if TYPE_CHECKING:  # pragma: no cover
+    from .. import FractalClient  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from ..models import ObjectId  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
 
 
 class Collection(abc.ABC):

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -12,11 +12,10 @@ from typing import Any, Dict, List, Optional, Set, Union
 import pandas as pd
 
 from ..models import ObjectId, ProtoModel
-from ..client import FractalClient
 
 
 class Collection(abc.ABC):
-    def __init__(self, name: str, client: FractalClient = None, **kwargs: Dict[str, Any]):
+    def __init__(self, name: str, client: Optional['FractalClient'] = None, **kwargs: Dict[str, Any]):
         """
         Initializer for the Collection objects. If no Portal is supplied or the Collection name
         is not present on the server that the Portal is connected to a blank Collection will be

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -196,12 +196,12 @@ class Dataset(Collection):
         self.data.history.add(tuple(new_history))
 
     def list_values(self,
-                    method: Optional[str] = None,
-                    basis: Optional[str] = None,
+                    method: Optional[Union[str, List[str]]] = None,
+                    basis: Optional[Union[str, List[str]]] = None,
                     keywords: Optional[str] = None,
                     program: Optional[str] = None,
                     driver: Optional[str] = None,
-                    name: Optional[str] = None,
+                    name: Optional[Union[str, List[str]]] = None,
                     native: Optional[bool] = None,
                     force: bool = False) -> pd.DataFrame:
         """
@@ -211,9 +211,9 @@ class Dataset(Collection):
 
         Parameters
         ----------
-        method : Optional[str], optional
+        method : Optional[Union[str, List[str]]], optional
             The computational method (B3LYP)
-        basis : Optional[str], optional
+        basis : Optional[Union[str, List[str]]], optional
             The computational basis (6-31G)
         keywords : Optional[str], optional
             The keyword alias
@@ -221,7 +221,7 @@ class Dataset(Collection):
             The underlying QC program
         driver : Optional[str], optional
             The type of calculation (e.g. energy, gradient, hessian, dipole...)
-        name : Optional[str], optional
+        name : Optional[Union[str, List[str]]], optional
             The canonical name of the data column
         native: Optional[bool], optional
             True: only include data computed with QCFractal
@@ -298,7 +298,8 @@ class Dataset(Collection):
                 raise TypeError(f"Search type {type(value)} not understood.")
         return ret
 
-    def list_records(self, dftd3: bool = False, pretty: bool = True, **search: Optional[str]) -> pd.DataFrame:
+    def list_records(self, dftd3: bool = False, pretty: bool = True,
+                     **search: Optional[Union[str, List[str]]]) -> pd.DataFrame:
         """
         Lists specifications of available records, i.e. method, program, basis set, keyword set, driver combinations
         `None` is a wildcard selector. To search for `None`, use `"None"`.
@@ -377,12 +378,12 @@ class Dataset(Collection):
         return ret
 
     def get_values(self,
-                   method: Optional[str] = None,
-                   basis: Optional[str] = None,
+                   method: Optional[Union[str, List[str]]] = None,
+                   basis: Optional[Union[str, List[str]]] = None,
                    keywords: Optional[str] = None,
                    program: Optional[str] = None,
                    driver: Optional[str] = None,
-                   name: Optional[str] = None,
+                   name: Optional[Union[str, List[str]]] = None,
                    native: Optional[bool] = None,
                    force: bool = False) -> pd.DataFrame:
         """
@@ -396,9 +397,9 @@ class Dataset(Collection):
 
         Parameters
         ----------
-        method : Optional[str], optional
+        method : Optional[Union[str, List[str]]], optional
             The computational method (B3LYP)
-        basis : Optional[str], optional
+        basis : Optional[Union[str, List[str]]], optional
             The computational basis (6-31G)
         keywords : Optional[str], optional
             The keyword alias
@@ -406,7 +407,7 @@ class Dataset(Collection):
             The underlying QC program
         driver : Optional[str], optional
             The type of calculation (e.g. energy, gradient, hessian, dipole...)
-        name : Optional[str], optional
+        name : Optional[Union[str, List[str]]], optional
             Canonical name of the record. Overrides the above selectors.
         native: Optional[bool], optional
             True: only include data computed with QCFractal

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -15,8 +15,8 @@ from ..visualization import bar_plot, violin_plot
 from .collection import Collection
 from .collection_utils import composition_planner, register_collection
 
-if TYPE_CHECKING:
-    from .. import FractalClient
+if TYPE_CHECKING:  # pragma: no cover
+    from .. import FractalClient  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
     from ..models import KeywordSet, Molecule, ResultRecord
     from . import DatasetView
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -9,7 +9,6 @@ import pandas as pd
 
 from qcelemental import constants
 
-from ..client import FractalClient
 from ..models import ComputeResponse, KeywordSet, Molecule, ObjectId, ProtoModel, ResultRecord
 from ..statistics import wrap_statistics
 from ..visualization import bar_plot, violin_plot
@@ -47,7 +46,7 @@ class Dataset(Collection):
     df : pd.DataFrame
         The underlying dataframe for the Dataset object
     """
-    def __init__(self, name: str, client: Optional[FractalClient] = None, **kwargs: Dict[str, Any]) -> None:
+    def __init__(self, name: str, client: Optional['FractalClient'] = None, **kwargs: Dict[str, Any]) -> None:
         """
         Initializer for the Dataset object. If no Portal is supplied or the database name
         is not present on the server that the Portal is connected to a blank database will be
@@ -109,7 +108,7 @@ class Dataset(Collection):
         if self._new_molecules or self._new_keywords or self._new_records or self._updated_state:
             raise ValueError("New molecules, keywords, or records detected, run save before submitting new tasks.")
 
-    def _canonical_pre_save(self, client: FractalClient) -> None:
+    def _canonical_pre_save(self, client: 'FractalClient') -> None:
 
         for k in list(self._new_keywords.keys()):
             ret = client.add_keywords([self._new_keywords[k]])
@@ -118,7 +117,7 @@ class Dataset(Collection):
             del self._new_keywords[k]
         self._updated_state = False
 
-    def _pre_save_prep(self, client: FractalClient) -> None:
+    def _pre_save_prep(self, client: 'FractalClient') -> None:
         self._canonical_pre_save(client)
 
         # Preps any new molecules introduced to the Dataset before storing data.

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -70,7 +70,6 @@ class Dataset(Collection):
         self._new_keywords: Dict[Tuple[str, str], KeywordSet] = {}
         self._new_records: List[Dict[str, Any]] = []
         self._updated_state = False
-        self._entry_index = None
 
         self._view: Optional['DatasetView'] = None
         self._disable_view: bool = False  # for debugging and testing
@@ -178,7 +177,7 @@ class Dataset(Collection):
 
         return {row['name']: row['molecule_id'] for row in index.to_dict('records')}
 
-    def _add_history(self, **history: Dict[str, Optional[str]]) -> None:
+    def _add_history(self, **history: Optional[str]) -> None:
         """
         Adds compute history to the dataset
         """
@@ -278,7 +277,8 @@ class Dataset(Collection):
         return ret
 
     @staticmethod
-    def _filter_records(df: pd.DataFrame, **spec) -> pd.DataFrame:
+    def _filter_records(df: pd.DataFrame,
+                        **spec: Optional[Union[str, bool, List[Union[str, bool]], Tuple]]) -> pd.DataFrame:
         """
         Helper for filtering records on a spec. Note that `None` is a wildcard while `"None"` matches `None` and NaN.
         """
@@ -298,8 +298,7 @@ class Dataset(Collection):
                 raise TypeError(f"Search type {type(value)} not understood.")
         return ret
 
-    def list_records(self, dftd3: bool = False, pretty: bool = True,
-                     **search: Dict[str, Optional[str]]) -> pd.DataFrame:
+    def list_records(self, dftd3: bool = False, pretty: bool = True, **search: Optional[str]) -> pd.DataFrame:
         """
         Lists specifications of available records, i.e. method, program, basis set, keyword set, driver combinations
         `None` is a wildcard selector. To search for `None`, use `"None"`.
@@ -549,7 +548,7 @@ class Dataset(Collection):
     def _visualize(self,
                    metric,
                    bench,
-                   query: Dict[str, Optional[str]],
+                   query: Dict[str, Union[Optional[str], List[str]]],
                    groupby: Optional[str] = None,
                    return_figure=None,
                    digits=3,
@@ -805,7 +804,7 @@ class Dataset(Collection):
 
         return name, dbkeys, history
 
-    def _get_molecules(self, indexer: Dict[str, 'ObjectId'], force: bool = False) -> pd.DataFrame:
+    def _get_molecules(self, indexer: Dict[Any, ObjectId], force: bool = False) -> pd.DataFrame:
         """Queries a list of molecules using a molecule indexer
 
         Parameters
@@ -853,7 +852,7 @@ class Dataset(Collection):
         return df
 
     def _get_records(self,
-                     indexer: Dict[str, 'ObjectId'],
+                     indexer: Dict[Any, ObjectId],
                      query: Dict[str, Any],
                      projection: Optional[Dict[str, bool]] = None,
                      merge: bool = False,
@@ -863,7 +862,7 @@ class Dataset(Collection):
 
         Parameters
         ----------
-        indexer : Dict[str, 'ObjectId']
+        indexer : Dict[str, ObjectId]
             A key/value index of molecules to query
         query : Dict[str, Any]
             A results query

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -53,7 +53,7 @@ class DatasetView(abc.ABC):
             A Dataframe with specification of available columns.
         """
     @abc.abstractmethod
-    def get_values(self, queries: List[Tuple[str]]) -> Tuple[pd.DataFrame, Dict[str, str]]:
+    def get_values(self, queries: List[Dict[str, str]]) -> Tuple[pd.DataFrame, Dict[str, str]]:
         """
         Get value columns.
 
@@ -124,7 +124,7 @@ class HDF5View(DatasetView):
         # for some reason, pandas makes native a float column
         return df.astype({"native": bool})
 
-    def get_values(self, queries: List[Tuple[str]]) -> Tuple[pd.DataFrame, Dict[str, str]]:
+    def get_values(self, queries: List[Dict[str, str]]) -> Tuple[pd.DataFrame, Dict[str, str]]:
         units = {}
         with self._read_file() as f:
             ret = pd.DataFrame(index=f["entry/entry"][()])
@@ -173,9 +173,9 @@ class HDF5View(DatasetView):
             with self._read_file() as f:
                 entry_group = f["entry"]
                 if entry_group.attrs["model"] == "MoleculeEntry":
-                    fields = ("name", "molecule_id")
+                    fields = ["name", "molecule_id"]
                 elif entry_group.attrs["model"] == "ReactionEntry":
-                    fields = ("name", "stoichiometry", "molecule", "coefficient")
+                    fields = ["name", "stoichiometry", "molecule", "coefficient"]
                 else:
                     raise ValueError(f"Unknown entry class ({entry_group.attrs['model']}) while "
                                      f"reading HDF5 entries.")

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -3,7 +3,7 @@ import distutils
 import pathlib
 import warnings
 from contextlib import contextmanager
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, Iterator, List, Tuple, Union
 
 # TODO(mattwelborn): Determine if h5py can/should be optionally imported
 import h5py
@@ -367,11 +367,11 @@ class HDF5View(DatasetView):
         return name.replace("/", ":")
 
     @contextmanager
-    def _read_file(self):
+    def _read_file(self) -> Iterator[h5py.File]:
         yield h5py.File(self._path, 'r')
 
     @contextmanager
-    def _write_file(self):
+    def _write_file(self) -> Iterator[h5py.File]:
         yield h5py.File(self._path, 'w')
 
     # Methods for serializing to strings for storage in HDF5 metadata fields ("attrs")

--- a/qcfractal/interface/collections/gridoptimization_dataset.py
+++ b/qcfractal/interface/collections/gridoptimization_dataset.py
@@ -1,12 +1,16 @@
 """
 QCPortal Database ODM
 """
-from typing import Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
-from ..models import GridOptimizationInput, Molecule, ObjectId, OptimizationSpecification, ProtoModel, QCSpecification
-from ..models.gridoptimization import GOKeywords, ScanDimension
+from ..models import GridOptimizationInput, ObjectId, OptimizationSpecification, ProtoModel, QCSpecification
+from ..models.gridoptimization import GOKeywords
 from .collection import BaseProcedureDataset
 from .collection_utils import register_collection
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..models.gridoptimization import ScanDimension  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from ..models import Molecule  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
 
 
 class GOEntry(ProtoModel):
@@ -74,8 +78,8 @@ class GridOptimizationDataset(BaseProcedureDataset):
 
     def add_entry(self,
                   name: str,
-                  initial_molecule: Molecule,
-                  scans: List[ScanDimension],
+                  initial_molecule: 'Molecule',
+                  scans: List['ScanDimension'],
                   preoptimization: bool = True,
                   attributes: Dict[str, Any] = None,
                   save: bool = True) -> None:

--- a/qcfractal/interface/collections/optimization_dataset.py
+++ b/qcfractal/interface/collections/optimization_dataset.py
@@ -63,7 +63,7 @@ class OptimizationDataset(BaseProcedureDataset):
                           name: str,
                           optimization_spec: OptimizationSpecification,
                           qc_spec: QCSpecification,
-                          description: str = None,
+                          description: Optional[str] = None,
                           protocols: Optional[Dict[str, Any]] = None,
                           overwrite=False) -> None:
         """
@@ -96,8 +96,8 @@ class OptimizationDataset(BaseProcedureDataset):
     def add_entry(self,
                   name: str,
                   initial_molecule: Molecule,
-                  additional_keywords: Dict[str, Any] = None,
-                  attributes: Dict[str, Any] = None,
+                  additional_keywords: Optional[Dict[str, Any]] = None,
+                  attributes: Optional[Dict[str, Any]] = None,
                   save: bool = True) -> None:
         """
         Parameters
@@ -133,7 +133,7 @@ class OptimizationDataset(BaseProcedureDataset):
         self._add_entry(name, entry, save)
 
     def counts(self, entries: Optional[Union[str, List[str]]] = None,
-               specs: Optional[Union[str, List[str]]] = None) -> 'DataFrame':
+               specs: Optional[Union[str, List[str]]] = None) -> pd.DataFrame:
         """Counts the number of optimization or gradient evaluations associated with the
         Optimizations.
 

--- a/qcfractal/interface/collections/optimization_dataset.py
+++ b/qcfractal/interface/collections/optimization_dataset.py
@@ -1,15 +1,18 @@
 """
 QCPortal Database ODM
 """
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import pandas as pd
 
 import qcelemental as qcel
 
-from ..models import Molecule, ObjectId, OptimizationSpecification, ProtoModel, QCSpecification
+from ..models import ObjectId, OptimizationSpecification, ProtoModel, QCSpecification
 from .collection import BaseProcedureDataset
 from .collection_utils import register_collection
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..models import Molecule  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
 
 
 class OptEntry(ProtoModel):
@@ -95,7 +98,7 @@ class OptimizationDataset(BaseProcedureDataset):
 
     def add_entry(self,
                   name: str,
-                  initial_molecule: Molecule,
+                  initial_molecule: 'Molecule',
                   additional_keywords: Optional[Dict[str, Any]] = None,
                   attributes: Optional[Dict[str, Any]] = None,
                   save: bool = True) -> None:

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -3,17 +3,21 @@ QCPortal Database ODM
 """
 import itertools as it
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
 from qcelemental import constants
 
-from ..models import ComputeResponse, Molecule, ObjectId, ProtoModel, ResultRecord
+from ..models import Molecule, ProtoModel
 from ..util import replace_dict_keys
 from .collection_utils import nCr, register_collection
 from .dataset import Dataset
+
+if TYPE_CHECKING:
+    from .. import FractalClient
+    from ..models import ComputeResponse, ObjectId, ResultRecord
 
 
 class _ReactionTypeEnum(str, Enum):
@@ -95,7 +99,7 @@ class ReactionDataset(Dataset):
                           stoich: Union[str, List[str]],
                           subset: Optional[Union[str, Set[str]]] = None,
                           coefficients: bool = False,
-                          force: bool = False) -> Tuple[Dict[Tuple[str, ...], ObjectId], Tuple[str]]:
+                          force: bool = False) -> Tuple[Dict[Tuple[str, ...], 'ObjectId'], Tuple[str]]:
         """Provides a {index: molecule_id} mapping for a given subset.
 
         Parameters
@@ -375,7 +379,7 @@ class ReactionDataset(Dataset):
                     program: Optional[str] = None,
                     stoich: Union[str, List[str]] = "default",
                     projection: Optional[Dict[str, bool]] = None,
-                    subset: Optional[Union[str, Set[str]]] = None) -> Union[pd.DataFrame, ResultRecord]:
+                    subset: Optional[Union[str, Set[str]]] = None) -> Union[pd.DataFrame, 'ResultRecord']:
         """
         Queries the local Portal for the requested keys and stoichiometry.
 
@@ -444,7 +448,7 @@ class ReactionDataset(Dataset):
                 stoich: str = "default",
                 ignore_ds_type: bool = False,
                 tag: Optional[str] = None,
-                priority: Optional[str] = None) -> ComputeResponse:
+                priority: Optional[str] = None) -> 'ComputeResponse':
         """Executes a computational method for all reactions in the Dataset.
         Previously completed computations are not repeated.
 

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -10,7 +10,6 @@ import pandas as pd
 
 from qcelemental import constants
 
-from ..client import FractalClient
 from ..models import ComputeResponse, Molecule, ObjectId, ProtoModel
 from ..util import replace_dict_keys
 from .collection_utils import nCr, register_collection
@@ -47,7 +46,7 @@ class ReactionDataset(Dataset):
     rxn_index : pd.Index
         The unrolled reaction index for all reactions in the Dataset
     """
-    def __init__(self, name: str, client: Optional[FractalClient] = None, ds_type: str = "rxn", **kwargs) -> None:
+    def __init__(self, name: str, client: Optional['FractalClient'] = None, ds_type: str = "rxn", **kwargs) -> None:
         """
         Initializer for the Dataset object. If no Portal is supplied or the database name
         is not present on the server that the Portal is connected to a blank database will be
@@ -151,7 +150,7 @@ class ReactionDataset(Dataset):
             if s.lower() not in self.valid_stoich:
                 raise KeyError("Stoichiometry not understood, valid keys are {}.".format(self.valid_stoich))
 
-    def _pre_save_prep(self, client: FractalClient) -> None:
+    def _pre_save_prep(self, client: 'FractalClient') -> None:
         self._canonical_pre_save(client)
 
         mol_ret = self._add_molecules_by_dict(client, self._new_molecules)

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -15,8 +15,8 @@ from ..util import replace_dict_keys
 from .collection_utils import nCr, register_collection
 from .dataset import Dataset
 
-if TYPE_CHECKING:
-    from .. import FractalClient
+if TYPE_CHECKING:  # pragma: no cover
+    from .. import FractalClient  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
     from ..models import ComputeResponse, ObjectId, ResultRecord
 
 

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -165,13 +165,13 @@ class ReactionDataset(Dataset):
         self._form_index()
 
     def get_values(self,
-                   method: Optional[str] = None,
-                   basis: Optional[str] = None,
+                   method: Optional[Union[str, List[str]]] = None,
+                   basis: Optional[Union[str, List[str]]] = None,
                    keywords: Optional[str] = None,
                    program: Optional[str] = None,
                    driver: Optional[str] = None,
                    stoich: str = "default",
-                   name: Optional[str] = None,
+                   name: Optional[Union[str, List[str]]] = None,
                    native: Optional[bool] = None,
                    force: bool = False) -> pd.DataFrame:
         """
@@ -185,9 +185,9 @@ class ReactionDataset(Dataset):
 
         Parameters
         ----------
-        method : Optional[str], optional
+        method : Optional[Union[str, List[str]]], optional
             The computational method (B3LYP)
-        basis : Optional[str], optional
+        basis : Optional[Union[str, List[str]]], optional
             The computational basis (6-31G)
         keywords : Optional[str], optional
             The keyword alias
@@ -197,7 +197,7 @@ class ReactionDataset(Dataset):
             The type of calculation (e.g. energy, gradient, hessian, dipole...)
         stoich : str, optional
             Stoichiometry of the reaction.
-        name : Optional[str], optional
+        name : Optional[Union[str, List[str]]], optional
             Canonical name of the record. Overrides the above selectors.
         native: Optional[bool], optional
             True: only include data computed with QCFractal

--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -1,15 +1,18 @@
 """
 QCPortal Database ODM
 """
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import pandas as pd
 
-from ..models import Molecule, ObjectId, OptimizationSpecification, ProtoModel, QCSpecification, TorsionDriveInput
+from ..models import ObjectId, OptimizationSpecification, ProtoModel, QCSpecification, TorsionDriveInput
 from ..models.torsiondrive import TDKeywords
 from ..visualization import custom_plot
 from .collection import BaseProcedureDataset
 from .collection_utils import register_collection
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..models import Molecule  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
 
 
 class TDEntry(ProtoModel):
@@ -78,7 +81,7 @@ class TorsionDriveDataset(BaseProcedureDataset):
 
     def add_entry(self,
                   name: str,
-                  initial_molecules: List[Molecule],
+                  initial_molecules: List['Molecule'],
                   dihedrals: List[Tuple[int, int, int, int]],
                   grid_spacing: List[int],
                   dihedral_ranges: Optional[List[Tuple[int, int]]] = None,

--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -51,8 +51,8 @@ class TorsionDriveDataset(BaseProcedureDataset):
                           name: str,
                           optimization_spec: OptimizationSpecification,
                           qc_spec: QCSpecification,
-                          description: str = None,
-                          overwrite=False) -> None:
+                          description: Optional[str] = None,
+                          overwrite: bool = False) -> None:
         """
         Parameters
         ----------
@@ -130,7 +130,7 @@ class TorsionDriveDataset(BaseProcedureDataset):
     def counts(self,
                entries: Union[str, List[str]],
                specs: Optional[Union[str, List[str]]] = None,
-               count_gradients=False) -> 'DataFrame':
+               count_gradients: bool = False) -> pd.DataFrame:
         """Counts the number of optimization or gradient evaluations associated with the
         TorsionDrives.
 
@@ -299,7 +299,7 @@ class TorsionDriveDataset(BaseProcedureDataset):
                specs: Union[str, List[str]] = None,
                collapse: bool = True,
                status: Optional[str] = None,
-               detail: bool = False) -> 'DataFrame':
+               detail: bool = False) -> pd.DataFrame:
         """Returns the status of all current specifications.
 
         Parameters
@@ -335,7 +335,7 @@ class TorsionDriveDataset(BaseProcedureDataset):
         data = []
 
         for service in services:
-            row = {}
+            row: Dict[str, Union[str, int]] = {}
             row["Name"] = reverse_map[service["procedure_id"]]
             row["Status"] = service["status"]
 

--- a/qcfractal/interface/models/gridoptimization.py
+++ b/qcfractal/interface/models/gridoptimization.py
@@ -12,7 +12,7 @@ from .common_models import Molecule, ObjectId, OptimizationSpecification, ProtoM
 from .model_utils import recursive_normalizer
 from .records import RecordBase
 
-__all__ = ["GridOptimizationInput", "GridOptimizationRecord"]
+__all__ = ["GOKeywords", "GridOptimizationInput", "GridOptimizationRecord", "ScanDimension"]
 
 
 class ScanTypeEnum(str, Enum):

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -5,7 +5,7 @@ A model for Compute Records
 import abc
 import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import numpy as np
 
@@ -13,8 +13,13 @@ import qcelemental as qcel
 from pydantic import Schema, constr, validator
 
 from ..visualization import scatter_plot
-from .common_models import DriverEnum, KeywordSet, Molecule, ObjectId, ProtoModel, QCSpecification
+from .common_models import DriverEnum, ObjectId, ProtoModel, QCSpecification
 from .model_utils import hash_dictionary, prepare_basis, recursive_normalizer
+
+if TYPE_CHECKING:
+    from qcelemental.models import OptimizationInput, ResultInput
+
+    from .common_models import KeywordSet, Molecule
 
 __all__ = ["OptimizationRecord", "ResultRecord", "OptimizationRecord", "RecordBase"]
 
@@ -281,7 +286,7 @@ class ResultRecord(RecordBase):
 
 ## QCSchema constructors
 
-    def build_schema_input(self, molecule: Molecule, keywords: Optional[KeywordSet] = None,
+    def build_schema_input(self, molecule: 'Molecule', keywords: Optional['KeywordSet'] = None,
                            checks: bool = True) -> 'ResultInput':
         """
         Creates a OptimizationInput schema.
@@ -329,7 +334,7 @@ class ResultRecord(RecordBase):
 
 ## QCSchema constructors
 
-    def get_molecule(self) -> Molecule:
+    def get_molecule(self) -> 'Molecule':
         """
         Pulls the Result's Molecule from the connected database.
 
@@ -399,8 +404,8 @@ class OptimizationRecord(RecordBase):
 ## QCSchema constructors
 
     def build_schema_input(self,
-                           initial_molecule: Molecule,
-                           qc_keywords: Optional[KeywordSet] = None,
+                           initial_molecule: 'Molecule',
+                           qc_keywords: Optional['KeywordSet'] = None,
                            checks: bool = True) -> 'OptimizationInput':
         """
         Creates a OptimizationInput schema.
@@ -452,7 +457,7 @@ class OptimizationRecord(RecordBase):
 
         return self.cache["trajectory"]
 
-    def get_molecular_trajectory(self) -> List[Molecule]:
+    def get_molecular_trajectory(self) -> List['Molecule']:
         """Returns the Molecule at each gradient evaluation in the trajectory.
 
         Returns
@@ -470,7 +475,7 @@ class OptimizationRecord(RecordBase):
 
         return self.cache["molecular_trajectory"]
 
-    def get_initial_molecule(self) -> Molecule:
+    def get_initial_molecule(self) -> 'Molecule':
         """Returns the initial molecule
 
         Returns
@@ -482,7 +487,7 @@ class OptimizationRecord(RecordBase):
         ret = self.client.query_molecules(id=[self.initial_molecule])
         return ret[0]
 
-    def get_final_molecule(self) -> Molecule:
+    def get_final_molecule(self) -> 'Molecule':
         """Returns the optimized molecule
 
         Returns

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -8,12 +8,12 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 
 import numpy as np
-from pydantic import Schema, constr, validator
 
 import qcelemental as qcel
+from pydantic import Schema, constr, validator
 
 from ..visualization import scatter_plot
-from .common_models import DriverEnum, ObjectId, ProtoModel, QCSpecification
+from .common_models import DriverEnum, KeywordSet, Molecule, ObjectId, ProtoModel, QCSpecification
 from .model_utils import hash_dictionary, prepare_basis, recursive_normalizer
 
 __all__ = ["OptimizationRecord", "ResultRecord", "OptimizationRecord", "RecordBase"]
@@ -281,7 +281,7 @@ class ResultRecord(RecordBase):
 
 ## QCSchema constructors
 
-    def build_schema_input(self, molecule: 'Molecule', keywords: Optional['KeywordsSet'] = None,
+    def build_schema_input(self, molecule: Molecule, keywords: Optional[KeywordSet] = None,
                            checks: bool = True) -> 'ResultInput':
         """
         Creates a OptimizationInput schema.
@@ -329,7 +329,7 @@ class ResultRecord(RecordBase):
 
 ## QCSchema constructors
 
-    def get_molecule(self) -> 'Molecule':
+    def get_molecule(self) -> Molecule:
         """
         Pulls the Result's Molecule from the connected database.
 
@@ -399,8 +399,8 @@ class OptimizationRecord(RecordBase):
 ## QCSchema constructors
 
     def build_schema_input(self,
-                           initial_molecule: 'Molecule',
-                           qc_keywords: Optional['KeywordsSet'] = None,
+                           initial_molecule: Molecule,
+                           qc_keywords: Optional[KeywordSet] = None,
                            checks: bool = True) -> 'OptimizationInput':
         """
         Creates a OptimizationInput schema.
@@ -435,7 +435,7 @@ class OptimizationRecord(RecordBase):
         """
         return self.energies[-1]
 
-    def get_trajectory(self) -> List['ResultRecord']:
+    def get_trajectory(self) -> List[ResultRecord]:
         """Returns the Result records for each gradient evaluation in the trajectory.
 
         Returns
@@ -452,7 +452,7 @@ class OptimizationRecord(RecordBase):
 
         return self.cache["trajectory"]
 
-    def get_molecular_trajectory(self) -> List['Molecule']:
+    def get_molecular_trajectory(self) -> List[Molecule]:
         """Returns the Molecule at each gradient evaluation in the trajectory.
 
         Returns
@@ -470,7 +470,7 @@ class OptimizationRecord(RecordBase):
 
         return self.cache["molecular_trajectory"]
 
-    def get_initial_molecule(self) -> 'Molecule':
+    def get_initial_molecule(self) -> Molecule:
         """Returns the initial molecule
 
         Returns
@@ -482,7 +482,7 @@ class OptimizationRecord(RecordBase):
         ret = self.client.query_molecules(id=[self.initial_molecule])
         return ret[0]
 
-    def get_final_molecule(self) -> 'Molecule':
+    def get_final_molecule(self) -> Molecule:
         """Returns the optimized molecule
 
         Returns

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -16,10 +16,10 @@ from ..visualization import scatter_plot
 from .common_models import DriverEnum, ObjectId, ProtoModel, QCSpecification
 from .model_utils import hash_dictionary, prepare_basis, recursive_normalizer
 
-if TYPE_CHECKING:
-    from qcelemental.models import OptimizationInput, ResultInput
+if TYPE_CHECKING:  # pragma: no cover
+    from qcelemental.models import OptimizationInput, ResultInput  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
 
-    from .common_models import KeywordSet, Molecule
+    from .common_models import KeywordSet, Molecule  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
 
 __all__ = ["OptimizationRecord", "ResultRecord", "OptimizationRecord", "RecordBase"]
 

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -4,7 +4,6 @@ Models for the REST interface
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import Schema, constr, validator
-
 from qcelemental.util import get_base_docs
 
 from .common_models import KeywordSet, Molecule, ObjectId, ProtoModel
@@ -13,7 +12,7 @@ from .records import ResultRecord
 from .task_models import PriorityEnum, TaskRecord
 from .torsiondrive import TorsionDriveInput
 
-__all__ = ["ComputeResponse", "rest_model", "QueryStr", "QueryObjectId", "QueryProjection"]
+__all__ = ["ComputeResponse", "rest_model", "QueryStr", "QueryObjectId", "QueryProjection", "ResultResponse"]
 
 ### Utility functions
 
@@ -21,15 +20,15 @@ __rest_models = {}
 __custom_rest_models = {}  # get requests models, with resource and subresources
 
 
-def register_model(resource: str, rest: str, body: 'ProtoModel', response: 'ProtoModel') -> None:
+def register_model(resource: str, rest: str, body: ProtoModel, response: ProtoModel) -> None:
     _register_model(False, resource, rest, body, response)
 
 
-def register_custom_model(resource: str, rest: str, body: 'ProtoModel', response: 'ProtoModel') -> None:
+def register_custom_model(resource: str, rest: str, body: ProtoModel, response: ProtoModel) -> None:
     _register_model(True, resource, rest, body, response)
 
 
-def _register_model(is_custom_queries: bool, name: str, rest: str, body: 'ProtoModel', response: 'ProtoModel') -> None:
+def _register_model(is_custom_queries: bool, name: str, rest: str, body: ProtoModel, response: ProtoModel) -> None:
     """
     Register a REST model.
 
@@ -65,7 +64,7 @@ def _register_model(is_custom_queries: bool, name: str, rest: str, body: 'ProtoM
     models_dict[name][rest] = (body, response)
 
 
-def rest_model(resource: str, rest: str, subresource: str = None) -> Tuple['ProtoModel', 'ProtoModel']:
+def rest_model(resource: str, rest: str, subresource: str = None) -> Tuple[ProtoModel, ProtoModel]:
     """Aquires a REST Model
 
     Parameters
@@ -78,7 +77,7 @@ def rest_model(resource: str, rest: str, subresource: str = None) -> Tuple['Prot
         A subresource under the main resource
     Returns
     -------
-    Tuple['ProtoModel', 'ProtoModel']
+    Tuple[ProtoModel, ProtoModel]
         The (body, response) models of the REST request.
 
     """

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -7,8 +7,8 @@ import json
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from pydantic import Schema, constr, validator
 
+from pydantic import Schema, constr, validator
 from qcelemental import constants
 
 from ..visualization import scatter_plot
@@ -16,7 +16,7 @@ from .common_models import Molecule, ObjectId, OptimizationSpecification, ProtoM
 from .model_utils import recursive_normalizer
 from .records import RecordBase
 
-__all__ = ["TorsionDriveInput", "TorsionDriveRecord"]
+__all__ = ["TDKeywords", "TorsionDriveInput", "TorsionDriveRecord"]
 
 
 class TDKeywords(ProtoModel):


### PR DESCRIPTION
## Description
This PR seeks to incrementally improve type hints in Portal, especially in modules used in the QCArchive examples. The motivation for this is twofold:

1. Help users to explore the portal functionality introduced in the examples. ("Can I pass a list of methods to `get_values`?") 
2. Find bugs with type checkers. Like the fact that you can totally pass a list of methods to `get_values`.

Non-goal: make Fractal pass mypy. We're nowhere near that.

## Status
- [ ] Changelog updated
- [ ] Ready to go