### PR TITLE
Allow empty body in http requests

### DIFF
--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -391,7 +391,6 @@ class QueueManager:
             response = {"nshutdown": 0, "success": False}
             shutdown_string = "Shutdown was not successful, {} tasks not returned."
 
-
         nshutdown = response["nshutdown"]
         if self.n_stale_jobs:
             shutdown_string = shutdown_string.format(

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -348,7 +348,7 @@ def postgres_server():
 
     storage = None
     psql = PostgresHarness({"database": {"port": 5432}})
-    # psql = PostgresHarness({"database": {"port": 5432, "username": 'qcarchive', "password": 'mypass'}})
+    # psql = PostgresHarness({"database": {"port": 5432, "username": "qcarchive", "password": "mypass"}})
     if not psql.is_alive():
         print()
         print(

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -33,7 +33,8 @@ class APIHandler(tornado.web.RequestHandler):
 
         self.content_type = "Not Provided"
         try:
-            self.content_type = self.request.headers["Content-Type"]
+            # default to "application/json"
+            self.content_type = self.request.headers.get("Content-Type", "application/json")
             self.encoding = _valid_encodings[self.content_type]
         except KeyError:
             raise tornado.web.HTTPError(

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -60,7 +60,10 @@ class APIHandler(tornado.web.RequestHandler):
             else:
                 blob = self.request.body
 
-            self.data = deserialize(blob, self.encoding)
+            if blob:
+                self.data = deserialize(blob, self.encoding)
+            else:
+                self.data = None
         except:
             raise tornado.web.HTTPError(status_code=401, reason="Could not deserialize body.")
 


### PR DESCRIPTION
## Description

A minor change to allow empty body in HTTP requests, which helps in queries like `/information` that has no need body.

Note that, Get requests in Javascript doesn't allow data in body (it's ignored).

Also, Default http requests Content-Type to JSON.
So now, you can go to [https://api.qcarchive.molssi.org:443/information](https://api.qcarchive.molssi.org:443/information) and get the derver info, which is actually a RESTful API now.

## Status
- [x] Code base linted
- [x] Ready to go
