### PR TITLE
Dataset: compute checksum after unzip

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -100,8 +100,7 @@ class CommonManagerSettings(AutodocBaseSettings):
         "otherwise, defaults are all used for any logger.",
     )
     nodes_per_job: int = Field(
-        1,
-        description="The number of nodes to request per job. Only used by the Parsl adapter at present"
+        1, description="The number of nodes to request per job. Only used by the Parsl adapter at present"
     )
 
     class Config(SettingsCommonConfig):
@@ -447,9 +446,8 @@ class ParslProviderSettings(SettingsBlocker):
     """
 
     def __init__(self, **kwargs):
-        if 'max_blocks' in kwargs:
-            raise ValueError('``max_blocks`` is set based on ``common.max_workers`` '
-                             'and ``common.nodes_per_job``')
+        if "max_blocks" in kwargs:
+            raise ValueError("``max_blocks`` is set based on ``common.max_workers`` " "and ``common.nodes_per_job``")
         super().__init__(**kwargs)
 
     partition: str = Field(
@@ -721,7 +719,7 @@ def main(args=None):
 
         # Error if the number of nodes per jobs is more than 1
         if settings.common.nodes_per_job > 1:
-            raise ValueError('Pool adapters only run on a single local node')
+            raise ValueError("Pool adapters only run on a single local node")
         queue_client = ProcessPoolExecutor(max_workers=settings.common.tasks_per_worker)
 
     elif settings.common.adapter == "dask":
@@ -737,7 +735,7 @@ def main(args=None):
 
         # Error if the number of nodes per jobs is more than 1
         if settings.common.nodes_per_job > 1:
-            raise NotImplementedError('Support for >1 node per job is not yet supported by QCFractal + Dask')
+            raise NotImplementedError("Support for >1 node per job is not yet supported by QCFractal + Dask")
             # TODO (wardlt): Implement multinode jobs in Dask
 
         _cluster_loaders = {
@@ -820,8 +818,14 @@ def main(args=None):
             raise ValueError(f"Parsl does not know how to handle cluster of type {settings.cluster.scheduler}.")
 
         # Headers
-        _provider_headers = {"slurm": "#SBATCH", "pbs": "#PBS", "moab": "#PBS",
-                             "sge": "#$$", "lsf": None, "cobalt": "#COBALT"}
+        _provider_headers = {
+            "slurm": "#SBATCH",
+            "pbs": "#PBS",
+            "moab": "#PBS",
+            "sge": "#$$",
+            "lsf": None,
+            "cobalt": "#COBALT",
+        }
 
         # Import the parsl things we need
         try:
@@ -851,7 +855,7 @@ def main(args=None):
 
         # Determine the maximum number of blocks
         if settings.common.max_workers % settings.common.nodes_per_job != 0:
-            raise ValueError(f'Maximum number of workers needs to be a multiple of the number of nodes per job.')
+            raise ValueError(f"Maximum number of workers needs to be a multiple of the number of nodes per job.")
         max_blocks = settings.common.max_workers // settings.common.nodes_per_job
 
         # Create one construct to quickly merge dicts with a final check

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -484,7 +484,7 @@ class FractalClient(object):
         aslist: bool = False,
         group: Optional[str] = "default",
         show_hidden: bool = False,
-        tag: Optional[Union[str, List[str]]] = None
+        tag: Optional[Union[str, List[str]]] = None,
     ) -> pd.DataFrame:
         """Lists the available collections currently on the server.
 
@@ -531,7 +531,7 @@ class FractalClient(object):
             if isinstance(tag, str):
                 tag = [tag]
             tag = {t.lower() for t in tag}
-            df = df[df.apply(lambda x: len({t.lower() for t in x['tags']} & tag) > 0, axis=1)]
+            df = df[df.apply(lambda x: len({t.lower() for t in x["tags"]} & tag) > 0, axis=1)]
 
         df.drop(["visibility", "group", "tags"], axis=1, inplace=True)
         if not aslist:

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -198,14 +198,6 @@ class Dataset(Collection):
                 if pbar is not None:
                     pbar.update(chunk_size)
 
-        if verify:
-            remote_checksum = self.data.view_metadata["blake2b_checksum"]
-            from . import HDF5View
-
-            local_checksum = HDF5View(local_path).hash()
-            if remote_checksum != local_checksum:
-                raise ValueError(f"Checksum verification failed. Expected: {remote_checksum}, Got: {local_checksum}")
-
         with open(local_path, "rb") as f:
             magic = f.read(2)
             gzipped = magic == b"\x1f\x8b"
@@ -216,6 +208,14 @@ class Dataset(Collection):
                     f.write(fgz.read())
             self._view_tempfile = extract_tempfile
             local_path = self._view_tempfile.name
+
+        if verify:
+            remote_checksum = self.data.view_metadata["blake2b_checksum"]
+            from . import HDF5View
+
+            local_checksum = HDF5View(local_path).hash()
+            if remote_checksum != local_checksum:
+                raise ValueError(f"Checksum verification failed. Expected: {remote_checksum}, Got: {local_checksum}")
 
         self.set_view(local_path)
 

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -113,7 +113,6 @@ class RecordBase(ProtoModel, abc.ABC):
     def check_program(cls, v):
         return v.lower()
 
-
     def __init__(self, **data):
 
         # Set datetime defaults if not automatically available

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1081,7 +1081,7 @@ def test_view_download_remote(s22_fixture):
 
     dsgz.data.__dict__["view_url_hdf5"] = "https://github.com/mattwelborn/QCArchiveViews/raw/master/S22/latest.hdf5.gz"
     dsgz.data.__dict__["view_metadata"] = {
-        "blake2b_checksum": "1c531140d746c415c0c0de604bcbc5f803dced7dfd311d4590563b6ed16f86ec0766e9c76f4f093e11222de5a1286ef1df11119c11eb37f08bfb4855c7b99167"
+        "blake2b_checksum": "f9d537a982f63af0c500753b0e4779604252b9289fa26b6d83b657bf6e1039f1af2e44bbc819001fb857f1602280892b48422b8649cea786cdec3d2eb73412a9"
     }
     dsgz.download()  # 90 kb
 


### PR DESCRIPTION
## Description
This PR makes dataset.download verify the checksum after unzipping hdf5 views. This will allow us to change between compressed and uncompressed views and compression algorithms without updating the checksum. 

## Changelog description
No changelog needed.

## Status
- [ ] Ready to go
