### PR TITLE
Change conda-envs to use dev psi4

### DIFF
--- a/devtools/conda-envs/generate_envs.py
+++ b/devtools/conda-envs/generate_envs.py
@@ -114,7 +114,7 @@ environs = [
 
         # Tests for the OpenFF toolchain (geometric and torsiondrive)
         "filename": "openff.yaml",
-        "channels": ["psi4"],
+        "channels": ["psi4/label/dev"],
         "dependencies": ["psi4>=1.3", "rdkit", "geometric >=0.9.3", "torsiondrive", "dftd3"],
     },
     {

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -1,7 +1,7 @@
 name: qcarchive
 channels:
   - defaults
-  - psi4
+  - psi4/label/dev
   - conda-forge
 dependencies:
   - python

--- a/devtools/prod-envs/qcarchive_worker_openff.yaml
+++ b/devtools/prod-envs/qcarchive_worker_openff.yaml
@@ -2,14 +2,15 @@ name: qcarchive-worker-openff
 channels:
   - defaults
   - conda-forge
+  - psi4/label/dev
 dependencies:
   - python <=3.7
   - qcfractal
 
     # Compute engines
-  - psi4::psi4 >=1.3.0
-  - psi4::dftd3
-  - psi4::gcp
+  - psi4 >=1.3.0
+  - dftd3
+  - gcp
   - rdkit
   - qcengine >=0.13.0
     


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR changes the openff conda environments to use psi4/label/dev instead of psi4. This makes it possible to use these environments on mac.

## Changelog description
N/A

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
