### PR TITLE
Storage: canonicalize molecular formula before query

### DIFF
--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -48,7 +48,7 @@ dependencies:
 
 #   QCArchive includes
   - qcengine >=0.11.0
-  - qcelemental >=0.9.0
+  - qcelemental >=0.13.1
 
 #   Pip includes
   - pip:

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -39,4 +39,4 @@ dependencies:
 
 #   QCArchive includes
   - qcengine >=0.11.0
-  - qcelemental >=0.11.0
+  - qcelemental >=0.13.1

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -48,7 +48,7 @@ dependencies:
   - pytest-cov
   - requests-mock
 """
-qca_ecosystem_template = ["qcengine >=0.11.0", "qcelemental >=0.9.0"]
+qca_ecosystem_template = ["qcengine >=0.11.0", "qcelemental >=0.13.1"]
 
 pip_depends_template = []
 

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -47,4 +47,4 @@ dependencies:
 
 #   QCArchive includes
   - qcengine >=0.11.0
-  - qcelemental >=0.9.0
+  - qcelemental >=0.13.1

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -386,7 +386,8 @@ class FractalClient(object):
         molecule_hash : QueryStr, optional
             Queries the Molecule ``molecule_hash`` field.
         molecular_formula : QueryStr, optional
-            Queries the Molecule ``molecular_formula`` field.
+            Queries the Molecule ``molecular_formula`` field. Molecular formulas are case-sensitive.
+            Molecular formulas are not order-sensitive (e.g. "H2O == OH2 != Oh2").
         limit : Optional[int], optional
             The maximum number of Molecules to query
         skip : int, optional

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -723,33 +723,14 @@ class SQLAlchemySocket:
         return ret
 
     def get_molecules(self, id=None, molecule_hash=None, molecular_formula=None, limit: int = None, skip: int = 0):
-        def canonicalize_formula(string: str) -> str:
-            """Converts a chemical formula to alphabetical order, matching behavior in qcel"""
-            import re
-            from collections import defaultdict
-
-            matches = re.findall("[A-Z][^A-Z]*", string)
-            count = defaultdict(int)
-            for match in matches:
-                match_n = re.match("(\D+)(\d*)", match)
-                assert match_n
-                if match_n.group(2) == "":
-                    n = 1
-                else:
-                    n = int(match_n.group(2))
-                count[match_n.group(1)] += n
-            ret = []
-            for k in sorted(count.keys()):
-                c = count[k]
-                ret.append(k)
-                if c > 1:
-                    ret.append(str(c))
-            return "".join(ret)
-
-        if isinstance(molecular_formula, str):
-            molecular_formula = canonicalize_formula(molecular_formula)
-        elif isinstance(molecular_formula, list):
-            molecular_formula = [canonicalize_formula(form) for form in molecular_formula]
+        try:
+            if isinstance(molecular_formula, str):
+                molecular_formula = qcelemental.molutil.order_molecular_formula(molecular_formula)
+            elif isinstance(molecular_formula, list):
+                molecular_formula = [qcelemental.molutil.order_molecular_formula(form) for form in molecular_formula]
+        except ValueError:
+            # Probably, the user provided an invalid chemical formula
+            pass
 
         meta = get_metadata_template()
 

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -723,6 +723,31 @@ class SQLAlchemySocket:
         return ret
 
     def get_molecules(self, id=None, molecule_hash=None, molecular_formula=None, limit: int = None, skip: int = 0):
+        def canonicalize_formula(string: str) -> str:
+            """Converts a chemical formula to alphabetical order, matching behavior in qcel"""
+            import re
+            from collections import defaultdict
+            matches = re.findall("[A-Z][^A-Z]*", string)
+            count = defaultdict(int)
+            for match in matches:
+                match_n = re.match("(\D+)(\d*)", match)
+                assert match_n
+                if match_n.group(2) == "":
+                    n = 1
+                else:
+                    n = int(match_n.group(2))
+                count[match_n.group(1)] += n
+            ret = []
+            for k in sorted(count.keys()):
+                c = count[k]
+                ret.append(k)
+                if c > 1:
+                    ret.append(str(c))
+            return "".join(ret)
+        if isinstance(molecular_formula, str):
+            molecular_formula = canonicalize_formula(molecular_formula)
+        elif isinstance(molecular_formula, list):
+            molecular_formula = [canonicalize_formula(form) for form in molecular_formula]
 
         meta = get_metadata_template()
 

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -727,6 +727,7 @@ class SQLAlchemySocket:
             """Converts a chemical formula to alphabetical order, matching behavior in qcel"""
             import re
             from collections import defaultdict
+
             matches = re.findall("[A-Z][^A-Z]*", string)
             count = defaultdict(int)
             for match in matches:
@@ -744,6 +745,7 @@ class SQLAlchemySocket:
                 if c > 1:
                     ret.append(str(c))
             return "".join(ret)
+
         if isinstance(molecular_formula, str):
             molecular_formula = canonicalize_formula(molecular_formula)
         elif isinstance(molecular_formula, list):

--- a/qcfractal/tests/test_storage.py
+++ b/qcfractal/tests/test_storage.py
@@ -1193,18 +1193,56 @@ def test_mol_pagination(storage_socket):
 
     inserted = storage_socket.add_molecules(molecules)
 
-    assert inserted["meta"]["n_inserted"] == total
+    try:
+        assert inserted["meta"]["n_inserted"] == total
 
-    ret = storage_socket.get_molecules(skip=1)
-    assert len(ret["data"]) == total - 1
-    assert ret["meta"]["n_found"] == total
+        ret = storage_socket.get_molecules(skip=1)
+        assert len(ret["data"]) == total - 1
+        assert ret["meta"]["n_found"] == total
 
-    ret = storage_socket.get_molecules(skip=total + 1)
-    assert len(ret["data"]) == 0
-    assert ret["meta"]["n_found"] == total
+        ret = storage_socket.get_molecules(skip=total + 1)
+        assert len(ret["data"]) == 0
+        assert ret["meta"]["n_found"] == total
 
-    # cleanup
-    storage_socket.del_molecules(inserted["data"])
+    finally:
+        # cleanup
+        storage_socket.del_molecules(inserted["data"])
+
+
+def test_mol_formula(storage_socket):
+    """
+        Test Molecule pagination
+    """
+
+    assert len(storage_socket.get_molecules()["data"]) == 0
+    mol_names = [
+        "water_dimer_minima.psimol",
+    ]
+    total = len(mol_names)
+    molecules = []
+    for mol_name in mol_names:
+        mol = ptl.data.get_molecule(mol_name)
+        molecules.append(mol)
+
+    inserted = storage_socket.add_molecules(molecules)
+    try:
+        assert inserted["meta"]["n_inserted"] == total
+
+        ret = storage_socket.get_molecules(molecular_formula="H4O2")
+        assert len(ret["data"]) == 1
+        assert ret["meta"]["n_found"] == 1
+
+        ret = storage_socket.get_molecules(molecular_formula="O2H4")
+        assert len(ret["data"]) == 1
+        assert ret["meta"]["n_found"] == 1
+
+        ret = storage_socket.get_molecules(molecular_formula="H4o2")
+        assert len(ret["data"]) == 0
+        assert ret["meta"]["n_found"] == 0
+
+    finally:
+        # cleanup
+        storage_socket.del_molecules(inserted["data"])
 
 
 def test_reset_task_blocks(storage_socket):

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
             #            'double-conversion >=3.0.0',
             # QCArchive depends
             "qcengine>=0.11.0",
-            "qcelemental>=0.11.0",
+            "qcelemental>=0.13.1",
         ],
         entry_points={
             "console_scripts": [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR sorts chemical formula to match qcel's order before querying the database. Now, e.g. searching for "NH3" will work.

I implemented the canonicalization code inside storage_socket, which is definitely the wrong place. Unfortunately, I think this should go in qcel?

## Changelog description
Molecule queries filtered on molecular formula no longer depend on the order of elements.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
