### PR TITLE
Remove mongdb compatibility from base_result in TaskQueue and TaskRecords

### DIFF
--- a/docs/qcfractal/source/changelog.rst
+++ b/docs/qcfractal/source/changelog.rst
@@ -25,6 +25,7 @@ Enhancements
 - (:pr:`483`) Dataset Views are now much faster to load in HDF5.
 - (:pr:`488`) Allows gzipped dataset views.
 - (:pr:`490`) Computes checksums on gzipped dataset views.
+- (:pr:`542`) ``TaskRecord.base_result`` is now an ``ObjectId``, and no more a ``DBRef``. So, code that uses ``my_task.base_result.id`` should change to simply be ``my_task.base_result``.
 
 Bug Fixes
 +++++++++

--- a/qcfractal/interface/models/task_models.py
+++ b/qcfractal/interface/models/task_models.py
@@ -87,7 +87,7 @@ class TaskRecord(ProtoModel):
         "explicitly reference this tag. If no Tag is specified, any Queue Manager can pull this Task.",
     )
     # Link back to the base Result
-    base_result: Union[DBRef, int] = Field(
+    base_result: ObjectId = Field(
         ..., description="Reference to the output Result from this Task as it exists within the database."
     )
     error: Optional[ComputeError] = Field(

--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -43,7 +43,7 @@ class BaseTasks:
                 "error_description": False,
                 "errors": errors,
             },
-            "data": {"ids": results_ids, "submitted": [x.base_result.id for x in new_tasks], "existing": existing_ids},
+            "data": {"ids": results_ids, "submitted": [x.base_result for x in new_tasks], "existing": existing_ids},
         }
 
         return results
@@ -146,7 +146,7 @@ class SingleResultTasks(BaseTasks):
                     "program": data.meta.program,
                     "tag": tag,
                     "priority": priority,
-                    "base_result": {"ref": "result", "id": base_id},
+                    "base_result": base_id,
                 }
             )
 
@@ -160,7 +160,7 @@ class SingleResultTasks(BaseTasks):
         completed_tasks = []
         updates = []
         for data in result_outputs:
-            result = self.storage.get_results(id=data["base_result"].id)["data"][0]
+            result = self.storage.get_results(id=data["base_result"])["data"][0]
             result = ResultRecord(**result)
 
             rdata = data["result"]
@@ -185,7 +185,7 @@ class SingleResultTasks(BaseTasks):
                 available_keys = wfn.keys() - _wfn_return_names
                 if available_keys > _wfn_all_fields:
                     self.logger.warning(
-                        f"Too much wavefunction data for result {data['base_result'].id}, removing extra data."
+                        f"Too much wavefunction data for result {data['base_result']}, removing extra data."
                     )
                     available_keys &= _wfn_all_fields
 
@@ -334,7 +334,7 @@ class OptimizationTasks(BaseTasks):
                     "procedure": data.meta.program,
                     "tag": tag,
                     "priority": priority,
-                    "base_result": {"ref": "procedure", "id": base_id},
+                    "base_result": base_id,
                 }
             )
 
@@ -351,7 +351,7 @@ class OptimizationTasks(BaseTasks):
         completed_tasks = []
         updates = []
         for output in opt_outputs:
-            rec = self.storage.get_procedures(id=output["base_result"].id)["data"][0]
+            rec = self.storage.get_procedures(id=output["base_result"])["data"][0]
             rec = OptimizationRecord(**rec)
 
             procedure = output["result"]

--- a/qcfractal/storage_sockets/models/sql_models.py
+++ b/qcfractal/storage_sockets/models/sql_models.py
@@ -239,7 +239,6 @@ class TaskQueueORM(Base):
     def base_result(self, val):
         self.base_result_id = int(val)
 
-
     # can reference ResultORMs or any ProcedureORM
     base_result_id = Column(Integer, ForeignKey("base_result.id", ondelete="cascade"), unique=True)
     base_result_obj = relationship("BaseResultORM", lazy="select")  # or lazy='joined'

--- a/qcfractal/storage_sockets/models/sql_models.py
+++ b/qcfractal/storage_sockets/models/sql_models.py
@@ -233,23 +233,12 @@ class TaskQueueORM(Base):
     # TODO: for back-compatibility with mongo, tobe removed
     @hybrid_property
     def base_result(self):
-        return self._base_result(self.base_result_id)
-
-    @staticmethod
-    def _base_result(base_result_id):
-        return dict(ref="result", id=str(base_result_id))
-        # return self.base_result_id   # todo, change to this
+        return self.base_result_id
 
     @base_result.setter
     def base_result(self, val):
-        """Only two valid values, dict and int"""
+        self.base_result_id = int(val)
 
-        if isinstance(val, dict):
-            self.base_result_id = int(val["id"])
-        else:
-            self.base_result_id = int(val)
-
-        return val
 
     # can reference ResultORMs or any ProcedureORM
     base_result_id = Column(Integer, ForeignKey("base_result.id", ondelete="cascade"), unique=True)

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1890,7 +1890,7 @@ class SQLAlchemySocket:
                     # print(str(err))
                     session.rollback()
                     # TODO: merge hooks
-                    task = session.query(TaskQueueORM).filter_by(base_result_id=record.base_result.id).first()
+                    task = session.query(TaskQueueORM).filter_by(base_result_id=record.base_result).first()
                     self.logger.warning("queue_submit got a duplicate task: {}".format(task.to_dict()))
                     results.append(str(task.id))
                     meta["duplicates"].append(task_num)
@@ -2247,7 +2247,7 @@ class SQLAlchemySocket:
         task_ids = []
         with self.session_scope() as session:
             for task in record_list:
-                doc = session.query(TaskQueueORM).filter_by(base_result_id=task.base_result.id)
+                doc = session.query(TaskQueueORM).filter_by(base_result_id=task.base_result_id)
 
                 if get_count_fast(doc) == 0:
                     doc = TaskQueueORM(**task.dict(exclude={"id"}))

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -304,8 +304,8 @@ def test_queue_ordering_time(fractal_compute_server):
 
     assert len(fractal_compute_server.storage.queue_get_next(manager, [], [], limit=1)) == 0
 
-    queue_id1 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0].base_result.id
-    queue_id2 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0].base_result.id
+    queue_id1 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0].base_result
+    queue_id2 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0].base_result
 
     assert queue_id1 == ret1
     assert queue_id2 == ret2
@@ -326,9 +326,9 @@ def test_queue_ordering_priority(fractal_compute_server):
 
     manager = get_manager_name(fractal_compute_server)
 
-    queue_id1 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0].base_result.id
-    queue_id2 = fractal_compute_server.storage.queue_get_next(manager, ["RDkit"], [], limit=1)[0].base_result.id
-    queue_id3 = fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], [], limit=1)[0].base_result.id
+    queue_id1 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0].base_result
+    queue_id2 = fractal_compute_server.storage.queue_get_next(manager, ["RDkit"], [], limit=1)[0].base_result
+    queue_id3 = fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], [], limit=1)[0].base_result
 
     assert queue_id1 == ret2
     assert queue_id2 == ret3
@@ -361,13 +361,13 @@ def test_queue_order_procedure_priority(fractal_compute_server):
 
     queue_id1 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], ["geometric"], limit=1)[
         0
-    ].base_result.id
+    ].base_result
     queue_id2 = fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], ["geometric"], limit=1)[
         0
-    ].base_result.id
+    ].base_result
     queue_id3 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], ["GEOMETRIC"], limit=1)[
         0
-    ].base_result.id
+    ].base_result
 
     assert queue_id1 == ret2
     assert queue_id2 == ret3
@@ -389,15 +389,15 @@ def test_queue_query_tag(fractal_compute_server):
 
     tasks_tag_test = client.query_tasks(tag="test")
     assert len(tasks_tag_test) == 1
-    assert tasks_tag_test[0].base_result.id == ret2
+    assert tasks_tag_test[0].base_result == ret2
 
     tasks_tag_none = client.query_tasks()
     assert len(tasks_tag_none) == 3
-    assert {task.base_result.id for task in tasks_tag_none} == {ret1, ret2, ret3}
+    assert {task.base_result for task in tasks_tag_none} == {ret1, ret2, ret3}
 
     tasks_tagged = client.query_tasks(tag=["test", "test2"])
     assert len(tasks_tagged) == 2
-    assert {task.base_result.id for task in tasks_tagged} == {ret2, ret3}
+    assert {task.base_result for task in tasks_tagged} == {ret2, ret3}
 
 
 def test_queue_query_manager(fractal_compute_server):
@@ -417,7 +417,7 @@ def test_queue_query_manager(fractal_compute_server):
     fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], [], limit=1)[0]
     tasks_manager = client.query_tasks(manager=manager)
     assert len(tasks_manager) == 1
-    assert tasks_manager[0].base_result.id == ret1
+    assert tasks_manager[0].base_result == ret1
 
     fractal_compute_server.storage.queue_get_next(manager, ["RDkit"], [], limit=1)[0]
     fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], [], limit=1)[0]

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -359,15 +359,9 @@ def test_queue_order_procedure_priority(fractal_compute_server):
     assert len(fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], ["geom"], limit=1)) == 0
     assert len(fractal_compute_server.storage.queue_get_next(manager, ["prog1"], ["geometric"], limit=1)) == 0
 
-    queue_id1 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], ["geometric"], limit=1)[
-        0
-    ].base_result
-    queue_id2 = fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], ["geometric"], limit=1)[
-        0
-    ].base_result
-    queue_id3 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], ["GEOMETRIC"], limit=1)[
-        0
-    ].base_result
+    queue_id1 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], ["geometric"], limit=1)[0].base_result
+    queue_id2 = fractal_compute_server.storage.queue_get_next(manager, ["RDKIT"], ["geometric"], limit=1)[0].base_result
+    queue_id3 = fractal_compute_server.storage.queue_get_next(manager, ["rdkit"], ["GEOMETRIC"], limit=1)[0].base_result
 
     assert queue_id1 == ret2
     assert queue_id2 == ret3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Remove mongdb compatibility from base_result in TaskQueue and TaskRecords.

## Changelog description
 - Important: `TaskRecord.base_result` is now an `ObjectId` (int or str), and no more a `DBRef`. So, code that uses `my_task.base_result.id` should change to simply use `my_task.base_result`
 
## Status
- [x] Code base linted
- [x] Ready to go
