### PR TITLE
Delete collection

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -627,11 +627,7 @@ class FractalClient(object):
         payload = {"meta": {"overwrite": overwrite}, "data": collection}
         return self._automodel_request("collection", "post", payload, full_return=full_return)
 
-    def delete_collection(
-            self,
-            collection_type: str,
-            name: str
-    ) -> None:
+    def delete_collection(self, collection_type: str, name: str) -> None:
         """Deletes a given collection from the server.
 
         Parameters
@@ -643,8 +639,7 @@ class FractalClient(object):
 
         Returns
         -------
-        Collection
-            A Collection object if the given collection was found otherwise returns `None`.
+        None
         """
         collection = self.get_collection(collection_type, name)
         self._automodel_request(f"collection/{collection.data.id}", "delete", payload={"meta": {}}, full_return=True)

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -222,6 +222,8 @@ class FractalClient(object):
                 r = requests.post(addr, **kwargs)
             elif method == "put":
                 r = requests.put(addr, **kwargs)
+            elif method == "delete":
+                r = requests.delete(addr, **kwargs)
             else:
                 raise KeyError("Method not understood: '{}'".format(method))
         except requests.exceptions.SSLError:
@@ -621,6 +623,28 @@ class FractalClient(object):
 
         payload = {"meta": {"overwrite": overwrite}, "data": collection}
         return self._automodel_request("collection", "post", payload, full_return=full_return)
+
+    def delete_collection(
+            self,
+            collection_type: str,
+            name: str
+    ) -> None:
+        """Deletes a given collection from the server.
+
+        Parameters
+        ----------
+        collection_type : str
+            The collection type to be deleted
+        name : str
+            The name of the collection to be deleted
+
+        Returns
+        -------
+        Collection
+            A Collection object if the given collection was found otherwise returns `None`.
+        """
+        collection = self.get_collection(collection_type, name)
+        self._automodel_request(f"collection/{collection.data.id}", "delete", payload={"meta": {}})
 
     ### Results section
 

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -524,18 +524,21 @@ class FractalClient(object):
             if item["collection"] in repl_name_map:
                 item["collection"] = repl_name_map[item["collection"]]
 
-        df = pd.DataFrame.from_dict(response)
-        if not show_hidden:
-            df = df[df["visibility"]]
-        if group is not None:
-            df = df[df["group"].str.lower() == group.lower()]
-        if tag is not None:
-            if isinstance(tag, str):
-                tag = [tag]
-            tag = {t.lower() for t in tag}
-            df = df[df.apply(lambda x: len({t.lower() for t in x["tags"]} & tag) > 0, axis=1)]
+        if len(response) == 0:
+            df = pd.DataFrame(columns=["name", "collection", "tagline"])
+        else:
+            df = pd.DataFrame.from_dict(response)
+            if not show_hidden:
+                df = df[df["visibility"]]
+            if group is not None:
+                df = df[df["group"].str.lower() == group.lower()]
+            if tag is not None:
+                if isinstance(tag, str):
+                    tag = [tag]
+                tag = {t.lower() for t in tag}
+                df = df[df.apply(lambda x: len({t.lower() for t in x["tags"]} & tag) > 0, axis=1)]
 
-        df.drop(["visibility", "group", "tags"], axis=1, inplace=True)
+            df.drop(["visibility", "group", "tags"], axis=1, inplace=True)
         if not aslist:
             df.set_index(["collection", "name"], inplace=True)
             df.sort_index(inplace=True)
@@ -644,7 +647,7 @@ class FractalClient(object):
             A Collection object if the given collection was found otherwise returns `None`.
         """
         collection = self.get_collection(collection_type, name)
-        self._automodel_request(f"collection/{collection.data.id}", "delete", payload={"meta": {}})
+        self._automodel_request(f"collection/{collection.data.id}", "delete", payload={"meta": {}}, full_return=True)
 
     ### Results section
 

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -465,6 +465,17 @@ class CollectionPOSTResponse(ProtoModel):
 
 register_model("collection", "POST", CollectionPOSTBody, CollectionPOSTResponse)
 
+
+class CollectionDELETEBody(ProtoModel):
+    meta: EmptyMeta
+
+
+class CollectionDELETEResponse(ProtoModel):
+    meta: ResponseMeta
+
+
+register_model("collection/[0-9]+", "DELETE", CollectionDELETEBody, CollectionDELETEResponse)
+
 ### Collection views
 
 

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1047,15 +1047,17 @@ class SQLAlchemySocket:
 
         return {"data": rdata, "meta": meta}
 
-    def del_collection(self, collection: Optional[str] = None, name: Optional[str] = None, col_id: Optional[int] = None) -> bool:
+    def del_collection(
+        self, collection: Optional[str] = None, name: Optional[str] = None, col_id: Optional[int] = None
+    ) -> bool:
         """
         Remove a collection from the database from its keys.
 
         Parameters
         ----------
-        collection: str
+        collection: Optional[str], optional
             CollectionORM type
-        name : str
+        name : Optional[str], optional
             CollectionORM name
         col_id: Optional[int], optional
             Database id of the collection
@@ -1067,7 +1069,9 @@ class SQLAlchemySocket:
 
         # Assuming here that we don't want to allow deletion of all collections, all datasets, etc.
         if not (col_id is not None or (collection is not None and name is not None)):
-            raise ValueError("Either col_id ({col_id}) must be specified, or collection ({collection}) and name ({name}) must be specified.")
+            raise ValueError(
+                "Either col_id ({col_id}) must be specified, or collection ({collection}) and name ({name}) must be specified."
+            )
 
         filter = {}
         if collection is not None:
@@ -1078,11 +1082,7 @@ class SQLAlchemySocket:
             filter["id"] = col_id
 
         with self.session_scope() as session:
-            count = (
-                session.query(CollectionORM)
-                .filter_by(**filter)
-                .delete(synchronize_session=False)
-            )
+            count = session.query(CollectionORM).filter_by(**filter).delete(synchronize_session=False)
         return count
 
     ## ResultORMs functions

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1073,16 +1073,16 @@ class SQLAlchemySocket:
                 "Either col_id ({col_id}) must be specified, or collection ({collection}) and name ({name}) must be specified."
             )
 
-        filter = {}
+        filter_spec = {}
         if collection is not None:
-            filter["collection"] = collection.lower()
+            filter_spec["collection"] = collection.lower()
         if name is not None:
-            filter["lname"] = name.lower()
+            filter_spec["lname"] = name.lower()
         if col_id is not None:
-            filter["id"] = col_id
+            filter_spec["id"] = col_id
 
         with self.session_scope() as session:
-            count = session.query(CollectionORM).filter_by(**filter).delete(synchronize_session=False)
+            count = session.query(CollectionORM).filter_by(**filter_spec).delete(synchronize_session=False)
         return count
 
     ## ResultORMs functions

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1449,3 +1449,16 @@ def test_list_collection_tags(fractal_compute_server):
     assert "test_list_collection_tags_2" in names
     assert "test_list_collection_tags_3" in names
     assert "test_list_collection_tags_4" in names
+
+
+def test_delete_collection(fractal_compute_server):
+    client = ptl.FractalClient(fractal_compute_server)
+
+    ds = ptl.collections.Dataset("test_delete_collection", client=client)
+    ds.save()
+
+    client.delete_collection("dataset", ds.name)
+    assert ds.name.lower() not in client.list_collections(collection_type="dataset").reset_index().name.str.lower()
+
+    with pytest.raises(IOError):
+        client.delete_collection("dataset", ds.name)

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1453,12 +1453,20 @@ def test_list_collection_tags(fractal_compute_server):
 
 def test_delete_collection(fractal_compute_server):
     client = ptl.FractalClient(fractal_compute_server)
+    client.list_collections()
 
     ds = ptl.collections.Dataset("test_delete_collection", client=client)
     ds.save()
 
-    client.delete_collection("dataset", ds.name)
-    assert ds.name.lower() not in client.list_collections(collection_type="dataset").reset_index().name.str.lower()
+    dsid = ds.data.id
 
-    with pytest.raises(IOError):
+    client.delete_collection("dataset", ds.name)
+    assert ds.name.lower() not in client.list_collections(collection_type="dataset", aslist=True)
+
+    # Fails at get_collection
+    with pytest.raises(KeyError):
         client.delete_collection("dataset", ds.name)
+
+    # Test DELETE failure specifically
+    with pytest.raises(IOError):
+        client._automodel_request(f"collection/{dsid}", "delete", payload={"meta": {}}, full_return=True)

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -396,15 +396,16 @@ class CollectionHandler(APIHandler):
         self.logger.info("POST: Collections - {} inserted.".format(response.meta.n_inserted))
         self.write(response)
 
-    def delete(self, collection_id=None):
+    def delete(self, collection_id, _):
         self.authenticate("write")
+
         body_model, response_model = rest_model(f"collection/{collection_id}", "delete")
         ret = self.storage.del_collection(col_id=collection_id)
         if ret == 0:
             self.logger.info(f"DELETE: Collections - Attempted to delete non-existent collection {collection_id}.")
             raise tornado.web.HTTPError(status_code=404, reason=f"Collection {collection_id} does not exist.")
         else:
-            self.write(response_model(meta={"success": True}))
+            self.write(response_model(meta={"success": True, "errors": [], "error_description": False}))
             self.logger.info(f"DELETE: Collections - Deleted collection {collection_id}.")
 
 

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -396,6 +396,17 @@ class CollectionHandler(APIHandler):
         self.logger.info("POST: Collections - {} inserted.".format(response.meta.n_inserted))
         self.write(response)
 
+    def delete(self, collection_id=None):
+        self.authenticate("write")
+        body_model, response_model = rest_model(f"collection/{collection_id}", "delete")
+        ret = self.storage.del_collection(col_id=collection_id)
+        if ret == 0:
+            self.logger.info(f"DELETE: Collections - Attempted to delete non-existent collection {collection_id}.")
+            raise tornado.web.HTTPError(status_code=404, reason=f"Collection {collection_id} does not exist.")
+        else:
+            self.write(response_model(meta={"success": True}))
+            self.logger.info(f"DELETE: Collections - Deleted collection {collection_id}.")
+
 
 class ResultHandler(APIHandler):
     """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR provides an endpoint (DELETE /collections/[collection id]) for deleting collections, and a corresponding function `delete_collection` in QCPortal. Resolves #523.

## Changelog description
The `delete_collection` function was added to `qcportal.FractalClient`. 

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
