### PR TITLE
Improves Molecule insert speed

### DIFF
--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -671,10 +671,6 @@ class SQLAlchemySocket:
         meta = get_metadata_template()
 
         query = format_query(MoleculeORM, id=id, molecule_hash=molecule_hash, molecular_formula=molecular_formula)
-        # query = [getattr(MoleculeORM, 'id') == id,
-        #          MoleculeORM.molecule_hash == molecule_hash,
-        #          MoleculeORM.molecular_formula == molecular_formula
-        # ]
 
         # Don't include the hash or the molecular_formula in the returned result
         rdata, meta['n_found'] = self.get_query_projection(MoleculeORM,

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -125,6 +125,7 @@ class SQLAlchemySocket:
     """
         SQLAlcehmy QCDB wrapper class.
     """
+
     def __init__(self,
                  uri: str,
                  project: str = "molssidb",
@@ -582,12 +583,13 @@ class SQLAlchemySocket:
 
         results = []
         with self.session_scope() as session:
+
+            # Build out the ORMs
             orm_molecules = []
             for dmol in molecules:
 
                 if dmol.validated is False:
                     dmol = Molecule(**dmol.dict(), validate=True)
-
 
                 mol_dict = dmol.dict(exclude={"id", "validated"})
 
@@ -609,11 +611,13 @@ class SQLAlchemySocket:
             # Check if we have duplicates
             hash_list = [x.molecule_hash for x in orm_molecules]
             query = format_query(MoleculeORM, molecule_hash=hash_list)
-            indices, match_cnt = self.get_query_projection(MoleculeORM, query, {"id"}, None, 0)
+            indices = session.query(MoleculeORM.molecule_hash, MoleculeORM.id).filter(*query)
+            previous_id_map = {k: v for k, v in indices}
 
+            # For a bulk add there must be no pre-existing and there must be no duplicates in the add list
             bulk_ok = len(hash_list) == len(set(hash_list))
-            bulk_ok &= (match_cnt == 0)
-            bulk_ok = False
+            bulk_ok &= (len(previous_id_map) == 0)
+            # bulk_ok = False
 
             if bulk_ok:
                 # Bulk save, doesn't update fields for speed
@@ -625,26 +629,38 @@ class SQLAlchemySocket:
                 indices = session.query(MoleculeORM.molecule_hash, MoleculeORM.id).filter(*query)
 
                 id_map = {k: v for k, v in indices}
-                results = [str(id_map[x.molecule_hash]) for x in orm_molecules]
+                n_inserted = len(orm_molecules)
 
-                meta['n_inserted'] = len(results)
             else:
-                for orm_mol in orm_molecules:
-                    doc = session.query(MoleculeORM.id).filter_by(molecule_hash=orm_mol.molecule_hash)
+                # Start from old ID map
+                id_map = previous_id_map
 
-                    if doc.count() == 0:
-                        session.add(orm_mol)
-                        session.commit()
-                        results.append(str(orm_mol.id))
-                        meta['n_inserted'] += 1
+                new_molecules = []
+                n_inserted = 0
+
+                for orm_mol in orm_molecules:
+                    duplicate_id = id_map.get(orm_mol.molecule_hash, False)
+                    if duplicate_id is not False:
+                        meta["duplicates"].append(str(duplicate_id))
                     else:
-                        id = str(doc.first().id)
-                        meta['duplicates'].append(id)  # TODO
-                        results.append(id)
+                        new_molecules.append(orm_mol)
+                        id_map[orm_mol.molecule_hash] = 'placeholder_id'
+                        n_inserted += 1
+                        session.add(orm_mol)
 
                     # We should make sure there was not a hash collision?
                     # new_mol.compare(old_mol)
                     # raise KeyError("!!! WARNING !!!: Hash collision detected")
+
+                session.commit()
+
+                for new_mol in new_molecules:
+                    id_map[new_mol.molecule_hash] = new_mol.id
+
+            results = [str(id_map[x.molecule_hash]) for x in orm_molecules]
+            assert 'placeholder_id' not in results
+            meta['n_inserted'] = n_inserted
+
         meta["success"] = True
 
         ret = {"data": results, "meta": meta}
@@ -1122,6 +1138,7 @@ class SQLAlchemySocket:
         -------
 
         """
+
     def get_results(self,
                     id: Union[str, List] = None,
                     program: str = None,

--- a/qcfractal/tests/test_storage.py
+++ b/qcfractal/tests/test_storage.py
@@ -15,8 +15,8 @@ from qcfractal.services.services import TorsionDriveService
 from qcfractal.storage_sockets.models.collections_models import DatasetORM
 from qcfractal.testing import sqlalchemy_socket_fixture as storage_socket
 
-bad_id1 = "000000000000000000000000"
-bad_id2 = "000000000000000000000001"
+bad_id1 = "99999000"
+bad_id2 = "99999001"
 
 
 def test_storage_repr(storage_socket):
@@ -109,24 +109,27 @@ def test_molecules_get(storage_socket):
     assert ret == 1
 
 
-# TODO: doesn't handel bad ids yet
-@pytest.mark.skip
 def test_molecules_mixed_add_get(storage_socket):
     water = ptl.data.get_molecule("water_dimer_minima.psimol")
+    water2 = ptl.data.get_molecule("water_dimer_stretch.psimol")
 
-    ret = storage_socket.get_add_molecules_mixed([bad_id1, water, bad_id2, "bad_id"])
+    del_ids = []
+    water2_id = storage_socket.add_molecules([water2])["data"][0]
+    del_ids.append(water2_id)
+
+    ret = storage_socket.get_add_molecules_mixed([bad_id1, water, bad_id2, water2_id])
     assert ret["data"][0] is None
     assert ret["data"][1].identifiers.molecule_hash == water.get_hash()
     assert ret["data"][2] is None
-    assert set(ret["meta"]["missing"]) == {0, 2, 3}
+    assert ret["data"][3].id == water2_id
+    assert set(ret["meta"]["missing"]) == {0, 2}
 
     # Cleanup adds
-    ret = storage_socket.del_molecules(id=ret["data"][1].id)
-    assert ret == 1
+    del_ids.append(ret["data"][1].id)
+    ret = storage_socket.del_molecules(id=del_ids)
+    assert ret == 2
 
 
-# TODO: doesn't handel bad ids yet
-@pytest.mark.skip
 def test_molecules_bad_get(storage_socket):
 
     water = ptl.data.get_molecule("water_dimer_minima.psimol")
@@ -136,10 +139,9 @@ def test_molecules_bad_get(storage_socket):
     water_id = ret["data"][0]
 
     # Pull molecule from the DB for tests
-    ret = storage_socket.get_molecules(id=[water_id, "something", 5, (3, 2)])
-    assert len(ret["meta"]["errors"]) == 1
-    assert ret["meta"]["errors"][0][0] == "id"
-    assert len(ret["meta"]["errors"][0][1]) == 3
+    ret = storage_socket.get_molecules(id=[water_id, bad_id1, bad_id2])
+
+    assert ret["data"][0].id == water_id
     assert ret["meta"]["n_found"] == 1
 
     # Cleanup adds
@@ -167,8 +169,6 @@ def test_keywords_add(storage_socket):
     assert 1 == storage_socket.del_keywords(id=ret_kw.id)
 
 
-# TODO: doesn't handel bad ids yet
-@pytest.mark.skip
 def test_keywords_mixed_add_get(storage_socket):
 
     opts1 = ptl.models.KeywordSet(values={"o": 5})

--- a/qcfractal/tests/test_storage.py
+++ b/qcfractal/tests/test_storage.py
@@ -109,6 +109,28 @@ def test_molecules_get(storage_socket):
     assert ret == 1
 
 
+def test_molecules_duplicate_insert(storage_socket):
+    water = ptl.data.get_molecule("water_dimer_minima.psimol")
+    water2 = ptl.data.get_molecule("water_dimer_stretch.psimol")
+
+    ret = storage_socket.add_molecules([water, water2])
+    assert ret["meta"]["n_inserted"] == 2
+
+    ret2 = storage_socket.add_molecules([water, water2])
+    assert ret2["meta"]["n_inserted"] == 0
+    assert ret["data"][0] == ret2["data"][0]
+    assert ret["data"][1] == ret2["data"][1]
+
+    ret3 = storage_socket.add_molecules([water, water])
+    assert ret2["meta"]["n_inserted"] == 0
+    assert ret["data"][0] == ret3["data"][0]
+    assert ret["data"][0] == ret3["data"][1]
+
+    # Cleanup adds
+    ret = storage_socket.del_molecules(id=ret["data"])
+    assert ret == 2
+
+
 def test_molecules_mixed_add_get(storage_socket):
     water = ptl.data.get_molecule("water_dimer_minima.psimol")
     water2 = ptl.data.get_molecule("water_dimer_stretch.psimol")


### PR DESCRIPTION
## Description
Molecule add/insert now has two modes:
1) Bulk insert where we have checked that there are no duplicates or pre-existing molecules (10-15x faster).
2) Duplicate/mixed insert which works similar to previous functionality, but based off a single commit and query rather than a commit/query per molecule (~3-4x faster).

The gains are with respect to current master.

This PR also re-enables several test that only failed due to bad ObjectID's which is to be expected.

## Status
- [ ] Changelog updated
- [x] Ready to go