### PR TITLE
RDS: visualize skip incomplete columns

### DIFF
--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -873,7 +873,7 @@ class Dataset(Collection):
                 q["stoich"] = q.pop("stoichiometry")
             values = self.get_values(**q)
 
-            if (not show_incomplete) and values.isnull().any():
+            if (not show_incomplete) and values.isnull().any().any():
                 continue
 
             # Create the statistics

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -929,6 +929,7 @@ class Dataset(Collection):
         bench: Optional[str] = None,
         kind: str = "bar",
         return_figure: Optional[bool] = None,
+        show_incomplete: bool = False,
     ) -> "plotly.Figure":
         """
         Parameters
@@ -952,6 +953,8 @@ class Dataset(Collection):
         return_figure : Optional[bool], optional
             If True, return the raw plotly figure. If False, returns a hosted iPlot.
             If None, return a iPlot display in Jupyter notebook and a raw plotly figure in all other circumstances.
+        show_incomplete: bool, optional
+            Display statistics method/basis set combinations where results are incomplete
 
         Returns
         -------

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -873,8 +873,8 @@ class Dataset(Collection):
                 q["stoich"] = q.pop("stoichiometry")
             values = self.get_values(**q)
 
-            if (not show_incomplete) and values.isnull().any().any():
-                continue
+            if not show_incomplete:
+                values = values.dropna(axis=1, how="any")
 
             # Create the statistics
             stat = self.statistics(metric, values, bench=bench)

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -785,7 +785,7 @@ class Dataset(Collection):
         return_figure=None,
         digits=3,
         kind="bar",
-        show_incomplete: bool = False
+        show_incomplete: bool = False,
     ) -> "plotly.Figure":
 
         # Validate query dimensions

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -785,6 +785,7 @@ class Dataset(Collection):
         return_figure=None,
         digits=3,
         kind="bar",
+        show_incomplete: bool = False
     ) -> "plotly.Figure":
 
         # Validate query dimensions
@@ -871,6 +872,9 @@ class Dataset(Collection):
             if "stoichiometry" in q:
                 q["stoich"] = q.pop("stoichiometry")
             values = self.get_values(**q)
+
+            if (not show_incomplete) and values.isnull().any():
+                continue
 
             # Create the statistics
             stat = self.statistics(metric, values, bench=bench)

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -356,7 +356,7 @@ class ReactionDataset(Dataset):
         bench: Optional[str] = None,
         kind: str = "bar",
         return_figure: Optional[bool] = None,
-        show_incomplete: bool = False
+        show_incomplete: bool = False,
     ) -> "plotly.Figure":
         """
         Parameters
@@ -392,7 +392,15 @@ class ReactionDataset(Dataset):
         query = {"method": method, "basis": basis, "keywords": keywords, "program": program, "stoichiometry": stoich}
         query = {k: v for k, v in query.items() if v is not None}
 
-        return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind, show_incomplete=show_incomplete)
+        return self._visualize(
+            metric,
+            bench,
+            query=query,
+            groupby=groupby,
+            return_figure=return_figure,
+            kind=kind,
+            show_incomplete=show_incomplete,
+        )
 
     def get_molecules(
         self,

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -473,8 +473,6 @@ class ReactionDataset(Dataset):
         ret = []
         for s in stoich:
             name, _, history = self._default_parameters(program, method, basis, keywords, stoich=s)
-            if len(self.list_records(**history)) == 0:
-                raise KeyError(f"Requested query ({name}) did not match a known record.")
             history.pop("stoichiometry")
             indexer, names = self._molecule_indexer(stoich=s, subset=subset, force=True)
             df = self._get_records(

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -383,6 +383,7 @@ class ReactionDataset(Dataset):
             If True, return the raw plotly figure. If False, returns a hosted iPlot. If None, return a iPlot display in Jupyter notebook and a raw plotly figure in all other circumstances.
         show_incomplete: bool, optional
             Display statistics method/basis set combinations where results are incomplete
+
         Returns
         -------
         plotly.Figure

--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -356,6 +356,7 @@ class ReactionDataset(Dataset):
         bench: Optional[str] = None,
         kind: str = "bar",
         return_figure: Optional[bool] = None,
+        show_incomplete: bool = False
     ) -> "plotly.Figure":
         """
         Parameters
@@ -380,7 +381,8 @@ class ReactionDataset(Dataset):
             The kind of chart to produce, either 'bar' or 'violin'
         return_figure : Optional[bool], optional
             If True, return the raw plotly figure. If False, returns a hosted iPlot. If None, return a iPlot display in Jupyter notebook and a raw plotly figure in all other circumstances.
-
+        show_incomplete: bool, optional
+            Display statistics method/basis set combinations where results are incomplete
         Returns
         -------
         plotly.Figure
@@ -390,7 +392,7 @@ class ReactionDataset(Dataset):
         query = {"method": method, "basis": basis, "keywords": keywords, "program": program, "stoichiometry": stoich}
         query = {k: v for k, v in query.items() if v is not None}
 
-        return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind)
+        return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind, show_incomplete=show_incomplete)
 
     def get_molecules(
         self,

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -638,10 +638,6 @@ def test_reactiondataset_dftd3_records(reactiondataset_dftd3_fixture_fixture):
     with pytest.raises(KeyError):
         ds.get_records("B3LYP", "6-31g", stoich="cp5")
 
-    # Wrong method
-    with pytest.raises(KeyError):
-        ds.get_records("Fake Method", "6-31g", stoich="cp")
-
 
 def test_reactiondataset_dftd3_energies(reactiondataset_dftd3_fixture_fixture):
     client, ds = reactiondataset_dftd3_fixture_fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR adds an option `show_incomplete` to ReactionDataset.visualize to skip data columns with missing data. Default True.

It also fixes an issue that prevented monomer records from being queried in RDS.

## Changelog description
Added an option `show_incomplete` to ReactionDataset.visualize to skip data columns with missing data. Default True.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
