### PR TITLE
add_results and update_results bulk function support

### DIFF
--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1165,7 +1165,7 @@ class SQLAlchemySocket:
                     # If new or duplicate, add the id to the return list
                     result_ids.append(id)
 
-            session.bulk_save_objects(results_list)
+            session.bulk_save_objects(results_list,return_defaults=True)
             session.commit()
         meta["success"] = True
 
@@ -1202,7 +1202,7 @@ class SQLAlchemySocket:
 
                 # result_db = session.query(ResultORM).filter_by(id=result.id).first()
             # data = result.dict()
-            result_list.append(ResultORM(**result.dict())
+            result_list.append(ResultORM(**result.dict()))
             updated_count += 1
 
                 # for attr, val in data.items():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
changes to some functions in the ```sqlalchemy_socket.py``` file for performance + one benchmark file ```bench_result_add.py```

## Changelog description
The changes to add_results and update_results show performance boost of up to 2x when the number of results to be saved reaches 1000.

## Status
Ready to go.
