### PR TITLE
Adds support for node parallel tasks

### DIFF
--- a/docs/qcfractal/source/index.rst
+++ b/docs/qcfractal/source/index.rst
@@ -124,6 +124,7 @@ Setting up and running Fractal's Queue Managers on your system.
 
 * :doc:`managers`
 * :doc:`managers_config_api`
+* :doc:`managers_hpc`
 * :doc:`managers_samples`
 * :doc:`managers_faq`
 

--- a/docs/qcfractal/source/managers_hpc.rst
+++ b/docs/qcfractal/source/managers_hpc.rst
@@ -1,0 +1,43 @@
+Queue Managers for High-Performance Computing
+=============================================
+
+High-performance computing (HPC) clusters are designed to complete highly-parallel tasks in a short time.
+Properly leverging such clusters requires utilizing large numbers of compute nodes at the same time,
+which requires special configurations for the QCFractal manager.
+This part of the guide details several routes for configuring HPC clusters to use either large numbers
+tasks that each use only a single node, or deploying a smaller number of tasks that use
+multiple nodes.
+
+*Note*: This guide is currently limited to using the Parsl adapter and contains some configuration
+options which do not work with other adapters.
+
+Many Nodes per Job, Single Node per Application
+-----------------------------------------------
+
+The recommended configuration for a QCFractal manager to use multi-node Jobs with
+tasks limited to a single node is launch many workers for a single Job.
+
+The Parsl adapter deploys a single ``interchange'' per Job and uses the HPC systems's
+MPI task launcher to deploy the workers.
+The interchange will run on the login or batch node (depending on the cluster's configuration)
+once the Job is started and will communicate to the workers using Parsl's ØMQ messaging protocol.
+The QCFractal QueueManager will only need to Parsl interchange and not any of the workers.
+
+See the `example page <manager_samples.html>` for details on how to configure Parsl for your system.
+The configuration setting ``common.nodes_per_job`` defines the ability to make multi-node allocation
+requests to a scheduler via an Adapter.
+
+Many Nodes per Job, More Than one Node Per Application
+------------------------------------------------------
+
+The recommended configuration for using node-parallel tasks is to have a single QCFractal worker
+running on the batch node, and using that worker to launch MPI tasks on the compute nodes.
+The differentiating aspect of deploying multi-node tasks is that the QCFractal Worker and
+QCEngine Python process will run on different nodes than the quantum chemistry code.
+
+The Parsl implementation for multi-node jobs will a single worker and Parsl interchange
+running on the login or batch node.
+The worker will call the MPI launching system to place quantum-chemistry calculations on
+to the compute nodes of the clusters and run many tasks in parallel.
+
+

--- a/docs/qcfractal/source/managers_hpc.rst
+++ b/docs/qcfractal/source/managers_hpc.rst
@@ -2,7 +2,7 @@ Queue Managers for High-Performance Computing
 =============================================
 
 High-performance computing (HPC) clusters are designed to complete highly-parallel tasks in a short time.
-Properly leverging such clusters requires utilizing large numbers of compute nodes at the same time,
+Properly leveraging such clusters requires utilizing large numbers of compute nodes at the same time,
 which requires special configurations for the QCFractal manager.
 This part of the guide details several routes for configuring HPC clusters to use either large numbers
 tasks that each use only a single node, or deploying a smaller number of tasks that use
@@ -17,17 +17,19 @@ Many Nodes per Job, Single Node per Application
 The recommended configuration for a QCFractal manager to use multi-node Jobs with
 tasks limited to a single node is launch many workers for a single Job.
 
-The Parsl adapter deploys a single ``interchange'' per Job and uses the HPC systems's
-MPI task launcher to deploy the workers.
-The interchange will run on the login or batch node (depending on the cluster's configuration)
+The Parsl adapter deploys a single ``manager'' per Job and uses the HPC systems's
+MPI task launcher to deploy the Parsl executors on to the compute nodes.
+Each "executor" will run a single Python process per QCEngine worker and can run
+more than one worker per node.
+The ``manager`` will run on the login or batch node (depending on the cluster's configuration)
 once the Job is started and will communicate to the workers using Parsl's ØMQ messaging protocol.
-The QCFractal QueueManager will only need to Parsl interchange and not any of the workers.
+The QCFractal QueueManager will only need to Parsl manager and not any of the workers.
 
-See the `example page <manager_samples.html>` for details on how to configure Parsl for your system.
+See the `example page <manager_samples.html>`_ for details on how to configure Parsl for your system.
 The configuration setting ``common.nodes_per_job`` defines the ability to make multi-node allocation
 requests to a scheduler via an Adapter.
 
-Many Nodes per Job, More Than one Node Per Application
+Many Nodes per Job, More than One Node per Application
 ------------------------------------------------------
 
 The recommended configuration for using node-parallel tasks is to have a single QCFractal worker
@@ -35,9 +37,11 @@ running on the batch node, and using that worker to launch MPI tasks on the comp
 The differentiating aspect of deploying multi-node tasks is that the QCFractal Worker and
 QCEngine Python process will run on different nodes than the quantum chemistry code.
 
-The Parsl implementation for multi-node jobs will a single worker and Parsl interchange
-running on the login or batch node.
-The worker will call the MPI launching system to place quantum-chemistry calculations on
-to the compute nodes of the clusters and run many tasks in parallel.
+The Parsl implementation for multi-node jobs will place a Parsl single executor and interchange
+on the login/batch node.
+The Parsl executor will launch a number of workers (as separate Python processes)
+equal to the number of nodes per Job divided by the number of nodes per Task.
+The worker will call the MPI launch system to place quantum-chemistry calculations on
+the compute nodes of the clusters.
 
-
+See the `example page <manager_samples.html>`_ for details on how to configure Parsl for your system.

--- a/docs/qcfractal/source/managers_samples.rst
+++ b/docs/qcfractal/source/managers_samples.rst
@@ -203,7 +203,7 @@ This example also uses Parsl and sets a scratch directory.
 Single Job with Multiple Nodes and Single-Node Tasks with Parsl Adapter
 -----------------------------------------------------------------------
 
-Many supercomputing clusters prefer or require more than one node per Job request.
+Leadership platforms prefer or require more than one node per Job request.
 The following command will request a Job with 256 nodes and place one Worker on each node.
 
 .. code-block:: yaml
@@ -211,7 +211,7 @@ The following command will request a Job with 256 nodes and place one Worker on 
         adapter: parsl
         tasks_per_worker: 1
         cores_per_worker: 64  # Number of cores per compute node
-        max_workers: 256  # Maximum number of workres deployed to compute nodes
+        max_workers: 256  # Maximum number of workers deployed to compute nodes
         nodes_per_job: 256
 
     cluster:
@@ -228,7 +228,7 @@ The following command will request a Job with 256 nodes and place one Worker on 
             queue: default
             launcher:  # Defines the MPI launching function
                 launcher_class: AprunLauncher
-                overrides: -d 64
+                overrides: -d 64  # Option for XC40 machines, allows workers to access 64 threads
             init_blocks: 0
             min_blocks: 0
             account: CSC249ADCD08
@@ -282,6 +282,9 @@ The configuration that describes how to launch the tasks must be written at a ``
 file. See `QCEngine docs<https://qcengine.readthedocs.io/en/stable/environment.html>`_
 for possible locations to place the ``qcengine.yaml`` file and full descriptions of the
 configuration option.
+One key option for the ``qcengine.yaml`` file is the description of how to launch MPI
+tasks, ``mpiexec_command``. For example, many systems use ``mpirun``
+(e.g., `OpenMPI <https://www.open-mpi.org/doc/v4.0/man1/mpirun.1.php>`_).
 An example configuration a Cray supercomputer is:
 
 .. code-block:: yaml
@@ -289,7 +292,7 @@ An example configuration a Cray supercomputer is:
       hostname_pattern: "*"
       scratch_directory: ./scratch  # Must be on the global filesystem
       is_batch_node: True  # Indicates that `aprun` must be used for all QC code invocations
-      mpirun_command: "aprun -n {total_ranks} -N {ranks_per_node} -C -cc depth --env CRAY_OMP_CHECK_AFFINITY=TRUE --env OMP_NUM_THREADS=4 --env MKL_NUM_THREADS=4
+      mpiexec_command: "aprun -n {total_ranks} -N {ranks_per_node} -C -cc depth --env CRAY_OMP_CHECK_AFFINITY=TRUE --env OMP_NUM_THREADS=4 --env MKL_NUM_THREADS=4
       -d 4 -j 1"
       jobs_per_node: 1
       ncores: 64

--- a/docs/qcfractal/source/managers_samples.rst
+++ b/docs/qcfractal/source/managers_samples.rst
@@ -198,3 +198,98 @@ This example also uses Parsl and sets a scratch directory.
      provider:
       partition: normal_q
       cmd_timeout: 30
+
+
+Single Job with Multiple Nodes and Single-Node Tasks with Parsl Adapter
+-----------------------------------------------------------------------
+
+Many supercomputing clusters prefer or require more than one node per Job request.
+The following command will request a Job with 256 nodes and place one Worker on each node.
+
+.. code-block:: yaml
+    common:
+        adapter: parsl
+        tasks_per_worker: 1
+        cores_per_worker: 64  # Number of cores per compute node
+        max_workers: 256  # Maximum number of workres deployed to compute nodes
+        nodes_per_job: 256
+
+    cluster:
+        node_exclusivity: true
+        task_startup_commands:
+            - module load miniconda-3/latest  # You will need to load the Python environment on startup
+            - source activate qcfractal
+            - export KMP_AFFINITY=disable  # KNL-related issue. Needed for multithreaded apps
+            - export PATH=~/software/psi4/bin:$PATH  # Points to psi4 compiled for compute nodes
+        scheduler: cobalt  # Varies depending on supercomputing center
+
+    parsl:
+        provider:
+            queue: default
+            launcher:  # Defines the MPI launching function
+                launcher_class: AprunLauncher
+                overrides: -d 64
+            init_blocks: 0
+            min_blocks: 0
+            account: CSC249ADCD08
+            cmd_timeout: 60
+            walltime: "3:00:00"
+
+Consult the `Parsl configuration docs <https://parsl.readthedocs.io/en/stable/userguide/configuring.html>`_
+for information on how to configure the Launcher and Provider classes for your cluster.
+
+
+Single Job with Multiple, Node-Parallel Tasks with Parsl Adapter
+---------------------------------------------------------------
+
+Running MPI-parallel tasks requires a similar configuration to the multiple nodes per job
+for the manager and also some extra work in defining the qcengine environment.
+The only difference between the multi-node manager and worker is that the ``nodes_per_job``
+is set to more than one and Parsl uses ``SimpleLauncher`` to deploy a Parsl executor onto
+the batch/login node once a job is allocated.
+
+.. code-block:: yaml
+    common:
+        adapter: parsl
+        tasks_per_worker: 1
+        cores_per_worker: 16  # Number of cores used each compute node
+        max_workers: 128
+        memory_per_worker: 180  # Summary for the amount per compute node
+        nodes_per_job: 128
+        nodes_per_task: 2
+
+    cluster:
+        node_exclusivity: true
+        task_startup_commands:
+            - module load miniconda-3/latest
+            - source activate qcfractal
+            - export PATH="/soft/applications/nwchem/6.8/bin/:$PATH"
+            - which nwchem
+        scheduler: cobalt
+
+    parsl:
+        provider:
+            queue: default
+            launcher:
+                launcher_class: SimpleLauncher
+            init_blocks: 0
+            min_blocks: 0
+            account: CSC249ADCD08
+            cmd_timeout: 60
+            walltime: "0:30:00"
+
+The configuration that describes how to launch the tasks must be written at a ``qcengine.yaml``
+file. See `QCEngine docs<https://qcengine.readthedocs.io/en/stable/environment.html>`_
+for possible locations to place the ``qcengine.yaml`` file and full descriptions of the
+configuration option.
+An example configuration a Cray supercomputer is:
+
+.. code-block:: yaml
+    all:
+      hostname_pattern: "*"
+      scratch_directory: ./scratch  # Must be on the global filesystem
+      is_batch_node: True  # Indicates that `aprun` must be used for all QC code invocations
+      mpirun_command: "aprun -n {total_ranks} -N {ranks_per_node} -C -cc depth --env CRAY_OMP_CHECK_AFFINITY=TRUE --env OMP_NUM_THREADS=4 --env MKL_NUM_THREADS=4
+      -d 4 -j 1"
+      jobs_per_node: 1
+      ncores: 64

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -861,6 +861,8 @@ def main(args=None):
         # Determine the maximum number of blocks
         # TODO (wardlt): Assumes that user does not set aside a compute node for the adapter
         max_nodes = settings.common.max_workers * settings.common.nodes_per_task
+        if settings.common.nodes_per_job > max_nodes:
+            raise ValueError("Number of nodes per job is more than the maximum number of nodes used by manager")
         if max_nodes % settings.common.nodes_per_job != 0:
             raise ValueError("Maximum number of nodes (maximum number of workers times nodes per task) "
                              "needs to be a multiple of the number of nodes per job")

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -859,9 +859,14 @@ def main(args=None):
         # Setup the providers
 
         # Determine the maximum number of blocks
-        if settings.common.max_workers % settings.common.nodes_per_job != 0:
-            raise ValueError(f"Maximum number of workers needs to be a multiple of the number of nodes per job.")
-        max_blocks = settings.common.max_workers // settings.common.nodes_per_job
+        # TODO (wardlt): Assumes that user does not set aside a compute node for the adapter
+        max_nodes = settings.common.max_workers * settings.common.nodes_per_task
+        if max_nodes % settings.common.nodes_per_job != 0:
+            raise ValueError("Maximum number of nodes (maximum number of workers times nodes per task) "
+                             "needs to be a multiple of the number of nodes per job")
+        if settings.common.nodes_per_job % settings.common.nodes_per_task != 0:
+            raise ValueError("Number of nodes per job needs to be a multiple of the number of nodes per task")
+        max_blocks = max_nodes // settings.common.nodes_per_job
 
         # Create one construct to quickly merge dicts with a final check
         common_parsl_provider_construct = {

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -938,7 +938,8 @@ def main(args=None):
                 **settings.parsl.executor.dict(skip_defaults=True),
             }
 
-        queue_client = Config(executors=[HighThroughputExecutor(**parsl_executor_construct)])
+        queue_client = Config(retries=settings.common.retries,
+                              executors=[HighThroughputExecutor(**parsl_executor_construct)])
 
     else:
         raise KeyError(

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -100,7 +100,12 @@ class CommonManagerSettings(AutodocBaseSettings):
         "otherwise, defaults are all used for any logger.",
     )
     nodes_per_job: int = Field(
-        1, description="The number of nodes to request per job. Only used by the Parsl adapter at present"
+        1, description="The number of nodes to request per job. Only used by the Parsl adapter at present",
+        gt=0
+    )
+    nodes_per_task: int = Field(
+        1, description="The number of nodes to use for each tasks. Only relevant for node-parallel executables.",
+        gt=0
     )
 
     class Config(SettingsCommonConfig):
@@ -924,6 +929,7 @@ def main(args=None):
         update_frequency=settings.manager.update_frequency,
         cores_per_task=cores_per_task,
         memory_per_task=memory_per_task,
+        nodes_per_task=settings.common.nodes_per_task,
         scratch_directory=settings.common.scratch_directory,
         retries=settings.common.retries,
         verbose=settings.common.verbose,

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import time
 
+from typing import Dict, Any
 import pytest
 import yaml
 
@@ -214,7 +215,7 @@ def cli_manager_runs(config_data, tmp_path):
 
 
 @pytest.mark.slow
-def load_manager_config(adapter, scheduler) -> dict:
+def load_manager_config(adapter, scheduler) -> Dict[str, Any]:
     config = read_config_file(os.path.join(_pwd, "manager_boot_template.yaml"))
     config["common"]["adapter"] = adapter
     config["cluster"]["scheduler"] = scheduler

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -13,6 +13,8 @@ from qcfractal import testing
 from qcfractal.cli.cli_utils import read_config_file
 
 # def _run_tests()
+from qcfractal.cli.qcfractal_manager import ManagerSettings
+
 _options = {"coverage": True, "dump_stdout": True}
 _pwd = os.path.dirname(os.path.abspath(__file__))
 
@@ -212,7 +214,7 @@ def cli_manager_runs(config_data, tmp_path):
 
 
 @pytest.mark.slow
-def load_manager_config(adapter, scheduler):
+def load_manager_config(adapter, scheduler) -> dict:
     config = read_config_file(os.path.join(_pwd, "manager_boot_template.yaml"))
     config["common"]["adapter"] = adapter
     config["cluster"]["scheduler"] = scheduler
@@ -296,3 +298,11 @@ def test_cli_managers_skel(tmp_path):
     config = tmp_path / "config.yaml"
     args = ["qcfractal-manager", "--skel", config.as_posix()]
     testing.run_process(args, **_options)
+
+
+def test_nodeparallel_tasks(tmp_path):
+    """Make sure that it boots up properly"""
+    config = load_manager_config("parsl", "cobalt")
+    config['common']['nodes_per_task'] = 2
+    config['common']['nodes_per_job'] = 2
+    cli_manager_runs(config, tmp_path)

--- a/qcfractal/queue/base_adapter.py
+++ b/qcfractal/queue/base_adapter.py
@@ -123,7 +123,7 @@ class BaseAdapter(abc.ABC):
         if self.retries is not None:
             local_options["retries"] = self.retries
         if self.nodes_per_task is not None:
-            local_options["nodes_per_task"] = self.nodes_per_task
+            local_options["nnodes"] = self.nodes_per_task
         return local_options
 
     def submit_tasks(self, tasks: List[Dict[str, Any]]) -> List[str]:

--- a/qcfractal/queue/base_adapter.py
+++ b/qcfractal/queue/base_adapter.py
@@ -22,6 +22,7 @@ class BaseAdapter(abc.ABC):
         scratch_directory: Optional[str] = None,
         retries: Optional[int] = 2,
         verbose: bool = False,
+        nodes_per_task: int = 1,
         **kwargs,
     ):
         """
@@ -50,6 +51,8 @@ class BaseAdapter(abc.ABC):
             Number of retries that QCEngine will attempt for RandomErrors detected when running
             its computations. After this many attempts (or on any other type of error), the
             error will be raised.
+        nodes_per_task : int, optional, Default:  1
+            Number of nodes to allocate per task. Default is to use a single node per task
         verbose: bool, Default: True
             Increase verbosity of the logger
         """
@@ -60,6 +63,7 @@ class BaseAdapter(abc.ABC):
         self.function_map = {}
         self.cores_per_task = cores_per_task
         self.memory_per_task = memory_per_task
+        self.nodes_per_task = nodes_per_task
         self.scratch_directory = scratch_directory
         self.retries = retries
         self.verbose = verbose
@@ -118,6 +122,8 @@ class BaseAdapter(abc.ABC):
             local_options["scratch_directory"] = self.scratch_directory
         if self.retries is not None:
             local_options["retries"] = self.retries
+        if self.nodes_per_task is not None:
+            local_options["nodes_per_task"] = self.nodes_per_task
         return local_options
 
     def submit_tasks(self, tasks: List[Dict[str, Any]]) -> List[str]:

--- a/qcfractal/tests/test_adapters.py
+++ b/qcfractal/tests/test_adapters.py
@@ -164,4 +164,4 @@ def test_node_parallel(adapter_client_fixture, caplog):
     assert "Program rdkit is not node parallel" in caplog.text
 
     # Check that ``nnodes`` is set in local properties
-    assert manager.queue_adapter.qcengine_local_options.get('nodes_per_task') == 2
+    assert manager.queue_adapter.qcengine_local_options.get('nnodes') == 2


### PR DESCRIPTION
## Description
Initial support for node parallel tasks, which is a product of a few different changes:

- Allowed ability to specify that a manager should exclusively deploy node parallel tasks
- Implemented a strategy for using Parsl to launch tasks from the batch nodes
- Added nodes_per_task configuration to the BaseAdapter and node count to the task configuration set to QCEngine workers

A description of the implementation has also been added to the docs. I'll leave off recounting that information here as a test for whether the docs make sense.

## Changelog description
Initial support for node parallel tasks

## Status
- [ ] Ready to go
