### PR TITLE
Docker: pin psi4 >=1.3.0 in qcarchive_worker_openff

### DIFF
--- a/devtools/docker/qcarchive_worker_openff/Dockerfile
+++ b/devtools/docker/qcarchive_worker_openff/Dockerfile
@@ -1,5 +1,5 @@
 FROM continuumio/miniconda3
-RUN conda install -c psi4 -c conda-forge psi4 dftd3 gcp qcengine qcfractal rdkit geometric pytest
+RUN conda install -c psi4 -c conda-forge "psi4 >=1.3.0" dftd3 gcp qcengine qcfractal rdkit geometric pytest
 RUN groupadd -g 999 qcfractal && \
     useradd -m -r -u 999 -g qcfractal qcfractal
 USER qcfractal


### PR DESCRIPTION
Otherwise, psi4 v1.2.1 was getting selected and breaking engine.
## Changelog description
Fixed version pins for psi4 in the qcarchive_worker_openff Dockerfile.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
