### PR TITLE
Return collected records in `query`

### DIFF
--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -501,7 +501,7 @@ class BaseProcedureDataset(Collection):
 
         return submitted
 
-    def query(self, specification: str, force: bool = False) -> str:
+    def query(self, specification: str, force: bool = False) -> pd.Series:
         """Queries a given specification from the server
 
         Parameters
@@ -510,6 +510,11 @@ class BaseProcedureDataset(Collection):
             The specification name to query
         force : bool, optional
             Force a fresh query if the specification already exists.
+
+        Returns
+        -------
+        pd.Series
+            Records collected from the server
         """
         # Try to get the specification, will throw if not found.
         spec = self.get_specification(specification)
@@ -540,7 +545,7 @@ class BaseProcedureDataset(Collection):
 
         self.df[spec.name] = df[spec.name]
 
-        return spec.name
+        return df[spec.name]
 
     def status(
         self,


### PR DESCRIPTION
Returning the records is more useful than just returning the specification name.

Addresses #562 

<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Previously, the `query` method for dataset objects merely returned the specification name. This was not very useful, as one would expect to receive data they can use after calling `query`. This PR returns the data collected from the server after calling `query`.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
`query` method for datasets now returns collected records

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
