### PR TITLE
Dataset: fix bug revealed by pandas 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_script:
   - psql --version
 
 script:
-  - pytest -v -rsx --runslow --cov=qcfractal qcfractal/
+  - pytest -v -rsx --runslow --cov=qcfractal qcfractal/ --tb=short
 
 notifications:
   email: false

--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -9,7 +9,7 @@ dependencies:
   - msgpack-python >=0.6.1
   - numpy
   - pyyaml >=5.1
-  - pydantic >=1.0.0
+  - pydantic >=1.4.0
   - requests
   - tornado
 

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -9,7 +9,7 @@ dependencies:
   - msgpack-python >=0.6.1
   - numpy
   - pyyaml >=5.1
-  - pydantic >=1.0.0
+  - pydantic >=1.4.0
   - requests
   - tornado
 

--- a/devtools/conda-envs/dev_head.yaml
+++ b/devtools/conda-envs/dev_head.yaml
@@ -9,7 +9,7 @@ dependencies:
   - msgpack-python >=0.6.1
   - numpy
   - pyyaml >=5.1
-  - pydantic >=1.0.0
+  - pydantic >=1.4.0
   - requests
   - tornado
 

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -20,7 +20,7 @@ dependencies:
   - msgpack-python >=0.6.1
   - numpy
   - pyyaml >=5.1
-  - pydantic >=1.0.0
+  - pydantic >=1.4.0
   - requests
   - tornado
 

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -10,7 +10,7 @@ dependencies:
   - msgpack-python >=0.6.1
   - numpy
   - pyyaml >=5.1
-  - pydantic >=1.0.0
+  - pydantic >=1.4.0
   - requests
   - tornado
 

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -442,7 +442,7 @@ class Dataset(Collection):
         # Sort
         sort_index = ["native"] + list(self.data.history_keys[:-1])
         if "stoichiometry" in ret.columns:
-            sort_index += ["stoichiometry"]
+            sort_index += ["stoichiometry", "name"]
         ret.set_index(sort_index, inplace=True)
         ret.sort_index(inplace=True)
         ret.reset_index(inplace=True)

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -291,7 +291,7 @@ class ReactionDataset(Dataset):
 
             # Multiply by coefficients and sum
             df["return_result"] *= df["coefficient"]
-            df = df.groupby(["name"])["return_result"].sum(skipna=False)
+            df = df.groupby(["name"])["return_result"].sum()
             df[null_mask] = np.nan
             return df
 

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -329,7 +329,7 @@ class ResultRecord(RecordBase):
         if missing:
 
             # Translate a return value
-            proj = {self.wavefunction["return_map"].get(x, x): True for x in missing}
+            proj = [self.wavefunction["return_map"].get(x, x) for x in missing]
 
             self.cache["wavefunction"].update(
                 self.client.custom_query(

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -117,6 +117,8 @@ class FractalServer:
         # Service options
         max_active_services: int = 20,
         service_frequency: float = 60,
+        # Testing functions
+        skip_storage_version_check=True,
     ):
         """QCFractal initialization
 
@@ -244,6 +246,7 @@ class FractalServer:
             bypass_security=storage_bypass_security,
             allow_read=allow_read,
             max_limit=query_limit,
+            skip_version_check=skip_storage_version_check,
         )
 
         if view_enabled:

--- a/qcfractal/snowflake.py
+++ b/qcfractal/snowflake.py
@@ -92,7 +92,9 @@ class FractalSnowflake(FractalServer):
             self._storage_uri = storage_uri
 
             if reset_database:
-                socket = storage_socket_factory(self._storage_uri, project_name=storage_project_name)
+                socket = storage_socket_factory(
+                    self._storage_uri, project_name=storage_project_name, skip_version_check=True
+                )
                 socket._clear_db(socket._project_name)
                 del socket
 

--- a/qcfractal/storage_sockets/db_queries.py
+++ b/qcfractal/storage_sockets/db_queries.py
@@ -402,6 +402,7 @@ class OptimizationQueries(QueryBase):
         for rec in query_result:
             self._remove_excluded_keys(rec)
             key = rec.pop("opt_id")
+            rec = {k: v for k, v in rec.items() if v is not None}
             ret[key] = Molecule(**rec)
 
         return ret
@@ -432,6 +433,7 @@ class OptimizationQueries(QueryBase):
         for rec in query_result:
             self._remove_excluded_keys(rec)
             key = rec.pop("opt_id")
+            rec = {k: v for k, v in rec.items() if v is not None}
             ret[key] = Molecule(**rec)
 
         return ret

--- a/qcfractal/storage_sockets/models/sql_base.py
+++ b/qcfractal/storage_sockets/models/sql_base.py
@@ -18,10 +18,16 @@ class MsgpackExt(TypeDecorator):
     impl = BYTEA
 
     def process_bind_param(self, value, dialect):
-        return msgpackext_dumps(value)
+        if value is None:
+            return value
+        else:
+            return msgpackext_dumps(value)
 
     def process_result_value(self, value, dialect):
-        return msgpackext_loads(value)
+        if value is None:
+            return value
+        else:
+            return msgpackext_loads(value)
 
 
 @as_declarative()

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -734,9 +734,13 @@ class SQLAlchemySocket:
 
         meta["success"] = True
 
-        # ret["meta"]["errors"].extend(errors)
-
-        data = [Molecule(**d, validate=False, validated=True) for d in rdata]
+        # This is required for sparse molecules as we don't know which values are spase
+        # We are lucky that None is the default and doesn't mean anything in Molecule
+        # This strategy does not work for other objects
+        data = []
+        for mol_dict in rdata:
+            mol_dict = {k:v for k, v in mol_dict.items() if v is not None}
+            data.append(Molecule(**mol_dict, validate=False, validated=True))
 
         return {"meta": meta, "data": data}
 

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -739,7 +739,7 @@ class SQLAlchemySocket:
         # This strategy does not work for other objects
         data = []
         for mol_dict in rdata:
-            mol_dict = {k:v for k, v in mol_dict.items() if v is not None}
+            mol_dict = {k: v for k, v in mol_dict.items() if v is not None}
             data.append(Molecule(**mol_dict, validate=False, validated=True))
 
         return {"meta": meta, "data": data}

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -165,6 +165,7 @@ class SQLAlchemySocket:
         logger: "Logger" = None,
         sql_echo: bool = False,
         max_limit: int = 1000,
+        skip_version_check: bool = False,
     ):
         """
         Constructs a new SQLAlchemy socket
@@ -210,7 +211,7 @@ class SQLAlchemySocket:
         # check version compatibility
         db_ver = self.check_lib_versions()
         self.logger.info(f"DB versions: {db_ver}")
-        if db_ver and qcfractal.__version__ != db_ver["fractal_version"]:
+        if (not skip_version_check) and (db_ver and qcfractal.__version__ != db_ver["fractal_version"]):
             raise TypeError(
                 f"You are running QCFractal version {qcfractal.__version__} "
                 f'with an older DB version ({db_ver["fractal_version"]}). '

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -463,6 +463,7 @@ def managed_compute_server(request, postgres_server):
             loop=loop,
             queue_socket=adapter_client,
             ssl_options=False,
+            skip_storage_version_check=True,
         )
 
         # Clean and re-init the database

--- a/qcfractal/tests/test_authentication.py
+++ b/qcfractal/tests/test_authentication.py
@@ -34,6 +34,7 @@ def sec_server(request, postgres_server):
             storage_project_name=storage_name,
             loop=loop,
             security="local",
+            skip_storage_version_check=True,
         )
 
         # Clean and re-init the databse

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -118,7 +118,7 @@ def test_queue_error(fractal_compute_server):
 
     client = ptl.FractalClient(fractal_compute_server)
 
-    hooh = ptl.data.get_molecule("hooh.json").copy(update={"connectivity": None})
+    hooh = ptl.data.get_molecule("hooh.json").copy(update={"connectivity_": None})
     compute_ret = client.add_compute("rdkit", "UFF", "", "energy", None, hooh)
 
     # Pull out a special iteration on the queue manager

--- a/qcfractal/tests/test_sqlalchemy.py
+++ b/qcfractal/tests/test_sqlalchemy.py
@@ -351,7 +351,7 @@ def test_add_task_queue(storage_socket, session, molecules_H4O2):
     session.add(result)
     session.commit()
 
-    task = TaskQueueORM(base_result_obj=result)
+    task = TaskQueueORM(base_result_obj=result, spec={"something": True})
     session.add(task)
     session.commit()
 

--- a/qcfractal/tests/test_storage_queries.py
+++ b/qcfractal/tests/test_storage_queries.py
@@ -102,7 +102,7 @@ def test_torsiondrive_initial_final_molecule(torsiondrive_fixture, fractal_compu
     mol = r["data"][0]
 
     # Msgpack field
-    assert isinstance(msgpackext_loads(mol["mass_numbers"]), np.ndarray)  # TODO
+    assert isinstance(msgpackext_loads(mol["geometry"]), np.ndarray)  # TODO
 
     # Sample fields in the molecule dict
     assert all(x in mol.keys() for x in ["schema_name", "symbols", "geometry", "molecular_charge"])

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
             "tornado",
             "requests",
             "pyyaml >=5.1",
-            "pydantic >=1.0.0",
+            "pydantic >=1.4.0",
             # Security dependencies
             "bcrypt",
             "cryptography",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
CI is failing. This seems to be caused by `df = df.groupby(["name"])["return_result"].sum(skipna=True)`. [It appears](https://github.com/pandas-dev/pandas/issues/20824) that `skipna` was never a valid kwarg of `groupby().sum()`, but that it was not checked until pandas 1.0. This PR removes `skipna=True`; the default behavior is to skip NaNs already.

## Changelog description
Fixed a bug that caused errors with pandas v1.0.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
