### PR TITLE
Backup/Restore CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ runinfo/
 
 #vscode
 **/.vscode/
+
+# QCFractal backup files
+*.bak

--- a/qcfractal/cli/qcfractal_server.py
+++ b/qcfractal/cli/qcfractal_server.py
@@ -27,13 +27,14 @@ def ensure_postgres_alive(psql):
             sys.exit(1)
 
 
-def human_sizeof_byte(num, suffix='B'):
+def human_sizeof_byte(num, suffix="B"):
     # SO: https://stackoverflow.com/questions/1094841/reusable-library-to-get-human-readable-version-of-file-size
-    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+    for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
         if abs(num) < 1024.0:
             return "%3.1f%s%s" % (num, unit, suffix)
         num /= 1024.0
-    return "%.1f%s%s" % (num, 'Yi', suffix)
+    return "%.1f%s%s" % (num, "Yi", suffix)
+
 
 def standard_command_startup(name, config, check=True):
     print(f"QCFractal server {name}.\n")
@@ -502,7 +503,18 @@ def server_backup(args, config):
 
     db_size = psql.database_size()
     print(f"Current database size: {db_size['stdout']}")
-    psql.backup_database(filename=args["filename"])
+
+    filename = args["filename"]
+    if filename is None:
+        filename = f"{config.database.database_name}.bak"
+        print(f"No filename provided, defaulting to filename: {filename}")
+
+    filename = os.path.realpath(filename)
+
+    filename_temporary = filename + ".in_progress"
+    psql.backup_database(filename=filename_temporary)
+
+    shutil.move(filename_temporary, filename)
 
     print("Backup complete!")
 

--- a/qcfractal/postgres_harness.py
+++ b/qcfractal/postgres_harness.py
@@ -338,6 +338,33 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
             self.logger(ret)
             raise ValueError("\nFailed to Stamp the database with current version.\n")
 
+    def backup_database(self, filename: Optional[str] = None) -> None:
+
+        # sudo -u dgasmith /home/dgasmith/miniconda3/envs/qcfprod/bin/pg_dump -Fc qcarchivedb
+        # > database_name.bak
+        # Reasonable check here
+        self._check_psql()
+
+        if filename is None:
+            filename = os.path.realpath(f"{self.config.database.database_name}.bak")
+
+        # fmt: off
+        cmds = [
+            shutil.which("pg_dump"),
+            "-p", str(self.config.database.port),
+            "-d", self.config.database.database_name,
+            "-Fc", # Custom postgres format, fast
+            "--file", filename
+        ]
+        # fmt: on
+
+        self.logger(f"pg_backup command: {'  '.join(cmds)}")
+        ret = self._run(cmds)
+
+        if ret["retcode"] != 0:
+            self.logger(ret)
+            raise ValueError("\nFailed to backup the database.\n")
+
 
 class TemporaryPostgres:
     def __init__(

--- a/qcfractal/postgres_harness.py
+++ b/qcfractal/postgres_harness.py
@@ -143,10 +143,13 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
         """
         self._check_psql()
 
+        if isinstance(cmd, str):
+            cmd = [cmd]
+
         self.logger(f"pqsl command: {cmd}")
         psql_cmd = [shutil.which("psql"), "-p", str(self.config.database.port), "-c"]
 
-        cmd = self._run(psql_cmd + [cmd])
+        cmd = self._run(psql_cmd + cmd)
         if check:
             if cmd["retcode"] != 0:
                 raise ValueError("psql operation did not complete.")
@@ -390,6 +393,15 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
         if ret["retcode"] != 0:
             self.logger(ret["stderr"])
             raise ValueError("\nFailed to restore the database.\n")
+
+    def database_size(self) -> str:
+        """
+        Returns a pretty formatted string of the database size.
+        """
+
+        return self.command([
+            f"SELECT pg_size_pretty( pg_database_size('{self.config.database.database_name}') );",
+            "-t", "-A"])
 
 
 class TemporaryPostgres:

--- a/qcfractal/postgres_harness.py
+++ b/qcfractal/postgres_harness.py
@@ -352,7 +352,9 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
         self._check_psql()
 
         if filename is None:
-            filename = os.path.realpath(f"{self.config.database.database_name}.bak")
+            filename = f"{self.config.database.database_name}.bak"
+
+        filename = os.path.realpath(filename)
 
         # fmt: off
         cmds = [
@@ -399,9 +401,9 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
         Returns a pretty formatted string of the database size.
         """
 
-        return self.command([
-            f"SELECT pg_size_pretty( pg_database_size('{self.config.database.database_name}') );",
-            "-t", "-A"])
+        return self.command(
+            [f"SELECT pg_size_pretty( pg_database_size('{self.config.database.database_name}') );", "-t", "-A"]
+        )
 
 
 class TemporaryPostgres:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Provides backup and restore command to the `qcfractal-server` CLI in order to... backup and restore databases. This is only tested locally at the moment as a unit test would be quite involved.

Closed #510.

## Changelog description
Provides backup and restore functionality from the `qcfractal-server` CLI.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
