### PR TITLE
Testing and LGTM un-regressions

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -11,11 +11,11 @@ from enum import Enum
 from math import ceil
 from typing import List, Optional
 
+import qcengine as qcng
 import tornado.log
 import yaml
 from pydantic import Field, validator
 
-import qcengine as qcng
 import qcfractal
 
 from ..interface.models import AutodocBaseSettings, ProtoModel

--- a/qcfractal/dashboard/dash_models.py
+++ b/qcfractal/dashboard/dash_models.py
@@ -1,8 +1,7 @@
+import dash_bootstrap_components as dbc
 import pandas as pd
 import plotly.graph_objs as go
 from plotly.colors import DEFAULT_PLOTLY_COLORS
-
-import dash_bootstrap_components as dbc
 
 from .connection import get_socket
 

--- a/qcfractal/dashboard/pages/landing.py
+++ b/qcfractal/dashboard/pages/landing.py
@@ -1,9 +1,8 @@
+import dash_bootstrap_components as dbc
 import dash_core_components as dcc
+import dash_coreui_components as coreui
 import pandas as pd
 from dash.dependencies import Input, Output
-
-import dash_bootstrap_components as dbc
-import dash_coreui_components as coreui
 from flask import current_app
 
 from ..app import app

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -15,9 +15,9 @@ from .models import build_procedure
 from .models.rest_models import rest_model
 
 if TYPE_CHECKING:  # pragma: no cover
-    from qcfractal import FractalServer  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    pass
 
-    from .collections.collection import Collection  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from .collections.collection import Collection
     from .models import (
         GridOptimizationInput,
         KeywordSet,
@@ -39,7 +39,7 @@ if TYPE_CHECKING:  # pragma: no cover
         ResultGETResponse,
         ServiceQueueGETResponse,
         TaskQueueGETResponse,
-    )  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    )
 
 ### Common docs
 

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -15,7 +15,7 @@ from .models import build_procedure
 from .models.rest_models import rest_model
 
 if TYPE_CHECKING:  # pragma: no cover
-    pass
+    from qcfractal import FractalServer
 
     from .collections.collection import Collection
     from .models import (

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -14,8 +14,8 @@ import pandas as pd
 from ..models import ProtoModel
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .. import FractalClient  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
-    from ..models import ObjectId  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from .. import FractalClient
+    from ..models import ObjectId
 
 
 class Collection(abc.ABC):

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -10,10 +10,9 @@ import numpy as np
 import pandas as pd
 import requests
 from pydantic import Field, validator
-from tqdm import tqdm
-
 from qcelemental import constants
 from qcelemental.models.types import Array
+from tqdm import tqdm
 
 from ..models import Citation, ComputeResponse, ObjectId, ProtoModel
 from ..statistics import wrap_statistics

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -21,7 +21,7 @@ from .collection import Collection
 from .collection_utils import composition_planner, register_collection
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .. import FractalClient  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from .. import FractalClient
     from ..models import KeywordSet, Molecule, ResultRecord
     from . import DatasetView
 

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -19,9 +19,8 @@ from .dataset import Dataset, MoleculeEntry
 from .reaction_dataset import ReactionDataset, ReactionEntry
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .. import FractalClient  # lgtm [py/unused-import]
-    from ..models.rest_models import CollectionSubresourceGETResponseMeta  # lgtm [py/unused-import]
-    import h5py  # lgtm [py/unused-import]
+    from .. import FractalClient
+    from ..models.rest_models import CollectionSubresourceGETResponseMeta
 
 
 class DatasetView(abc.ABC):

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, NoReturn, Optional,
 
 import numpy as np
 import pandas as pd
-
 from qcelemental.util.serialization import deserialize, serialize
 
 from ..models import Molecule, ObjectId

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -19,6 +19,7 @@ from .dataset import Dataset, MoleculeEntry
 from .reaction_dataset import ReactionDataset, ReactionEntry
 
 if TYPE_CHECKING:  # pragma: no cover
+    import h5py
     from .. import FractalClient
     from ..models.rest_models import CollectionSubresourceGETResponseMeta
 

--- a/qcfractal/interface/collections/gridoptimization_dataset.py
+++ b/qcfractal/interface/collections/gridoptimization_dataset.py
@@ -9,10 +9,8 @@ from .collection import BaseProcedureDataset
 from .collection_utils import register_collection
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..models.gridoptimization import (
-        ScanDimension,
-    )  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
-    from ..models import Molecule  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from ..models.gridoptimization import ScanDimension
+    from ..models import Molecule
 
 
 class GOEntry(ProtoModel):

--- a/qcfractal/interface/collections/optimization_dataset.py
+++ b/qcfractal/interface/collections/optimization_dataset.py
@@ -4,7 +4,6 @@ QCPortal Database ODM
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import pandas as pd
-
 import qcelemental as qcel
 
 from ..models import ObjectId, OptimizationSpecification, ProtoModel, QCSpecification

--- a/qcfractal/interface/collections/optimization_dataset.py
+++ b/qcfractal/interface/collections/optimization_dataset.py
@@ -11,7 +11,7 @@ from .collection import BaseProcedureDataset
 from .collection_utils import register_collection
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..models import Molecule  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from ..models import Molecule
 
 
 class OptEntry(ProtoModel):

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -15,7 +15,7 @@ from .collection_utils import nCr, register_collection
 from .dataset import Dataset
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .. import FractalClient  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from .. import FractalClient
     from ..models import ComputeResponse
 
 

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
-
 from qcelemental import constants
 
 from ..models import Molecule, ProtoModel

--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -12,7 +12,7 @@ from .collection import BaseProcedureDataset
 from .collection_utils import register_collection
 
 if TYPE_CHECKING:  # pragma: no cover
-    pass
+    from ..models import Molecule
 
 
 class TDEntry(ProtoModel):

--- a/qcfractal/interface/collections/torsiondrive_dataset.py
+++ b/qcfractal/interface/collections/torsiondrive_dataset.py
@@ -12,7 +12,7 @@ from .collection import BaseProcedureDataset
 from .collection_utils import register_collection
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..models import Molecule  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    pass
 
 
 class TDEntry(ProtoModel):

--- a/qcfractal/interface/models/common_models.py
+++ b/qcfractal/interface/models/common_models.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Any, Dict, Optional
 
 from pydantic import Field, validator
-
 from qcelemental.models import AutodocBaseSettings, Molecule, ProtoModel, Provenance
 from qcelemental.models.procedures import OptimizationProtocols
 from qcelemental.models.results import ResultProtocols

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from qcelemental.models import (
         OptimizationInput,
         ResultInput,
-    )  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    )
 
-    from .common_models import KeywordSet, Molecule  # lgtm[py/unused-import] (https://github.com/Semmle/ql/issues/2014)
+    from .common_models import KeywordSet, Molecule
 
 __all__ = ["OptimizationRecord", "ResultRecord", "OptimizationRecord", "RecordBase"]
 

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -8,9 +8,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import numpy as np
-from pydantic import Field, constr, validator
-
 import qcelemental as qcel
+from pydantic import Field, constr, validator
 
 from ..visualization import scatter_plot
 from .common_models import DriverEnum, ObjectId, ProtoModel, QCSpecification

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -7,7 +7,6 @@ import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import Field, constr, root_validator, validator
-
 from qcelemental.util import get_base_docs
 
 from .common_models import KeywordSet, Molecule, ObjectId, ProtoModel

--- a/qcfractal/interface/models/task_models.py
+++ b/qcfractal/interface/models/task_models.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import Field, validator
-
 from qcelemental.models import ComputeError
 
 from .common_models import ObjectId, ProtoModel

--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from pydantic import Field, constr, validator
-
 from qcelemental import constants
 
 from ..visualization import scatter_plot

--- a/qcfractal/interface/tests/test_molecule.py
+++ b/qcfractal/interface/tests/test_molecule.py
@@ -6,7 +6,6 @@ import json
 
 import numpy as np
 import pytest
-
 import qcelemental as qcel
 
 from . import portal as ptl

--- a/qcfractal/interface/tests/test_visualization.py
+++ b/qcfractal/interface/tests/test_visualization.py
@@ -29,7 +29,6 @@ def live_fractal_or_skip():
     except (requests.exceptions.ConnectionError, ConnectionRefusedError):
         print("Failed to connect to localhost")
         try:
-            return pytest.xfail("Until QCA is migrated to v0.12.0")
             requests.get("https://api.qcarchive.molssi.org:443", json={}, timeout=5)
             return portal.FractalClient()
         except (requests.exceptions.ConnectionError, ConnectionRefusedError):

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -10,9 +10,9 @@ import time
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import qcengine as qcng
 from pydantic import BaseModel, validator
 
-import qcengine as qcng
 from qcfractal.extras import get_information
 
 from ..interface.data import get_molecule

--- a/qcfractal/services/service_util.py
+++ b/qcfractal/services/service_util.py
@@ -7,7 +7,6 @@ import datetime
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from pydantic import validator
-
 from qcelemental.models import ComputeError
 
 from ..interface.models import ObjectId, ProtoModel

--- a/qcfractal/storage_sockets/models/sql_base.py
+++ b/qcfractal/storage_sockets/models/sql_base.py
@@ -1,3 +1,4 @@
+from qcelemental.util import msgpackext_dumps, msgpackext_loads
 from sqlalchemy import and_, inspect
 from sqlalchemy.dialects.postgresql import BYTEA
 from sqlalchemy.ext.associationproxy import ASSOCIATION_PROXY
@@ -5,8 +6,6 @@ from sqlalchemy.ext.declarative import as_declarative
 from sqlalchemy.ext.hybrid import HYBRID_PROPERTY
 from sqlalchemy.orm import object_session
 from sqlalchemy.types import TypeDecorator
-
-from qcelemental.util import msgpackext_dumps, msgpackext_loads
 
 # from sqlalchemy.ext.orderinglist import ordering_list
 # from sqlalchemy.ext.associationproxy import association_proxy

--- a/qcfractal/storage_sockets/view.py
+++ b/qcfractal/storage_sockets/view.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Union
 
 import numpy as np
 import pandas as pd
-
 from qcelemental.util.serialization import serialize
 
 from ..interface.collections import HDF5View

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -17,11 +17,10 @@ from contextlib import contextmanager
 import numpy as np
 import pandas as pd
 import pytest
-import requests
-from tornado.ioloop import IOLoop
-
 import qcengine as qcng
+import requests
 from qcelemental.models import Molecule
+from tornado.ioloop import IOLoop
 
 from .interface import FractalClient
 from .postgres_harness import PostgresHarness, TemporaryPostgres
@@ -555,7 +554,6 @@ def live_fractal_or_skip():
     except (requests.exceptions.ConnectionError, ConnectionRefusedError):
         print("Failed to connect to localhost")
         try:
-            return pytest.xfail("Until QCA is migrated to v0.12.0")
             requests.get("https://api.qcarchive.molssi.org:443", json={}, timeout=5)
             return FractalClient()
         except (requests.exceptions.ConnectionError, ConnectionRefusedError):

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -8,11 +8,11 @@ from typing import List
 
 import numpy as np
 import pytest
-
 import qcelemental as qcel
-import qcfractal.interface as ptl
 from qcelemental.models import Molecule, ProtoModel
 from qcengine.testing import is_program_new_enough
+
+import qcfractal.interface as ptl
 from qcfractal import testing
 from qcfractal.testing import df_compare, fractal_compute_server, live_fractal_or_skip
 

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -4,11 +4,11 @@ Tests the server compute capabilities.
 
 import numpy as np
 import pytest
-import requests
-
 import qcengine as qcng
-import qcfractal.interface as ptl
+import requests
 from qcelemental.util import parse_version
+
+import qcfractal.interface as ptl
 from qcfractal import testing
 from qcfractal.testing import fractal_compute_server
 

--- a/qcfractal/tests/test_storage_queries.py
+++ b/qcfractal/tests/test_storage_queries.py
@@ -6,9 +6,9 @@ import copy
 
 import numpy as np
 import pytest
+from qcelemental.util import msgpackext_dumps, msgpackext_loads
 
 import qcfractal.interface as ptl
-from qcelemental.util import msgpackext_dumps, msgpackext_loads
 from qcfractal.interface.models import GridOptimizationInput, Molecule, TorsionDriveInput
 from qcfractal.testing import fractal_compute_server, recursive_dict_merge, using_geometric, using_rdkit
 

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -5,7 +5,6 @@ import json
 
 import tornado.web
 from pydantic import ValidationError
-
 from qcelemental.util import deserialize, serialize
 
 from .interface.models.rest_models import rest_model


### PR DESCRIPTION
## Description
This PR:
1) Removes the xfail from tests involving the QCA server now that it is updated to >=0.12.0. 
2) Runs `make format`
3) Removes `LGTM py/unused-import` annotations since Semmle/ql#2014 is resolved.

## Changelog description
This PR does not need a change log line.

## Status
- [x] Ready to go
