### PR TITLE
Collections: Add metadata field to DataModel

### DIFF
--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -77,6 +77,8 @@ class Collection(abc.ABC):
         view_metadata: Optional[Dict[str, str]] = None
         view_available: bool = False
 
+        metadata: Optional[Dict[str, Any]] = {}
+
     def __str__(self) -> str:
         """
         A simple string representation of the Collection.

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1373,28 +1373,9 @@ def test_get_collection_no_records_ds(fractal_compute_server):
 
 def test_collection_metadata(fractal_compute_server):
     client = ptl.FractalClient(fractal_compute_server)
-    name = "test_collection_metadata"
-    ds = ptl.collections.Dataset(name, client=client)
 
-    class MlMetadata(ProtoModel):
-        data_points: int
-        elements: List[str]
-        theory_level: str
-        sampling: str
-        labels: List[str]
-
-    meta = MlMetadata(data_points=133_885,
-                      elements=['C', 'O', 'N', 'F', 'H'],
-                      theory_level="DFT",
-                      sampling="Minima",
-                      labels=[
-                          "energy", "frequency", "polarizability", "rotational constant", "homo", "lumo",
-                          "electronic spatial extent", "dipole", "zpve", "enthalpy", "free energy", "heat capacity"
-                      ])
-    ds.data.metadata.update(meta.dict())
+    ds = ptl.collections.Dataset("test_collection_metadata", client=client)
+    ds.data.metadata["data_points"] = 133_885
     ds.save()
 
-    ds_from_server = client.get_collection("dataset", name)
-    meta_from_server = MlMetadata(**ds_from_server.data.metadata)
-
-    assert meta_from_server == meta
+    assert client.get_collection("dataset", ds.name).data.metadata["data_points"] == 133_885

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -8,11 +8,11 @@ from typing import List
 
 import numpy as np
 import pytest
-
 import qcelemental as qcel
-import qcfractal.interface as ptl
 from qcelemental.models import Molecule, ProtoModel
 from qcengine.testing import is_program_new_enough
+
+import qcfractal.interface as ptl
 from qcfractal import testing
 from qcfractal.testing import df_compare, fractal_compute_server, live_fractal_or_skip
 
@@ -1379,3 +1379,11 @@ def test_collection_metadata(fractal_compute_server):
     ds.save()
 
     assert client.get_collection("dataset", ds.name).data.metadata["data_points"] == 133_885
+
+    ds = ptl.collections.Dataset("test_collection_metadata_oldstyle", client=client)
+    ds.data.__dict__["metadata"] = None
+    ds.save()
+
+    ds = client.get_collection("dataset", ds.name)
+    with pytest.raises(AttributeError):
+        ds.metadata


### PR DESCRIPTION
## Description
This PR adds a metadata field to collections. It uses the extras functionality; there is no schema migration.

## Status
- [ ] Changelog updated
- [x] Ready to go