### PR TITLE
Add ability to query managers from portal

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -1189,7 +1189,7 @@ class FractalClient(object):
             "meta": {"limit": limit, "skip": skip},
             "data": {"name": name, "status": status},
         }
-        return self._automodel_request("manager_info", "get", payload, full_return=full_return)
+        return self._automodel_request("manager", "get", payload, full_return=full_return)
 
     # -------------------------------------------------------------------------
     # ------------------   Advanced Queries -----------------------------------

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -1157,6 +1157,40 @@ class FractalClient(object):
 
         return self._automodel_request("service_queue", "put", payload, full_return=full_return)
 
+    def query_managers(
+        self,
+        name: Optional["QueryStr"] = None,
+        status: Optional["QueryStr"] = "ACTIVE",
+        limit: Optional[int] = None,
+        skip: int = 0,
+        full_return: bool = False,
+    ) -> Dict[str, Any]:
+        """Obtains information about compute managers attached to this Fractal instance
+
+        Parameters
+        ----------
+        name : QueryStr, optional
+            Queries the managers name.
+        status : QueryStr, optional
+            Queries the manager's ``status`` field. Default is to search for only ACTIVE managers
+        limit : Optional[int], optional
+            The maximum number of managers to query
+        skip : int, optional
+            The number of managers to skip in the query, used during pagination
+        full_return : bool, optional
+            Returns the full server response if True that contains additional metadata.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            A dictionary of each match that contains all the information for each manager
+        """
+        payload = {
+            "meta": {"limit": limit, "skip": skip},
+            "data": {"name": name, "status": status},
+        }
+        return self._automodel_request("manager_info", "get", payload, full_return=full_return)
+
     # -------------------------------------------------------------------------
     # ------------------   Advanced Queries -----------------------------------
     # -------------------------------------------------------------------------

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -1149,3 +1149,23 @@ register_model(r"optimization/final_result", "GET", OptimizationFinalResultBody,
 register_model(r"optimization/all_results", "GET", OptimizationAllResultBody, ListResultResponse)
 register_model(r"optimization/initial_molecule", "GET", OptimizationAllResultBody, ListMoleculeResponse)
 register_model(r"optimization/final_molecule", "GET", OptimizationAllResultBody, ListMoleculeResponse)
+
+
+class ManagerInfoGETBody(ProtoModel):
+    class Data(ProtoModel):
+        name: QueryStr = Field(None, description="Name(s) of managers to query for.")
+        status: QueryStr = Field(
+            None,
+            description="Managers will be searched based on status. See :class:`ManagerStatusEnum` for valid statuses.",
+        )
+
+    meta: QueryMeta = Field(QueryMeta(), description=common_docs[QueryMeta])
+    data: Data = Field(..., description="The keys with data to search the database on for Managers.")
+
+
+class ManagerInfoGETResponse(ProtoModel):
+    meta: ResponseGETMeta = Field(..., description=common_docs[ResponseGETMeta])
+    data: List[Dict[str, Any]] = Field(..., description="Information about the requested managers")
+
+
+register_model(r"manager_info", "GET", ManagerInfoGETBody, ManagerInfoGETResponse)

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -1168,4 +1168,4 @@ class ManagerInfoGETResponse(ProtoModel):
     data: List[Dict[str, Any]] = Field(..., description="Information about the requested managers")
 
 
-register_model(r"manager_info", "GET", ManagerInfoGETBody, ManagerInfoGETResponse)
+register_model(r"manager", "GET", ManagerInfoGETBody, ManagerInfoGETResponse)

--- a/qcfractal/queue/__init__.py
+++ b/qcfractal/queue/__init__.py
@@ -3,5 +3,5 @@ Initializer for the queue_handler folder
 """
 
 from .adapters import build_queue_adapter
-from .handlers import QueueManagerHandler, ServiceQueueHandler, TaskQueueHandler
+from .handlers import QueueManagerHandler, ServiceQueueHandler, TaskQueueHandler, ComputeManagerHandler
 from .managers import QueueManager

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -360,7 +360,7 @@ class ComputeManagerHandler(APIHandler):
         """Gets manager information from the task queue
         """
 
-        body_model, response_model = rest_model("manager_info", "get")
+        body_model, response_model = rest_model("manager", "get")
         body = self.parse_bodymodel(body_model)
 
         self.logger.info("GET: ComputeManagerHandler")

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -18,7 +18,7 @@ import tornado.web
 
 from .extras import get_information
 from .interface import FractalClient
-from .queue import QueueManager, QueueManagerHandler, ServiceQueueHandler, TaskQueueHandler
+from .queue import QueueManager, QueueManagerHandler, ServiceQueueHandler, TaskQueueHandler, ComputeManagerHandler
 from .services import construct_service
 from .storage_sockets import ViewHandler, storage_socket_factory
 from .storage_sockets.api_logger import API_AccessLogger
@@ -291,6 +291,7 @@ class FractalServer:
             (r"/task_queue", TaskQueueHandler, self.objects),
             (r"/service_queue", ServiceQueueHandler, self.objects),
             (r"/queue_manager", QueueManagerHandler, self.objects),
+            (r"/manager_info", ComputeManagerHandler, self.objects),
         ]
 
         # Build the app

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -291,7 +291,7 @@ class FractalServer:
             (r"/task_queue", TaskQueueHandler, self.objects),
             (r"/service_queue", ServiceQueueHandler, self.objects),
             (r"/queue_manager", QueueManagerHandler, self.objects),
-            (r"/manager_info", ComputeManagerHandler, self.objects),
+            (r"/manager", ComputeManagerHandler, self.objects),
         ]
 
         # Build the app

--- a/qcfractal/tests/test_managers.py
+++ b/qcfractal/tests/test_managers.py
@@ -67,7 +67,7 @@ def test_queue_manager_single_tags(compute_adapter_fixture):
     assert len(ret) == 1
 
     # Check the logs to make sure
-    managers = server.storage.get_managers()["data"]
+    managers = client.query_managers()
     assert len(managers) == 2
 
     test_results = {"stuff": 0, "other": 1}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Adds the ability to query for compute manager information via qcportal.
This is done by adding the appropriate REST models and handlers, then adding
the appropriate function to the client.

Currently, admin access is required, although this may be relaxed in the future. Also, the passwords used by the managers to connect to the fractal instance are scrubbed.

This is required for the dashboard.

Also, I fixed a few of the comments in the REST handlers.

## Changelog description
Adds ability to query manager information from the client

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Tests
- [x] Code base linted
- [x] Ready to go
