### PR TITLE
Dataset: add support for gzipped datasets

### DIFF
--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1069,13 +1069,23 @@ def test_s22_view_identical(s22_fixture):
 
 @pytest.mark.slow
 def test_view_download_remote(s22_fixture):
-    client, ds = s22_fixture
+    _, ds = s22_fixture
 
     ds.data.__dict__["view_url_hdf5"] = "https://github.com/mattwelborn/QCArchiveViews/raw/master/S22/latest.hdf5"
     ds.data.__dict__["view_metadata"] = {
         "blake2b_checksum": "f9d537a982f63af0c500753b0e4779604252b9289fa26b6d83b657bf6e1039f1af2e44bbc819001fb857f1602280892b48422b8649cea786cdec3d2eb73412a9"
     }
-    ds.download()  # 700 kb
+    ds.download()  # 800 kb
+
+    _, dsgz = s22_fixture
+
+    dsgz.data.__dict__["view_url_hdf5"] = "https://github.com/mattwelborn/QCArchiveViews/raw/master/S22/latest.hdf5.gz"
+    dsgz.data.__dict__["view_metadata"] = {
+        "blake2b_checksum": "1c531140d746c415c0c0de604bcbc5f803dced7dfd311d4590563b6ed16f86ec0766e9c76f4f093e11222de5a1286ef1df11119c11eb37f08bfb4855c7b99167"
+    }
+    dsgz.download()  # 90 kb
+
+    assert ds._view.hash() == dsgz._view.hash()
 
 
 def test_view_download_mock(gradient_dataset_fixture, tmp_path_factory):


### PR DESCRIPTION
## Description
This PR adds support for `dataset.download()`-ing gzipped dataset views, resolving issue #479.

## Changelog description
Added gzip support to `Dataset.download()`.

## Status
- [x] Ready to go
