### PR TITLE
Tasks submission to queue database optimization

### DIFF
--- a/benchmarks/bench_queue_submit.py
+++ b/benchmarks/bench_queue_submit.py
@@ -67,7 +67,7 @@ if run_tests:
     assert ret1[1] == ret2[1]
     assert ret1[2] == ret2[2]
 
-    print("Running timings for add and update...\n")
+    print("Running timings for add...\n")
     for trial in mol_trials:
         tasks = [create_unique_task() for x in range(trial)]
 
@@ -83,4 +83,4 @@ if run_tests:
         for r, rid in zip(tasks, ret):
             r.__dict__["id"] = rid
 
-        print()
+    print()

--- a/benchmarks/bench_queue_submit.py
+++ b/benchmarks/bench_queue_submit.py
@@ -1,0 +1,86 @@
+import time
+from qcfractal.interface.models.records import ResultRecord
+from qcfractal.interface.models import KeywordSet, TaskRecord
+import qcfractal
+import qcfractal.interface as ptl
+import numpy as np
+import qcelemental as qcel
+
+print("Building and clearing the database...\n")
+db_name = "molecule_tests"
+storage = qcfractal.storage_socket_factory(f"postgresql://localhost:5432/{db_name}")
+storage._delete_DB_data(db_name)
+
+run_tests = True
+mol_trials = [1, 5, 10, 25, 50, 100, 500, 1000]
+
+COUNTER_MOL = 0
+
+def build_unique_mol():
+    global COUNTER_MOL
+    mol = qcel.models.Molecule(symbols=["He", "He"], geometry=np.random.rand(2, 3) + COUNTER_MOL, validated=True)
+    COUNTER_MOL += 1
+    return mol
+
+
+def create_unique_result():
+
+    mol = build_unique_mol()
+    ret = storage.add_molecules([mol])["data"]
+    result = ResultRecord(version='1', driver='energy', program='games', molecule=ret[0],
+                          method='test', basis='6-31g')
+
+    return result
+
+def create_unique_task():
+
+    result = create_unique_result()
+    res = storage.add_results([result])["data"]
+    task = ptl.models.TaskRecord(
+        **{
+            # "hash_index": idx,  # not used anymore
+            "spec": {"function": "qcengine.compute_procedure", "args": [{"json_blob": "data"}], "kwargs": {}},
+            "tag": None,
+            "program": "p1",
+            "parser": "",
+            "base_result": res[0],
+        }
+    )
+    return task;
+
+if run_tests:
+    print("Running tests...\n")
+    # Tests
+    test_task1 = create_unique_task()
+    test_task2 = create_unique_task()
+    test_task3 = create_unique_task()
+
+    # Sequential
+    ret = storage.queue_submit([test_task1, test_task2, test_task3])["data"]
+    assert ret[0] != ret[1]
+    assert ret[1] != ret[2]
+
+    # Multiple inserts
+    ret1 = storage.queue_submit([test_task1, test_task2, test_task3])["data"]
+    ret2 = storage.queue_submit([test_task1, test_task2, test_task3])["data"]
+    assert ret1[0] == ret2[0]
+    assert ret1[1] == ret2[1]
+    assert ret1[2] == ret2[2]
+
+    print("Running timings for add and update...\n")
+    for trial in mol_trials:
+        tasks = [create_unique_task() for x in range(trial)]
+
+
+        t = time.time()
+        ret = storage.queue_submit(tasks)["data"]
+
+        ttime = (time.time() - t) * 1000
+        time_per_mol = ttime / trial
+
+        print(f"add   : {trial:6d} {ttime:9.3f} {time_per_mol:6.3f}")
+
+        for r, rid in zip(tasks, ret):
+            r.__dict__["id"] = rid
+
+        print()

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -1,7 +1,7 @@
 name: qcarchive
 channels:
   - defaults
-  - psi4
+  - psi4/label/dev
   - conda-forge
 dependencies:
   - python

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1900,7 +1900,7 @@ class SQLAlchemySocket:
         results = ["placeholder"] * len(data)
 
         with self.session_scope() as session:
-
+            # preserving all the base results for later check
             all_base_results = [record.base_result for record in data]
             query_res = (
                 session.query(TaskQueueORM.id, TaskQueueORM.base_result_id)
@@ -1908,13 +1908,18 @@ class SQLAlchemySocket:
                 .all()
             )
 
-            # existing_base_results = map(lambda x: str(x), found_base_results)
+            # constructing a dict of found tasks and their ids
             found_dict = {str(base_result_id): str(task_id) for task_id, base_result_id in query_res}
             new_tasks, new_idx = [], []
+            duplicate_idx = []
             for task_num, record in enumerate(data):
 
                 if found_dict.get(record.base_result):
+                    # if found, get id from found_dict
+                    # Note: found_dict may return a task object because the duplicate id is of an object in the input.
                     results[task_num] = found_dict.get(record.base_result)
+                    # add index of duplicates
+                    duplicate_idx.append(task_num)
                     meta["duplicates"].append(task_num)
 
                 else:
@@ -1922,42 +1927,23 @@ class SQLAlchemySocket:
                     task = TaskQueueORM(**task_dict)
                     new_idx.append(task_num)
                     task.priority = task.priority.value
+                    # append all the new tasks that should be added
                     new_tasks.append(task)
+                    # add the (yet to be) inserted object id to dictionary
+                    found_dict[record.base_result] = task
 
             session.add_all(new_tasks)
             session.commit()
 
             meta["n_inserted"] += len(new_tasks)
+            # setting the id for new inserted objects, cannot be done before commiting as new objects do not have ids
             for i, task_idx in enumerate(new_idx):
                 results[task_idx] = str(new_tasks[i].id)
 
-        # results = []
-        # with self.session_scope() as session:
-        #     for task_num, record in enumerate(data):
-        #         try:
-        #             task_dict = record.dict(exclude={"id"})
-        #             # # for compatibility with mongoengine
-        #             # if isinstance(task_dict['base_result'], dict):
-        #             #     task_dict['base_result'] = task_dict['base_result']['id']
-        #             task = TaskQueueORM(**task_dict)
-        #             task.priority = task.priority.value  # Must be an integer for sorting
-        #             session.add(task)
-        #             session.commit()
-        #             results.append(str(task.id))
-        #             meta["n_inserted"] += 1
-        #         except IntegrityError as err:  # rare case
-        #             # print(str(err))
-        #             session.rollback()
-        #             # TODO: merge hooks
-        #             task = session.query(TaskQueueORM).filter_by(base_result_id=record.base_result).first()
-        #             self.logger.warning("queue_submit got a duplicate task: {}".format(task.to_dict()))
-        #             results.append(str(task.id))
-        #             meta["duplicates"].append(task_num)
-        #         # except Exception as err:
-        #         #     self.logger.warning('queue_submit submission error: {}'.format(str(err)))
-        #         #     meta["success"] = False
-        #         #     meta["errors"].append(str(err))
-        #         #     results.append(None)
+            # finding the duplicate items in input, for which ids are found only after insertion
+            for i in duplicate_idx:
+                if not isinstance(results[i], str):
+                    results[i] = str(results[i].id)
 
         meta["success"] = True
 

--- a/qcfractal/tests/test_storage.py
+++ b/qcfractal/tests/test_storage.py
@@ -699,6 +699,24 @@ def test_queue_submit_sql(storage_results):
     assert ret["meta"]["n_inserted"] == 0
     assert len(ret["meta"]["duplicates"]) == 1
 
+    result2 = storage_results.get_results()["data"][1]
+
+    task2 = ptl.models.TaskRecord(
+        **{
+            "spec": {"function": "qcengine.compute_procedure", "args": [{"json_blob": "data"}], "kwargs": {}},
+            "tag": None,
+            "program": "p1",
+            "parser": "",
+            "base_result": result2["id"],
+        }
+    )
+
+    # submit repeated tasks
+    ret = storage_results.queue_submit([task2, task2])
+    assert len(ret["data"]) == 2
+    assert ret["meta"]["n_inserted"] == 1
+    assert ret["data"][0] == ret["data"][1]
+
 
 # ----------------------------------------------------------
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Changing the function ```queue_submit.py``` in ```storage_sqlalchemy.py``` file, which does the query once on all the ids of items to be added to find the duplicates. Then adds all the non-duplicate ones. Also a benchmark file is also provided for adding a number of tasks raising from 1 to 1000 to measure how much of speedup the change gives. The results are brought in the file below.(The best run is selected for both the main repo and this repo's code.)
[runs_submit.txt](https://github.com/MolSSI/QCFractal/files/4385357/runs_submit.txt)


## Changelog description
Optimized the ```queue_submit``` function for task submission to queue in the database.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
