### PR TITLE
Use versions to correctly detect and upgrade db, closes #509

### DIFF
--- a/qcfractal/cli/qcfractal_server.py
+++ b/qcfractal/cli/qcfractal_server.py
@@ -396,6 +396,7 @@ def server_upgrade(args, config):
 
     try:
         psql.upgrade()
+        psql.update_db_version()
     except ValueError as e:
         print(str(e))
         sys.exit(1)


### PR DESCRIPTION
## Description
Use versions to correctly detect and upgrade db. This was not implemented yet, although version tables existed.

Different test scenarios:
  - Init a new fractal-server, then start  --> should work
  - Init a new fractal-server, run upgrade, then start --> should work
  - Existing fractal-server, then pip update qcfractal, then start server --> won't start and give msg to upgrade
  - Existing fractal-server, then pip update qcfractal, run upgrade, then start server --> should work

Using a newer DB with older QCFractal version is not supported, and both need to be updated.

## Questions: 
 Any other test scenarios you can think ok?


closes issue #509 

## Changelog description
 No change needed.

## Status
- [x] Code base linted
- [ ] Ready to go
`