### PR TITLE
Adapters: changes for parsl 0.9.0 with slurm

### DIFF
--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -36,7 +36,7 @@ dependencies:
   - dask-jobqueue>=0.5.0
   - ipyparallel
   - ipykernel
-  - parsl>=0.8.0
+  - parsl>=0.9.0
 
 # QCArchive includes
   - qcengine>=0.11.0

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -99,7 +99,7 @@ environs = [
         "filename":
         "adapters.yaml",
         "dependencies":
-        ["rdkit", "dask", "distributed", "dask-jobqueue>=0.5.0", "ipyparallel", "ipykernel", "parsl>=0.8.0"],
+        ["rdkit", "dask", "distributed", "dask-jobqueue>=0.5.0", "ipyparallel", "ipykernel", "parsl>=0.9.0"],
         "pip_dependencies": ["fireworks"]
     },
     {

--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -37,6 +37,11 @@ Deprecated Features
 - (:pr:`426`) In ``Dataset`` and ``ReactionDataset`` (``interface.collections``),
   the previously deprecated functions ``query``, ``get_history``, and ``list_history`` have been removed.
 
+Optional Dependency Changes
++++++++++++++++++++++++++++
+- (:pr:`454`) Users of the optional Parsl queue adapter are required to upgrade to Parsl v0.9.0, which fixes
+  issues that caused SLURM managers to crash.
+
 0.11.0 / 2019-10-01
 -------------------
 

--- a/docs/qcfractal/source/setup_quickstart.rst
+++ b/docs/qcfractal/source/setup_quickstart.rst
@@ -19,10 +19,10 @@ The table below lists some common use cases for QCFractal:
 .. list-table::
    :widths: 25 25 25 25
    :header-rows: 1
-   
+
    * - Use case
      - ``qcfractal-server`` location
-     - ``qcfractal-manager`` location 
+     - ``qcfractal-manager`` location
      - Recommended manager
    * - :doc:`Demonstration/Exploration <quickstart>`
      - Snowflake
@@ -49,9 +49,9 @@ The table below lists some common use cases for QCFractal:
      - Docker container
      - Pool
 
-QCFractal is highly adaptable and is not limited to the above use cases. 
+QCFractal is highly adaptable and is not limited to the above use cases.
 For example, it possible to mix local, cluster, supercomputer, and cloud :term:`Managers <Manager>` simultaneously.
-In addition, a cloud instance may provide a good option for running ``qcfractal-server`` when a persistent web-exposed server is not otherwise available. 
+In addition, a cloud instance may provide a good option for running ``qcfractal-server`` when a persistent web-exposed server is not otherwise available.
 
 Quickstart Setups
 -----------------
@@ -67,17 +67,17 @@ General guides are also available:
 Single Workstation
 ++++++++++++++++++
 
-This quickstart guide addresses QCFractal setup on a single computer which will be used for the :term:`Server`, :term:`Manager`, user client, and compute. 
+This quickstart guide addresses QCFractal setup on a single computer which will be used for the :term:`Server`, :term:`Manager`, user client, and compute.
 On the workstation, initialize the :term:`Server`::
 
-   qcfractal-server init 
+   qcfractal-server init
 
 Next, start the :term:`Server` and ProcessPoolExecutor :term:`Manager`::
 
    nohup qcfractal-server start --local-manager 1 &
 
 The second command starts ``qcfractal-server`` in the background.
-It also starts one :term:`Worker` which will pull :term:`tasks <Task>` from the :term:`Server` and run them. 
+It also starts one :term:`Worker` which will pull :term:`tasks <Task>` from the :term:`Server` and run them.
 
 Test if everything is setup by running a Hartree-Fock calculation on a single hydrogen molecule,
 as in the :doc:`quickstart` (note this requires ``psi4``):
@@ -99,7 +99,7 @@ as in the :doc:`quickstart` (note this requires ``psi4``):
    >>> print(proc)
    <ResultRecord(id='0' status='COMPLETE')>
    >>> print(proc.properties.scf_total_energy)
-   -0.6865598095254312 
+   -0.6865598095254312
 
 
 .. _quickstart-private-cluster:
@@ -107,8 +107,8 @@ as in the :doc:`quickstart` (note this requires ``psi4``):
 Private Cluster
 +++++++++++++++
 
-This quickstart guide addresses QCFractal setup on a private cluster comprising a head node and compute nodes, with a :term:`Scheduler` such as SLURM, PBS, or Torque. 
-This guide requires `Parsl <https://parsl.readthedocs.io/en/stable/quickstart.html>`_ which may be installed with ``pip``.
+This quickstart guide addresses QCFractal setup on a private cluster comprising a head node and compute nodes, with a :term:`Scheduler` such as SLURM, PBS, or Torque.
+This guide requires `Parsl <https://parsl.readthedocs.io/en/stable/quickstart.html>`_ which may be installed with ``pip`` or ``conda``.
 
 Begin by initializing the :term:`Server` on the cluster head node::
 
@@ -129,20 +129,20 @@ The :term:`Manager` must be configured before use. Create a configuration file (
     memory_per_worker: 64
     max_workers: 5
     scratch_directory: "$TMPDIR"
-   
+
    cluster:
     node_exclusivity: True
     scheduler: slurm
-   
+
    parsl:
     provider:
      partition: CLUSTER
-     cmd_timeout: 30 
+     cmd_timeout: 30
 
 You may need to modify these values to match the particulars of your cluster. In particular:
 
 * The ``scheduler`` and ``partition`` options should be set to match the details of your :term:`Scheduler` (e.g. SLURM, PBS, Torque).
-* Options related to :term:`Workers <Worker>` should be set appropriately for the compute node on your cluster. 
+* Options related to :term:`Workers <Worker>` should be set appropriately for the compute node on your cluster.
   Note that Parsl requires that full nodes be allocated to each :term:`Worker` (i.e. ``node_exclusivity: True``).
 
 For more information on :term:`Manager` configuration, see :doc:`managers` and :doc:`managers_samples`.
@@ -173,7 +173,7 @@ as in the :doc:`quickstart` (note this requires ``psi4``):
    >>> print(proc)
    <ResultRecord(id='0' status='COMPLETE')>
    >>> print(proc.properties.scf_total_energy)
-   -0.6865598095254312 
+   -0.6865598095254312
 
 
 .. _quickstart-shared-cluster:
@@ -181,24 +181,24 @@ as in the :doc:`quickstart` (note this requires ``psi4``):
 Shared Clusters, Supercomputers, and Multiple Clusters
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This quickstart guide addresses QCFractal setup on one or more shared cluster(s). 
-The :term:`Server` should be set up on a persistent server for which you have permission to expose ports. 
+This quickstart guide addresses QCFractal setup on one or more shared cluster(s).
+The :term:`Server` should be set up on a persistent server for which you have permission to expose ports.
 For example, this may be a dedicated webserver, the head node of a private cluster, or a cloud instance.
-The :term:`Manager` should be set up on each shared cluster. 
-In most cases, the :term:`Manager` may be run on the head node; 
+The :term:`Manager` should be set up on each shared cluster.
+In most cases, the :term:`Manager` may be run on the head node;
 contact your system administrator if you are unsure.
-This guide requires `Parsl <https://parsl.readthedocs.io/en/stable/quickstart.html>`_ to be installed for the :term:`Manager`. It may be installed with ``pip``.
+This guide requires `Parsl <https://parsl.readthedocs.io/en/stable/quickstart.html>`_ to be installed for the :term:`Manager`. It may be installed with ``pip`` or ``conda``.
 
 Begin by initializing the :term:`Server` on your persistent server::
 
-    qcfractal-server init 
+    qcfractal-server init
 
-The QCFractal server receives connections from :term:`Managers <Manager>` and clients on TCP port 7777. 
-You may optionally specify the ``--port`` option to choose a custom port. 
+The QCFractal server receives connections from :term:`Managers <Manager>` and clients on TCP port 7777.
+You may optionally specify the ``--port`` option to choose a custom port.
 You may need to configure your firewall to allow access to this port.
 
-Because the :term:`Server` will be exposed to the internet, 
-security should be enabled to control access. 
+Because the :term:`Server` will be exposed to the internet,
+security should be enabled to control access.
 Enable security by changing the YAML file (default: ``~/.qca/qcfractal/qcfractal_config.yaml``)
 ``fractal.security`` option to ``local``:
 
@@ -219,21 +219,21 @@ Start the :term:`Server`::
     but host verification will be unavailable
     (and :term:`Managers <Manager>` and clients will need to specify ``verify=False``).
 
-Next, add users for admin, the :term:`Manager`, and a user 
+Next, add users for admin, the :term:`Manager`, and a user
 (you may choose whatever usernames you like)::
 
    qcfractal-server user add admin --permissions admin
    qcfractal-server user add manager --permissions queue
    qcfractal-server user add user --permissions read write compute
 
-Passwords will be automatically generated and printed. You may instead specify a password with the ``--password`` option. 
+Passwords will be automatically generated and printed. You may instead specify a password with the ``--password`` option.
 See :doc:`server_user` for more information.
 
-:term:`Managers <Manager>` should be set up on each shared cluster. 
-In most cases, the :term:`Manager` may be run on the head node; 
+:term:`Managers <Manager>` should be set up on each shared cluster.
+In most cases, the :term:`Manager` may be run on the head node;
 contact your system administrator if you are unsure.
 
-The :term:`Manager` must be configured before use. 
+The :term:`Manager` must be configured before use.
 Create a configuration file (e.g. in ``~/.qca/qcfractal/my_manager.yaml``) based on the following template:
 
 .. code-block:: yaml
@@ -245,20 +245,20 @@ Create a configuration file (e.g. in ``~/.qca/qcfractal/my_manager.yaml``) based
     memory_per_worker: 64
     max_workers: 5
     scratch_directory: "$TMPDIR"
-   
+
    cluster:
     node_exclusivity: True
     scheduler: slurm
-   
+
    parsl:
     provider:
      partition: CLUSTER
-     cmd_timeout: 30 
+     cmd_timeout: 30
 
 You may need to modify these values to match the particulars of each cluster. In particular:
 
 * The ``scheduler`` and ``partition`` options should be set to match the details of your :term:`Scheduler` (e.g. SLURM, PBS, Torque).
-* Options related to :term:`Workers <Worker>` should be set appropriately for the compute node on your cluster. 
+* Options related to :term:`Workers <Worker>` should be set appropriately for the compute node on your cluster.
   Note that Parsl requires that full nodes be allocated to each :term:`Worker` (i.e. ``node_exclusivity: True``).
 
 For more information on :term:`Manager` configuration, see :doc:`managers` and :doc:`managers_samples`.
@@ -270,8 +270,8 @@ Finally, start the :term:`Manager` in the background on each cluster head node::
 If you did not specify a TLS certificate in the ``qcfractal-server start`` step, you will additionally need to specify ``--verify False`` in the above command.
 
 Test if everything is setup by running a Hartree-Fock calculation on a single hydrogen molecule,
-as in the :doc:`quickstart` 
-(note this requires ``psi4`` to be installed on at least one compute resource). 
+as in the :doc:`quickstart`
+(note this requires ``psi4`` to be installed on at least one compute resource).
 This test may be run from any machine.
 
 .. code-block:: python
@@ -292,7 +292,7 @@ This test may be run from any machine.
    >>> print(proc)
    <ResultRecord(id='0' status='COMPLETE')>
    >>> print(proc.properties.scf_total_energy)
-   -0.6865598095254312 
+   -0.6865598095254312
 
 
 
@@ -502,4 +502,4 @@ Other Use Cases
 
 QCFractal is highly configurable and supports many use cases beyond those described here.
 For more information, see the :doc:`Server <server_init>` and :doc:`Manager <managers>` documentation sections.
-You may also :ref:`contact us <work-with-us>`. 
+You may also :ref:`contact us <work-with-us>`.


### PR DESCRIPTION
## Description
This PR addresses parsl 0.9.0 (#437) in two ways:
- Parsl >=0.9.0  is now required. This version fixes two major bugs in the SlurmProvider that led to crashes.
- Our `cores_per_worker` is translated to parsl's new `SlurmProvider.cores_per_node`. `mem_per_node` is buggy (Parsl/parsl#1416). 

Resolves #437 

## Status
- [x] Changelog updated
- [x] Ready to go