### PR TITLE
Skip fewer tests on travis

### DIFF
--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -107,7 +107,7 @@ environs = [
         # Tests for the OpenFF toolchain (geometric and torsiondrive)
         "filename": "openff.yaml",
         "channels": ["psi4"],
-        "dependencies": ["psi4>=1.3", "rdkit", "geometric>=0.9.3", "torsiondrive"],
+        "dependencies": ["psi4>=1.3", "rdkit", "geometric>=0.9.3", "torsiondrive", "dftd3"],
     },
     {
 

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -35,6 +35,7 @@ dependencies:
   - rdkit
   - geometric>=0.9.3
   - torsiondrive
+  - dftd3
 
 # QCArchive includes
   - qcengine>=0.11.0

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -108,7 +108,7 @@ def test_cli_user_remove(qcfractal_base_init):
     assert testing.run_process(args, **_options) is False
 
 
-@pytest.mark.skip(reason="Failing on Travis for unknown reasons.")
+@pytest.mark.xfail(reason="Failing on Travis for unknown reasons.")
 @pytest.mark.slow
 def test_cli_server_local_boot(qcfractal_base_init):
     port = "--port=" + str(testing.find_open_port())


### PR DESCRIPTION
## Description
This PR seeks to reduce the number of skipped tests on travis. It turns out that many tests were getting skipped due to dftd3 not being installed.

## Status
- [ ] Changelog updated
- [x] Ready to go