### PR TITLE
Fix citation model

### DIFF
--- a/qcfractal/interface/models/common_models.py
+++ b/qcfractal/interface/models/common_models.py
@@ -200,7 +200,8 @@ class KeywordSet(ProtoModel):
 
 class Citation(ProtoModel):
     """ A literature citation.  """
-    acs_citation: str = None  # hand-formatted citation in ACS style. In the future, this could be bibtex, rendered to different formats.
+    acs_citation: Optional[
+        str] = None  # hand-formatted citation in ACS style. In the future, this could be bibtex, rendered to different formats.
     bibtex: Optional[str] = None  # bibtex blob for later use with bibtex-renderer
     doi: Optional[str] = None
     url: Optional[str] = None

--- a/qcfractal/interface/models/common_models.py
+++ b/qcfractal/interface/models/common_models.py
@@ -200,11 +200,11 @@ class KeywordSet(ProtoModel):
 
 class Citation(ProtoModel):
     """ A literature citation.  """
-    _acs_citation: str  # hand-formatted citation in ACS style. In the future, this could be bibtex, rendered to different formats.
-    _bibtex: Optional[Dict[str, str]]  # bibtex blob for later use with bibtex-renderer
-    doi: Optional[str]
-    url: Optional[str]
+    acs_citation: str = None  # hand-formatted citation in ACS style. In the future, this could be bibtex, rendered to different formats.
+    bibtex: Optional[str] = None  # bibtex blob for later use with bibtex-renderer
+    doi: Optional[str] = None
+    url: Optional[str] = None
 
     def to_acs(self) -> str:
         """ Returns an ACS-formatted citation """
-        return self._acs_citation
+        return self.acs_citation


### PR DESCRIPTION
## Description
This PR fixes the citation model:

- underscore-prefixed fields are renamed since pydantic does not treat these as fields
- everything is now optional
- bibtex is a string because unpacking it into a dictionary is too fancy

Sorry for not catching this earlier. 

## Status
- [x] Ready to go