### PR TITLE
Docker: add gcp to qcarchive_worker_openff and switch to stable psi

### DIFF
--- a/devtools/docker/qcarchive_worker_openff/Dockerfile
+++ b/devtools/docker/qcarchive_worker_openff/Dockerfile
@@ -1,5 +1,5 @@
 FROM continuumio/miniconda3
-RUN conda install -c psi4/label/dev -c conda-forge psi4 dftd3 mp2d qcengine qcfractal rdkit geometric pytest
+RUN conda install -c psi4 -c conda-forge psi4 dftd3 gcp qcengine qcfractal rdkit geometric pytest
 RUN groupadd -g 999 qcfractal && \
     useradd -m -r -u 999 -g qcfractal qcfractal
 USER qcfractal


### PR DESCRIPTION
## Description
This PR adds gcp to the qcarchive_worker_openff docker image.

## Changelog description
(Probably not needed.)

## Status
- [ ] Ready to go
