### PR TITLE
[WIP] Dataset: don't pull records before save if no records were changed.

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -600,7 +600,7 @@ class FractalClient(object):
             raise KeyError("Collection '{}:{}' not found.".format(collection_type, name))
 
     def add_collection(
-        self, collection: Dict[str, Any], overwrite: bool = False, full_return: bool = False
+        self, collection: Dict[str, Any], overwrite: bool = False, full_return: bool = False, ignore: Optional[List[str]] = None
     ) -> Union["CollectionGETResponse", List["ObjectId"]]:
         """Adds a new Collection to the server.
 
@@ -625,6 +625,8 @@ class FractalClient(object):
             raise KeyError("Attempting to overwrite collection, but no server ID found (cannot use 'local').")
 
         payload = {"meta": {"overwrite": overwrite}, "data": collection}
+        if ignore is not None:
+            payload["meta"]["ignore"] = ignore
         return self._automodel_request("collection", "post", payload, full_return=full_return)
 
     def delete_collection(self, collection_type: str, name: str) -> None:

--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -202,7 +202,7 @@ class Collection(abc.ABC):
             return copy.deepcopy(data)
 
     @abc.abstractmethod
-    def _pre_save_prep(self, client: "FractalClient"):
+    def _pre_save_prep(self, client: "FractalClient") -> Optional[List[str]]:
         """
         Additional actions to take before saving, done as the last step before data is written.
 
@@ -240,16 +240,16 @@ class Collection(abc.ABC):
             self._check_client()
             client = self.client
 
-        self._pre_save_prep(client)
+        ignore = self._pre_save_prep(client)
 
         # Add the database
         if self.data.id == self.data.__fields__["id"].default:
-            response = client.add_collection(self.data.dict(), overwrite=False, full_return=True)
+            response = client.add_collection(self.data.dict(), overwrite=False, full_return=True, ignore=ignore)
             if response.meta.success is False:
                 raise KeyError(f"Error adding collection: \n{response.meta.error_description}")
             self.data.__dict__["id"] = response.data
         else:
-            response = client.add_collection(self.data.dict(), overwrite=True, full_return=True)
+            response = client.add_collection(self.data.dict(), overwrite=True, full_return=True, ignore=ignore)
             if response.meta.success is False:
                 raise KeyError(f"Error updating collection: \n{response.meta.error_description}")
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -261,8 +261,7 @@ class Dataset(Collection):
 
     def _entry_index(self, subset: Optional[List[str]] = None) -> pd.DataFrame:
         # TODO: make this fast for subsets
-        if self.data.records is None:
-            self._get_data_records_from_db()
+        self._ensure_records()
 
         ret = pd.DataFrame(
             [[entry.name, entry.molecule_id] for entry in self.data.records], columns=["name", "molecule_id"]
@@ -292,7 +291,7 @@ class Dataset(Collection):
 
         # Update internal molecule UUID's to servers UUID's
         if len(self._new_records) > 0:
-            self._get_data_records_from_db()
+            self._ensure_records()
         for record in self._new_records:
             molecule_hash = record.pop("molecule_hash")
             new_record = MoleculeEntry(molecule_id=mol_ret[molecule_hash], **record)
@@ -1382,6 +1381,10 @@ class Dataset(Collection):
 
     def _ensure_contributed_values(self) -> None:
         if self.data.contributed_values is None:
+            self._get_data_records_from_db()
+
+    def _ensure_records(self) -> None:
+        if self.data.records is None:
             self._get_data_records_from_db()
 
     def _list_contributed_values(self) -> pd.DataFrame:

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -283,7 +283,7 @@ class Dataset(Collection):
             del self._new_keywords[k]
         self._updated_state = False
 
-    def _pre_save_prep(self, client: "FractalClient") -> None:
+    def _pre_save_prep(self, client: "FractalClient") -> Optional[List[str]]:
         self._canonical_pre_save(client)
 
         # Preps any new molecules introduced to the Dataset before storing data.
@@ -299,6 +299,9 @@ class Dataset(Collection):
 
         self._new_records = []
         self._new_molecules = {}
+
+        if self.data.records is None:
+            return ["records"]
 
     def get_entries(self, subset: Optional[List[str]] = None, force: bool = False) -> pd.DataFrame:
         """
@@ -1118,7 +1121,7 @@ class Dataset(Collection):
         """
         self._check_client()
         self._check_state()
-
+        self._ensure_records()
         ret = []
         plan = composition_planner(**query)
         if raise_on_plan and (len(plan) > 1):
@@ -1200,6 +1203,7 @@ class Dataset(Collection):
 
         self._check_client()
         self._check_state()
+        self._ensure_records()
 
         umols = list(set(molecules))
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -277,9 +277,6 @@ class Dataset(Collection):
             raise ValueError("New molecules, keywords, or records detected, run save before submitting new tasks.")
 
     def _canonical_pre_save(self, client: "FractalClient") -> None:
-        self._ensure_contributed_values()
-        if self.data.records is None:
-            self._get_data_records_from_db()
         for k in list(self._new_keywords.keys()):
             ret = client.add_keywords([self._new_keywords[k]])
             assert len(ret) == 1, "KeywordSet added incorrectly"
@@ -294,6 +291,8 @@ class Dataset(Collection):
         mol_ret = self._add_molecules_by_dict(client, self._new_molecules)
 
         # Update internal molecule UUID's to servers UUID's
+        if len(self._new_records) > 0:
+            self._get_data_records_from_db()
         for record in self._new_records:
             molecule_hash = record.pop("molecule_hash")
             new_record = MoleculeEntry(molecule_id=mol_ret[molecule_hash], **record)

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -87,8 +87,7 @@ class ReactionDataset(Dataset):
         )
 
     def _entry_index(self, subset: Optional[List[str]] = None) -> None:
-        if self.data.records is None:
-            self._get_data_records_from_db()
+        self._ensure_records()
         # Unroll the index
         tmp_index = []
         for rxn in self.data.records:

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -426,6 +426,7 @@ class CollectionPOSTBody(ProtoModel):
             description="The existing Collection in the database will be updated if this is True, otherwise will "
             "remain unmodified if it already exists.",
         )
+        ignore: List[str] = Field([], description="When updating a collection, do not update these fields.")
 
     class Data(ProtoModel):
         id: str = Field(

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -968,7 +968,6 @@ class SQLAlchemySocket:
                 update_fields[field] = data.pop(field)
 
         update_fields["extra"] = data  # todo: check for sql injection
-
         with self.session_scope() as session:
 
             try:

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1508,3 +1508,32 @@ def test_update_metadata(gradient_dataset_fixture):
     ds.save()
     assert ds.data.records is None
     assert ds.data.contributed_values is None
+
+
+def test_update_metadata_2(fractal_compute_server):
+    client = ptl.FractalClient(fractal_compute_server)
+    client.list_collections()
+
+    ds = ptl.collections.Dataset("test_update_metadata_2", client=client)
+    ds.add_entry("He1", ptl.Molecule.from_data("He -1 0 0\n--\nHe 0 0 1"))
+    ds.save()
+    assert len(ds.data.records) == 1
+
+    ds = client.get_collection("Dataset", "test_update_metadata_2")
+    ds.get_entries()
+    assert len(ds.data.records) == 1
+
+    ds = client.get_collection("Dataset", "test_update_metadata_2")
+    assert ds.data.records is None
+    assert ds.data.contributed_values is None
+
+    ds.data.__dict__["description"] = "modified description"
+    ds.save()
+    assert ds.data.records is None
+    assert ds.data.contributed_values is None
+
+    ds.get_entries()
+    assert len(ds.data.records) == 1
+
+
+

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1497,3 +1497,14 @@ def test_delete_collection(fractal_compute_server):
     # Test DELETE failure specifically
     with pytest.raises(IOError):
         client._automodel_request(f"collection/{dsid}", "delete", payload={"meta": {}}, full_return=True)
+
+
+def test_update_metadata(gradient_dataset_fixture):
+    _, ds = gradient_dataset_fixture
+    assert ds.data.records is None
+    assert ds.data.contributed_values is None
+
+    ds.data.__dict__["description"] = "modified description"
+    ds.save()
+    assert ds.data.records is None
+    assert ds.data.contributed_values is None

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -390,7 +390,10 @@ class CollectionHandler(APIHandler):
             self.logger.info("POST: Collections - Access attempted on subresource.")
             return
 
-        ret = self.storage.add_collection(body.data.dict(), overwrite=body.meta.overwrite)
+        data = body.data.dict()
+        for field in body.meta.ignore:
+            data.pop(field)
+        ret = self.storage.add_collection(data, overwrite=body.meta.overwrite)
         response = response_model(**ret)
 
         self.logger.info("POST: Collections - {} inserted.".format(response.meta.n_inserted))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR allows for updating dataset metadata without pulling and re-writing records. This is especially helpful for large datasets like QM9. 

## Changelog description
Improved the performance of `Dataset.save()` if no new records have been added.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
