### PR TITLE
Fixes errors in collections status() functionality (Issue #586)

### DIFF
--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1280,7 +1280,17 @@ def test_torsiondrive_dataset(fractal_compute_server):
     fractal_compute_server.await_services(max_iter=1)
 
     # Check status
+    status_basic = ds.status()
+    assert status_basic.loc("COMPLETE", "Spec1") == 1
+    status_spec = ds.status("Spec1")
+    assert status_basic.loc("COMPLETE", "Spec1") == 1
+
     status_detail = ds.status("Spec1", detail=True)
+    assert status_detail.loc["hooh2", "Complete Tasks"] == 1
+    assert status_detail.loc["hooh2", "Total Points"] == 6
+
+    # List of length 1 with detail=True
+    status_detail = ds.status(["Spec1"], detail=True)
     assert status_detail.loc["hooh2", "Complete Tasks"] == 1
     assert status_detail.loc["hooh2", "Total Points"] == 6
 
@@ -1368,6 +1378,10 @@ def test_optimization_dataset(fractal_compute_server):
     status = ds.status()
     assert status.loc["COMPLETE", "test"] == 3
     assert status.loc["COMPLETE", "test2"] == 1
+
+    status_spec = ds.status("test")
+    assert status_spec.loc("COMPLETE", "test") == 3
+    assert status_spec.loc("COMPLETE", "test2") == 1
 
     counts = ds.counts()
     assert counts.loc["hooh1", "test"] == 9


### PR DESCRIPTION
## Description

Fixes two bugs in the Collection status() function
  1. If spec was given as a list of length 1 and detail=True,
        an exception was raised, since other functions weren't expecting a list
  2. `status(['spec'])` would raise an exception due to the internal
        dataframe not being populated at that time (issue #586).
        Fixed by making calls to query()

Tests were added, however some may actually be useless. The original test framework may be too simplistic to catch this error, since this is partly due to a mismatch between the server and local data.

<!-- Thank you for your contribution! -->

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fixes bugs related to status function in Collections

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
