### PR TITLE
Pin pint !=0.11

### DIFF
--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -37,7 +37,7 @@ dependencies:
   - pytest-cov
   - requests-mock
 
-  # Temportary pins
+  # Temporary pins
   - pint !=0.11
 
 #   Environment specific includes

--- a/devtools/conda-envs/adapters.yaml
+++ b/devtools/conda-envs/adapters.yaml
@@ -37,6 +37,9 @@ dependencies:
   - pytest-cov
   - requests-mock
 
+  # Temportary pins
+  - pint !=0.11
+
 #   Environment specific includes
   - rdkit
   - dask

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -37,7 +37,7 @@ dependencies:
   - pytest-cov
   - requests-mock
 
-  # Temportary pins
+  # Temporary pins
   - pint !=0.11
 
 #   QCArchive includes

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -37,6 +37,9 @@ dependencies:
   - pytest-cov
   - requests-mock
 
+  # Temportary pins
+  - pint !=0.11
+
 #   QCArchive includes
   - qcengine >=0.11.0
   - qcelemental >=0.13.1

--- a/devtools/conda-envs/dev_head.yaml
+++ b/devtools/conda-envs/dev_head.yaml
@@ -37,7 +37,7 @@ dependencies:
   - pytest-cov
   - requests-mock
 
-  # Temportary pins
+  # Temporary pins
   - pint !=0.11
 
 #   Environment specific includes

--- a/devtools/conda-envs/dev_head.yaml
+++ b/devtools/conda-envs/dev_head.yaml
@@ -37,6 +37,9 @@ dependencies:
   - pytest-cov
   - requests-mock
 
+  # Temportary pins
+  - pint !=0.11
+
 #   Environment specific includes
   - rdkit
 

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -48,7 +48,7 @@ dependencies:
   - pytest-cov
   - requests-mock
   
-  # Temportary pins
+  # Temporary pins
   - pint !=0.11
 """
 qca_ecosystem_template = ["qcengine >=0.11.0", "qcelemental >=0.13.1"]

--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -47,6 +47,9 @@ dependencies:
   - pytest
   - pytest-cov
   - requests-mock
+  
+  # Temportary pins
+  - pint !=0.11
 """
 qca_ecosystem_template = ["qcengine >=0.11.0", "qcelemental >=0.13.1"]
 

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -38,6 +38,9 @@ dependencies:
   - pytest-cov
   - requests-mock
 
+  # Temportary pins
+  - pint !=0.11
+
 #   Environment specific includes
   - psi4>=1.3
   - rdkit

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -38,7 +38,7 @@ dependencies:
   - pytest-cov
   - requests-mock
 
-  # Temportary pins
+  # Temporary pins
   - pint !=0.11
 
 #   Environment specific includes

--- a/devtools/prod-envs/qcarchive_worker_openff.yaml
+++ b/devtools/prod-envs/qcarchive_worker_openff.yaml
@@ -18,3 +18,6 @@ dependencies:
 
     # Testing
   - pytest
+
+    # Temporary pins
+  - pint !=0.11

--- a/devtools/prod-envs/qcfractal.yaml
+++ b/devtools/prod-envs/qcfractal.yaml
@@ -10,3 +10,6 @@ dependencies:
 
     # Testing
   - pytest
+
+    # Temporary pins
+  - pint !=0.11

--- a/devtools/prod-envs/qcfractal_snowflake.yaml
+++ b/devtools/prod-envs/qcfractal_snowflake.yaml
@@ -22,3 +22,6 @@ dependencies:
     # Viz
   - jupyter
   - nglview
+
+  # Temporary pins
+  - pint !=0.11

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ if __name__ == "__main__":
             # QCArchive depends
             "qcengine>=0.11.0",
             "qcelemental>=0.13.1",
+            # Temporary pins
+            "pint!=0.11"
         ],
         entry_points={
             "console_scripts": [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR pins pint to avoid v0.11 so that CI will pass. This is intended to be reverted once the problem is either fixed upstream or mitigated in qcel.

## Changelog description
N/A

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
