### PR TITLE
Dataset: fix #534

### DIFF
--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1559,7 +1559,7 @@ class Dataset(Collection):
             Either a DataFrame of indexed ResultRecords or a single ResultRecord if a single subset string was provided.
         """
         name, _, history = self._default_parameters(program, method, basis, keywords)
-        if name not in set(self.list_records().reset_index()["name"].unique()):
+        if len(self.list_records(**history)) == 0:
             raise KeyError(f"Requested query ({name}) did not match a known record.")
 
         indexer = self._molecule_indexer(subset=subset, force=True)

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -465,7 +465,7 @@ class ReactionDataset(Dataset):
         ret = []
         for s in stoich:
             name, _, history = self._default_parameters(program, method, basis, keywords, stoich=s)
-            if name not in set(self.list_records(stoichiometry=s).reset_index()["name"].unique()):
+            if len(self.list_records(**history)) == 0:
                 raise KeyError(f"Requested query ({name}) did not match a known record.")
             history.pop("stoichiometry")
             indexer, names = self._molecule_indexer(stoich=s, subset=subset, force=True)

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -324,6 +324,16 @@ def test_gradient_dataset_values_subset(gradient_dataset_fixture, use_cache):
         assert df_compare(df1, df2, sort=True)
 
 
+def test_gradient_dataset_records_args(gradient_dataset_fixture):
+    client, ds = gradient_dataset_fixture
+
+    assert len(ds.get_records(method="hf", keywords="scf_default", basis="sto-3g")) == 2
+    assert (
+        len(ds.get_records(method="hf", keywords="scf_default")) == 4
+    )  # TODO: we might want a multi-keyword dataset fixture here
+    assert len(ds.get_records(method="hf")) == 4
+
+
 @pytest.fixture(scope="module", params=["download_view", "no_view", "remote_view"])
 def contributed_dataset_fixture(fractal_compute_server, tmp_path_factory, request):
     """ Fixture for testing rich contributed datasets with many properties and molecules of different sizes"""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR fixes an issue in `Dataset.get_records()` that can occur when the optional arguments `keywords` and `basis` are not provided. This PR resolves #534.

## Changelog description
Fixed an issue in `Dataset.get_records()` that could occur when the optional arguments `keywords` and `basis` were not provided. 

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
