### PR TITLE
Improve ALCF and Parsl Support

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -198,6 +198,7 @@ class SchedulerEnum(str, Enum):
     sge = "sge"
     moab = "moab"
     lsf = "lsf"
+    cobalt = "cobalt"
 
 
 class AdaptiveCluster(str, Enum):
@@ -792,6 +793,7 @@ def main(args=None):
             "pbs": "TorqueProvider",
             "moab": "TorqueProvider",
             "sge": "GridEngineProvider",
+            "cobalt": "CobaltProvider",
             "lsf": None,
         }
 
@@ -799,7 +801,8 @@ def main(args=None):
             raise ValueError(f"Parsl does not know how to handle cluster of type {settings.cluster.scheduler}.")
 
         # Headers
-        _provider_headers = {"slurm": "#SBATCH", "pbs": "#PBS", "moab": "#PBS", "sge": "#$$", "lsf": None}
+        _provider_headers = {"slurm": "#SBATCH", "pbs": "#PBS", "moab": "#PBS",
+                             "sge": "#$$", "lsf": None, "cobalt": "#COBALT"}
 
         # Import the parsl things we need
         try:

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -421,7 +421,7 @@ class ParslLauncherSettings(AutodocBaseSettings):
         return launcher(**self.dict(exclude={"launcher_class"}))
 
     class Config(SettingsCommonConfig):
-        pass
+        extra = "allow"
 
 
 class ParslProviderSettings(SettingsBlocker):


### PR DESCRIPTION
## Description
Improves support for running tasks at ALCF with Parsl

Specific changes include:
- Adding support for Cobalt scheduler to Parsl adapters
- task_per_worker now maps to "max_workers" on the HTEx Parsl executor, which properly controls the number of concurrent tasks per worker
- Parsl provider sets the number of nodes per block, which makes it possible to request >1 node per job
- The maximum number of "blocks" requested by the Parsl provider is now set by the maximum number of workers and the number of nodes per block (which defines the number of workers per block)

## Changelog description
Improves support for Parsl at Argonne Leadership Computer Facility

## Status
- [x] Ready to go. I have tested this on Theta, not sure if I need more tests for the CI
