### PR TITLE
Many fixes for the HPC documentation

### DIFF
--- a/docs/qcfractal/source/index.rst
+++ b/docs/qcfractal/source/index.rst
@@ -131,6 +131,7 @@ Setting up and running Fractal's Queue Managers on your system.
 
    managers.rst
    managers_config_api.rst
+   managers_hpc.rst
    managers_samples.rst
    managers_faq.rst
    managers_detailed.rst

--- a/docs/qcfractal/source/managers_hpc.rst
+++ b/docs/qcfractal/source/managers_hpc.rst
@@ -1,5 +1,5 @@
-Queue Managers for High-Performance Computing
-=============================================
+Configuration for High-Performance Computing
+============================================
 
 High-performance computing (HPC) clusters are designed to complete highly-parallel tasks in a short time.
 Properly leveraging such clusters requires utilizing large numbers of compute nodes at the same time,
@@ -17,15 +17,15 @@ Many Nodes per Job, Single Node per Application
 The recommended configuration for a QCFractal manager to use multi-node Jobs with
 tasks limited to a single node is launch many workers for a single Job.
 
-The Parsl adapter deploys a single ``manager'' per Job and uses the HPC systems's
+The Parsl adapter deploys a single ''manager'' per Job and uses the HPC system's
 MPI task launcher to deploy the Parsl executors on to the compute nodes.
 Each "executor" will run a single Python process per QCEngine worker and can run
 more than one worker per node.
 The ``manager`` will run on the login or batch node (depending on the cluster's configuration)
 once the Job is started and will communicate to the workers using Parsl's ØMQ messaging protocol.
-The QCFractal QueueManager will only need to Parsl manager and not any of the workers.
+The QCFractal QueueManager will connect to the Parsl manager for each Job.
 
-See the `example page <manager_samples.html>`_ for details on how to configure Parsl for your system.
+See the `example page <managers_samples.html>`_ for details on how to configure Parsl for your system.
 The configuration setting ``common.nodes_per_job`` defines the ability to make multi-node allocation
 requests to a scheduler via an Adapter.
 
@@ -44,4 +44,4 @@ equal to the number of nodes per Job divided by the number of nodes per Task.
 The worker will call the MPI launch system to place quantum-chemistry calculations on
 the compute nodes of the clusters.
 
-See the `example page <manager_samples.html>`_ for details on how to configure Parsl for your system.
+See the `example page <managers_samples.html>`_ for details on how to configure Parsl for your system.

--- a/docs/qcfractal/source/managers_samples.rst
+++ b/docs/qcfractal/source/managers_samples.rst
@@ -204,9 +204,10 @@ Single Job with Multiple Nodes and Single-Node Tasks with Parsl Adapter
 -----------------------------------------------------------------------
 
 Leadership platforms prefer or require more than one node per Job request.
-The following command will request a Job with 256 nodes and place one Worker on each node.
+The following configuration will request a Job with 256 nodes and place one Worker on each node.
 
 .. code-block:: yaml
+
     common:
         adapter: parsl
         tasks_per_worker: 1
@@ -250,6 +251,7 @@ Parsl uses ``SimpleLauncher`` to deploy a Parsl executor onto
 the batch/login node once a job is allocated.
 
 .. code-block:: yaml
+
     common:
         adapter: parsl
         tasks_per_worker: 1
@@ -281,7 +283,7 @@ the batch/login node once a job is allocated.
             walltime: "0:30:00"
 
 The configuration that describes how to launch the tasks must be written at a ``qcengine.yaml``
-file. See `QCEngine docs<https://qcengine.readthedocs.io/en/stable/environment.html>`_
+file. See `QCEngine docs <https://qcengine.readthedocs.io/en/stable/environment.html>`_
 for possible locations to place the ``qcengine.yaml`` file and full descriptions of the
 configuration option.
 One key option for the ``qcengine.yaml`` file is the description of how to launch MPI
@@ -290,6 +292,7 @@ tasks, ``mpiexec_command``. For example, many systems use ``mpirun``
 An example configuration a Cray supercomputer is:
 
 .. code-block:: yaml
+
     all:
       hostname_pattern: "*"
       scratch_directory: ./scratch  # Must be on the global filesystem


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Fixes many errors in the HPC documentation. Mostly issues in writing the rst.

## Changelog description
Fixed RST errors in HPC portion of readthedocs

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
