### PR TITLE
Makefile: enable isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install:
 .PHONY: format
 format:
 #	$(autoflake)
-#	$(isort)
+	$(isort)
 	$(black)
 
 .PHONY: lint

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -4,8 +4,8 @@ Tests for QCFractals CLI
 import os
 import tempfile
 import time
+from typing import Any, Dict
 
-from typing import Dict, Any
 import pytest
 import yaml
 

--- a/qcfractal/cli/tests/test_cli.py
+++ b/qcfractal/cli/tests/test_cli.py
@@ -13,9 +13,6 @@ import qcfractal
 from qcfractal import testing
 from qcfractal.cli.cli_utils import read_config_file
 
-# def _run_tests()
-from qcfractal.cli.qcfractal_manager import ManagerSettings
-
 _options = {"coverage": True, "dump_stdout": True}
 _pwd = os.path.dirname(os.path.abspath(__file__))
 

--- a/qcfractal/dashboard/pages/landing.py
+++ b/qcfractal/dashboard/pages/landing.py
@@ -2,7 +2,6 @@ import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 import dash_coreui_components as coreui
 import pandas as pd
-
 from dash.dependencies import Input, Output
 from flask import current_app
 

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -519,7 +519,7 @@ class RemoteView(DatasetView):
         return self._deserialize(response.data.values, response.meta.msgpacked_cols), response.data.units
 
     def list_values(self) -> pd.DataFrame:
-        payload = {"meta": {}, "data": {}}
+        payload: Dict[str, Dict[str, Any]] = {"meta": {}, "data": {}}
         response = self._client._automodel_request(f"collection/{self._id}/list", "get", payload, full_return=True)
         self._check_response_meta(response.meta)
         return self._deserialize(response.data, response.meta.msgpacked_cols)

--- a/qcfractal/interface/collections/optimization_dataset.py
+++ b/qcfractal/interface/collections/optimization_dataset.py
@@ -182,7 +182,7 @@ class OptimizationDataset(BaseProcedureDataset):
             specs = new_specs
 
         def count_gradients(opt):
-            if (not hasattr(opt, 'status')) or opt.status != "COMPLETE":
+            if (not hasattr(opt, "status")) or opt.status != "COMPLETE":
                 return None
             return len(opt.energies)
 

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -18,7 +18,7 @@ import secrets
 from collections.abc import Iterable
 from contextlib import contextmanager
 from datetime import datetime as dt
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import bcrypt
 
@@ -61,6 +61,9 @@ from qcfractal.storage_sockets.models import (
 from qcfractal.storage_sockets.storage_utils import add_metadata_template, get_metadata_template
 
 from .models import Base
+
+if TYPE_CHECKING:
+    from ..services.service_util import BaseService
 
 _null_keys = {"basis", "keywords"}
 _id_keys = {"id", "molecule", "keywords", "procedure_id"}

--- a/qcfractal/tests/test_adapters.py
+++ b/qcfractal/tests/test_adapters.py
@@ -2,8 +2,8 @@
 Explicit tests for queue manipulation.
 """
 
-import tempfile
 import logging
+import tempfile
 
 import pytest
 

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1302,7 +1302,7 @@ def test_optimization_dataset(fractal_compute_server):
     assert status.loc["COMPLETE", "test2"] == 1
 
     counts = ds.counts()
-    assert counts.loc["hooh1" ,"test"] == 9
+    assert counts.loc["hooh1", "test"] == 9
     assert np.isnan(counts.loc["hooh2", "test2"])
     assert len(ds.df.loc["hooh1", "test"].trajectory) == 1
 

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -274,5 +274,5 @@ def test_node_parallel(compute_adapter_fixture):
     client, server, adapter = compute_adapter_fixture
 
     manager = queue.QueueManager(client, adapter, nodes_per_task=2, cores_per_rank=2)
-    assert manager.queue_adapter.qcengine_local_options['nnodes'] == 2
-    assert manager.queue_adapter.qcengine_local_options['cores_per_rank'] == 2
+    assert manager.queue_adapter.qcengine_local_options["nnodes"] == 2
+    assert manager.queue_adapter.qcengine_local_options["cores_per_rank"] == 2


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Isort was previously disabled due to an issue with TYPE_CHECKING imports getting deleted. It seems the issue was with autoflake only, so isort has been re-enabled. A few type annotations have been added as well. 

## Changelog description
None needed, probably. 

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
