### PR TITLE
RDS: fix issue when stoich has only one molecule

### DIFF
--- a/qcfractal/interface/collections/reaction_dataset.py
+++ b/qcfractal/interface/collections/reaction_dataset.py
@@ -160,7 +160,8 @@ class ReactionDataset(Dataset):
     def _validate_stoich(self, stoich: Union[List[str], str], subset=None, force: bool = False) -> None:
         if isinstance(stoich, str):
             stoich = [stoich]
-
+        if isinstance(subset, str):
+            subset = [subset]
         valid_stoich = self.valid_stoich(subset=subset, force=force)
         for s in stoich:
             if s.lower() not in valid_stoich:
@@ -428,6 +429,9 @@ class ReactionDataset(Dataset):
 
         self._check_client()
         self._check_state()
+        if isinstance(subset, str):
+            subset = [subset]
+
         self._validate_stoich(stoich, subset=subset, force=force)
 
         indexer, names = self._molecule_indexer(stoich=stoich, subset=subset, force=force)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR fixes an issue with `RDS.get_molecules` that arises when requesting a string subset corresponding to a record with only one molecule in a particular stoichiometry -- this issue can arise for conformer datasets.  Resovles MolSSI/QCArchiveWebApps#59. 

## Changelog description
Fixes an issue with `RDS.get_molecules` that could arise for conformer datasets.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
