### PR TITLE
Docker: fix entrypoint of openff worker

### DIFF
--- a/devtools/docker/qcarchive_worker_openff/Dockerfile
+++ b/devtools/docker/qcarchive_worker_openff/Dockerfile
@@ -7,4 +7,4 @@ RUN groupadd -g 999 qcfractal && \
 USER qcfractal
 ENV PATH /opt/local/conda/envs/base/bin/:$PATH
 RUN echo "source activate qcfractal" > ~/.bashrc
-ENTRYPOINT /opt/conda/envs/qcfractal/bin/qcfractal-manager --config-file /etc/qcfractal-manager/manager.yaml
+ENTRYPOINT /bin/bash -c "source activate qcfractal && qcfractal-manager --config-file /etc/qcfractal-manager/manager.yaml -v"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR fixes `ENTRYPOINT` of the qcarchive_worker_openff worker. (Conda and Docker are not friends.)

## Changelog description
(None needed)

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
