### PR TITLE
torsiondrive: fix get_history for big procedures

### DIFF
--- a/qcfractal/interface/models/torsiondrive.py
+++ b/qcfractal/interface/models/torsiondrive.py
@@ -228,7 +228,9 @@ class TorsionDriveRecord(RecordBase):
 
             # Grab procedures
             needed_ids = [x for v in self.optimization_history.values() for x in v]
-            objects = self.client.query_procedures(id=needed_ids)
+            objects = []
+            for i in range(0, len(needed_ids), self.client.query_limit):
+                objects.extend(self.client.query_procedures(id=needed_ids[i : i + self.client.query_limit]))
             procedures = {v.id: v for v in objects}
 
             # Move procedures into the correct order


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR fixes TorsiondriveRecord.get_history when there are more procedure objects than client.query limit. Resolves #484. @ChayaSt 

## Changelog description
Fixed an issue that could arise when `detailed_status()` was called on `TorsiondriveRecord`s for large molecules.

## Status
- [x] Ready to go
