### PR TITLE
Fix conda paths in dockerfiles

### DIFF
--- a/devtools/docker/qcarchive_worker_openff/Dockerfile
+++ b/devtools/docker/qcarchive_worker_openff/Dockerfile
@@ -5,6 +5,6 @@ RUN conda env create -n qcfractal qcarchive/qcarchive-worker-openff
 RUN groupadd -g 999 qcfractal && \
     useradd -m -r -u 999 -g qcfractal qcfractal
 USER qcfractal
-ENV PATH /opt/local/conda/envs/base/bin/:$PATH
+ENV PATH /opt/conda/envs/qcfractal/bin/:$PATH
 RUN echo "source activate qcfractal" > ~/.bashrc
 ENTRYPOINT /bin/bash -c "source activate qcfractal && qcfractal-manager --config-file /etc/qcfractal-manager/manager.yaml -v"

--- a/devtools/docker/qcfractal/Dockerfile
+++ b/devtools/docker/qcfractal/Dockerfile
@@ -5,5 +5,5 @@ RUN conda env create -n qcfractal qcarchive/qcfractal
 RUN groupadd -g 999 qcfractal && \
     useradd -m -r -u 999 -g qcfractal qcfractal
 USER qcfractal
-ENV PATH /opt/local/conda/envs/base/bin/:$PATH
+ENV PATH /opt/conda/envs/qcfractal/bin/:$PATH
 RUN echo "source activate qcfractal" > ~/.bashrc

--- a/devtools/docker/qcfractal_snowflake/Dockerfile
+++ b/devtools/docker/qcfractal_snowflake/Dockerfile
@@ -6,5 +6,5 @@ RUN /opt/conda/envs/qcfractal/bin/jupyter-nbextension enable nglview --py --sys-
 RUN groupadd -g 999 qcfractal && \
     useradd -m -r -u 999 -g qcfractal qcfractal
 USER qcfractal
-ENV PATH /opt/local/conda/envs/base/bin/:$PATH
+ENV PATH /opt/conda/envs/qcfractal/bin/:$PATH
 RUN echo "source activate qcfractal" > ~/.bashrc


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR fixes the PATH inside the Dockerfiles.

## Changelog description
Fixed an issue where Docker images did not have qcfractal in their PATH. 

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [x] Ready to go
