### PR TITLE
Make protocols field optional in pydantic models

### DIFF
--- a/qcfractal/interface/models/common_models.py
+++ b/qcfractal/interface/models/common_models.py
@@ -71,7 +71,7 @@ class QCSpecification(ProtoModel):
         description="The Id of the :class:`KeywordSet` registered in the database to run this calculation with. This "
         "Id must exist in the database.",
     )
-    protocols: ResultProtocols = Field(ResultProtocols(), description=str(ResultProtocols.__base_doc__))
+    protocols: Optional[ResultProtocols] = Field(ResultProtocols(), description=str(ResultProtocols.__base_doc__))
     program: str = Field(
         ...,
         description="The quantum chemistry program to evaluate the computation with. Not all quantum chemistry programs"
@@ -131,7 +131,7 @@ class OptimizationSpecification(ProtoModel):
         "Note that unlike :class:`QCSpecification` this is a dictionary of keywords, not the Id for a "
         ":class:`KeywordSet`. ",
     )
-    protocols: OptimizationProtocols = Field(
+    protocols: Optional[OptimizationProtocols] = Field(
         OptimizationProtocols(), description=str(OptimizationProtocols.__base_doc__)
     )
 

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -271,7 +271,9 @@ class ResultRecord(RecordBase):
         description="The Id of the :class:`KeywordSet` which was passed into the quantum chemistry program that "
         "performed this calculation.",
     )
-    protocols: qcel.models.results.ResultProtocols = Field(qcel.models.results.ResultProtocols(), description="")
+    protocols: Optional[qcel.models.results.ResultProtocols] = Field(
+        qcel.models.results.ResultProtocols(), description=""
+    )
 
     # Output data
     return_result: Union[float, qcel.models.types.Array[float], Dict[str, Any]] = Field(
@@ -460,7 +462,7 @@ class OptimizationRecord(RecordBase):
         description="The keyword options which were passed into the Optimization program. "
         "Note: These are a dictionary and not a :class:`KeywordSet` object.",
     )
-    protocols: qcel.models.procedures.OptimizationProtocols = Field(
+    protocols: Optional[qcel.models.procedures.OptimizationProtocols] = Field(
         qcel.models.procedures.OptimizationProtocols(), description=""
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
The `protocols` field in the models was given default values but were not made optional. This would cause some older tasks (without `protocols` specfied in the task) to be rejected by the server when a manager tried to upload completed results.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Make protocols field optional to allow for re-running (some) older tasks

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [ ] Ready to go
