### PR TITLE
Storage: fix bug where limit=0 caused max_limit results to be returned

### DIFF
--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -306,7 +306,7 @@ class SQLAlchemySocket:
          SQLAlchemySocket.max_limit then the max_limit will be returned instead.
         """
 
-        return limit if limit and limit < self._max_limit else self._max_limit
+        return limit if limit is not None and limit < self._max_limit else self._max_limit
 
     def get_query_projection(self, className, query, *, limit=None, skip=0, include=None, exclude=None):
 

--- a/qcfractal/tests/test_storage.py
+++ b/qcfractal/tests/test_storage.py
@@ -612,6 +612,10 @@ def test_results_get_total(storage_results):
     assert 6 == len(storage_results.get_results()["data"])
 
 
+def test_results_get_0(storage_results):
+    assert 0 == len(storage_results.get_results(limit=0)["data"])
+
+
 def test_get_results_by_ids(storage_results):
     results = storage_results.get_results()["data"]
     ids = [x["id"] for x in results]


### PR DESCRIPTION
## Description
This PR fixes a bug where `limit=0` caused `max_limit` results to be returned. Resolves #489.

## Changelog description
Fixed a bug in FractalClient where passing `limit=0` to `query_{molecules,results,etc.}` caused the maximum number of results to be returned, rather than 0.

## Status
- [ ] Ready to go
