### PR TITLE
Use inlcude/exclude in queries with hybrid prop

### DIFF
--- a/qcfractal/storage_sockets/models/collections_models.py
+++ b/qcfractal/storage_sockets/models/collections_models.py
@@ -135,9 +135,20 @@ class DatasetORM(CollectionORM, DatasetMixin):
         """calculated property when accessed, not saved in the DB
         A view of the many to many relation"""
 
+        return self._records(self.records_obj)
+
+    @staticmethod
+    def _records(records_obj):
+
+        if not records_obj:
+            return []
+
+        if not isinstance(records_obj, list):
+            records_obj = [records_obj]
+
         ret = []
         try:
-            for rec in self.records_obj:
+            for rec in records_obj:
                 ret.append(rec.to_dict(exclude=['dataset_id']))
         except Exception as err:
             # raises exception of first access!!
@@ -215,9 +226,20 @@ class ReactionDatasetORM(CollectionORM, DatasetMixin):
         """calculated property when accessed, not saved in the DB
         A view of the many to many relation"""
 
+        return self._records(self.records_obj)
+
+    @staticmethod
+    def _records(records_obj):
+
+        if not records_obj:
+            return []
+
+        if not isinstance(records_obj, list):
+            records_obj = [records_obj]
+
         ret = []
         try:
-            for rec in self.records_obj:
+            for rec in records_obj:
                 ret.append(rec.to_dict(exclude=['reaction_dataset_id']))
         except Exception as err:
             # raises exception of first access!!

--- a/qcfractal/storage_sockets/models/results_models.py
+++ b/qcfractal/storage_sockets/models/results_models.py
@@ -323,9 +323,20 @@ class GridOptimizationProcedureORM(ProcedureMixin, BaseResultORM):
         """calculated property when accessed, not saved in the DB
         A view of the many to many relation in the form of a dict"""
 
+        return self._grid_optimizations(self.grid_optimizations_obj)
+
+    @staticmethod
+    def _grid_optimizations(grid_optimizations_obj):
+
+        if not grid_optimizations_obj:
+            return {}
+
+        if not isinstance(grid_optimizations_obj, list):
+            grid_optimizations_obj = {grid_optimizations_obj}
+
         ret = {}
         try:
-            for obj in self.grid_optimizations_obj:
+            for obj in grid_optimizations_obj:
                 ret[obj.key] = str(obj.opt_id)
 
         except Exception as err:
@@ -428,9 +439,20 @@ class TorsionDriveProcedureORM(ProcedureMixin, BaseResultORM):
         """calculated property when accessed, not saved in the DB
         A view of the many to many relation in the form of a dict"""
 
+        return self._optimization_history(self.optimization_history_obj)
+
+    @staticmethod
+    def _optimization_history(optimization_history_obj):
+
+        if not optimization_history_obj:
+            return {}
+
+        if not isinstance(optimization_history_obj, list):
+            optimization_history_obj = {optimization_history_obj}
+
         ret = {}
         try:
-            for opt_history in self.optimization_history_obj:
+            for opt_history in optimization_history_obj:
                 if opt_history.key in ret:
                     ret[opt_history.key].append(str(opt_history.opt_id))
                 else:

--- a/qcfractal/storage_sockets/models/sql_models.py
+++ b/qcfractal/storage_sockets/models/sql_models.py
@@ -194,7 +194,11 @@ class TaskQueueORM(Base):
     # TODO: for back-compatibility with mongo, tobe removed
     @hybrid_property
     def base_result(self):
-        return dict(ref="result", id=str(self.base_result_id))
+        return self._base_result(self.base_result_id)
+
+    @staticmethod
+    def _base_result(base_result_id):
+        return dict(ref="result", id=str(base_result_id))
         # return self.base_result_id   # todo, change to this
 
     @base_result.setter


### PR DESCRIPTION
## Description
Add exclude/include functionality in the backend Database layer
`include` is still called projection, and it takes a list (not dict), although dict works by grabbing the keys.

This works as expected. If any include (projection list) or exclude is specified, then only requested fields will be fetched/excluded.

## Status
- [x] Ready to go