### PR TITLE
Torsioninitmol mapping class replacing table representation

### DIFF
--- a/benchmarks/bench_procedure.py
+++ b/benchmarks/bench_procedure.py
@@ -1,0 +1,79 @@
+import time
+from qcfractal.interface.models.records import ResultRecord
+from qcfractal.interface.models import KeywordSet
+import qcfractal
+import qcfractal.interface as ptl
+import numpy as np
+import qcelemental as qcel
+import random
+
+print("Building and clearing the database...\n")
+db_name = "molecule_tests"
+storage = qcfractal.storage_socket_factory(f"postgresql://localhost:5432/{db_name}")
+storage._delete_DB_data(db_name)
+
+def build_unique_mol(num = 1):
+    mols = [qcel.models.Molecule(symbols=["He", "He"], geometry=np.random.rand(2, 3) + i, validated=True)
+                for i in range(num)]
+    ret = storage.add_molecules(mols)["data"]
+    return ret
+
+
+def create_unique_result(mols):
+    results = [ResultRecord(version='1', driver='energy', program='games', molecule=mol_ret,
+                    method='test', basis='6-31g') for mol_ret in mols]
+    ret = storage.add_results(results)["data"]
+    return ret
+
+def create_procedures(res_ids, mol_ids, num=1):
+    methods = ["HF", "uff ", "pm6", "hf3c"]
+    basis = ["dzvp", "6-31g", "dzvp", "sto-3g", None]
+    programs = ["psi4", "rdkit", "mopac", "ddk"]
+
+    record_list = []
+    for i in range(num):
+        proc_template = {
+        "procedure": "optimization",
+        "initial_molecule": mol_ids[i],
+        "program": "something",
+        "hash_index": None,
+        # "trajectory": None,
+        "trajectory": [res_ids[i]],
+        "qc_spec": {
+            "driver": "gradient",
+            "method": random.choice(methods),
+            "basis": random.choice(basis),
+            # "keywords": None,
+            "program": random.choice(programs),
+            },
+        }
+        record_list.append(ptl.models.OptimizationRecord(**proc_template))
+    ret = storage.add_procedures(record_list=record_list)["data"]
+    
+    return ret
+
+proc_trials = [1, 10, 100, 500, 1000]
+
+def main():
+    print("Running timings for add and update...\n")
+for trial in proc_trials:
+    # adding procedures and benchmarking
+    mol_ids = build_unique_mol(num=trial)
+    res_ids = create_unique_result(mol_ids)
+
+    t = time.time()
+    proc_ids = create_procedures(res_ids, mol_ids, num=trial)
+    
+    ttime = (time.time() - t) * 1000
+    time_per_proc = ttime / trial
+
+    print(f"add   : {trial:6d} {ttime:9.3f} {time_per_proc:6.3f}")
+    
+    # get_procedure benchmark section
+    t = time.time()
+    ret = storage.get_procedures(procedure="optimization", status=None)
+
+    ttime = (time.time() - t) * 1000
+    time_per_proc = ttime / trial
+
+    print(f"get   : {trial:6d} {ttime:9.3f} {time_per_proc:6.3f}")

--- a/qcfractal/alembic/versions/1604623c481a_id_pirmary_key_for_torsion_init_mol.py
+++ b/qcfractal/alembic/versions/1604623c481a_id_pirmary_key_for_torsion_init_mol.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '1604623c481a'
-down_revision = 'fb5bd88ae2f3'
+revision = "1604623c481a"
+down_revision = "fb5bd88ae2f3"
 branch_labels = None
 depends_on = None
 

--- a/qcfractal/alembic/versions/1604623c481a_id_pirmary_key_for_torsion_init_mol.py
+++ b/qcfractal/alembic/versions/1604623c481a_id_pirmary_key_for_torsion_init_mol.py
@@ -1,0 +1,24 @@
+"""id(pirmary key) for torsion_init_mol
+
+Revision ID: 1604623c481a
+Revises: fb5bd88ae2f3
+Create Date: 2020-07-02 18:42:17.267792
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1604623c481a'
+down_revision = 'fb5bd88ae2f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("alter table torsion_init_mol_association add column id serial primary key;")
+
+
+def downgrade():
+    op.execute("alter table torsion_init_mol_association drop column id;")

--- a/qcfractal/alembic/versions/1604623c481a_id_pirmary_key_for_torsion_init_mol.py
+++ b/qcfractal/alembic/versions/1604623c481a_id_pirmary_key_for_torsion_init_mol.py
@@ -18,6 +18,7 @@ depends_on = None
 
 def upgrade():
 
+    # Removes (harmless) duplicate rows
     op.execute(
         "DELETE FROM torsion_init_mol_association a USING \
     (SELECT MIN(ctid) as ctid, torsion_id, molecule_id \
@@ -28,8 +29,8 @@ def upgrade():
       AND a.ctid <> b.ctid"
     )
 
-    op.execute("alter table add primary key (torsion_id, molecule_id)")
+    op.execute("alter table torsion_init_mol_association add primary key (torsion_id, molecule_id)")
 
 
 def downgrade():
-    op.execute("alter table drop constraint torsion_init_mol_association_pkey")
+    op.execute("alter table torsion_init_mol_association drop constraint torsion_init_mol_association_pkey")

--- a/qcfractal/storage_sockets/models/results_models.py
+++ b/qcfractal/storage_sockets/models/results_models.py
@@ -405,9 +405,10 @@ class TorsionInitMol(Base):
 
     __tablename__ = "torsion_init_mol_association"
 
-    id = Column("id", Integer, primary_key=True)
-    torsion_id = Column("torsion_id", Integer, ForeignKey("torsiondrive_procedure.id", ondelete="cascade"))
-    molecule_id = Column("molecule_id", Integer, ForeignKey("molecule.id", ondelete="cascade"))
+    torsion_id = Column(
+        "torsion_id", Integer, ForeignKey("torsiondrive_procedure.id", ondelete="cascade"), primary_key=True
+    )
+    molecule_id = Column("molecule_id", Integer, ForeignKey("molecule.id", ondelete="cascade"), primary_key=True)
 
 
 # association table for many to many relation

--- a/qcfractal/storage_sockets/models/results_models.py
+++ b/qcfractal/storage_sockets/models/results_models.py
@@ -397,15 +397,18 @@ class OptimizationHistory(Base):
 
     # optimization_obj = relationship(OptimizationProcedureORM, lazy="joined")
 
+
 class TorsionInitMol(Base):
     """
     Association table for many to many relation
     """
+
     __tablename__ = "torsion_init_mol_association"
 
     id = Column("id", Integer, primary_key=True)
     torsion_id = Column("torsion_id", Integer, ForeignKey("torsiondrive_procedure.id", ondelete="cascade"))
     molecule_id = Column("molecule_id", Integer, ForeignKey("molecule.id", ondelete="cascade"))
+
 
 # association table for many to many relation
 # torsion_init_mol_association = Table(
@@ -435,14 +438,10 @@ class TorsionDriveProcedureORM(ProcedureMixin, BaseResultORM):
 
     # ids of the many to many relation
     initial_molecule = column_property(
-        select([func.array_agg(TorsionInitMol.molecule_id)]).where(
-            TorsionInitMol.torsion_id == id
-        )
+        select([func.array_agg(TorsionInitMol.molecule_id)]).where(TorsionInitMol.torsion_id == id)
     )
     # actual objects relation M2M, never loaded here
-    initial_molecule_obj = relationship(
-        MoleculeORM, secondary=TorsionInitMol.__table__, uselist=True, lazy="noload"
-    )
+    initial_molecule_obj = relationship(MoleculeORM, secondary=TorsionInitMol.__table__, uselist=True, lazy="noload")
 
     optimization_spec = Column(JSON)
 

--- a/qcfractal/storage_sockets/models/sql_base.py
+++ b/qcfractal/storage_sockets/models/sql_base.py
@@ -136,7 +136,9 @@ class Base:
                     )
                 )
             if to_add:
-                session.execute(table.insert().values([{parent_id_name : parent_id_val, child_id_name :my_id} for my_id in to_add]))
+                session.execute(
+                    table.insert().values([{parent_id_name: parent_id_val, child_id_name: my_id} for my_id in to_add])
+                )
 
     def __str__(self):
         if hasattr(self, "id"):

--- a/qcfractal/storage_sockets/models/sql_base.py
+++ b/qcfractal/storage_sockets/models/sql_base.py
@@ -136,7 +136,7 @@ class Base:
                     )
                 )
             if to_add:
-                session.execute(table.insert().values([(parent_id_val, my_id) for my_id in to_add]))
+                session.execute(table.insert().values([{parent_id_name : parent_id_val, child_id_name :my_id} for my_id in to_add]))
 
     def __str__(self):
         if hasattr(self, "id"):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
```torsion_init_mol``` table now has a mapping ORM class assigned in the codebase, rather than a simple table representation.

## Changelog description
```torsion_init_mol``` was represented as a simple table which would be populated every time an insertion or update command was issued to ```torsiondrive_procedure```. Now it has its own mapping class which would make it simpler for manipulation of rows from objects in code. Since the current production database has rows where the ```molecule_id``` and ```torsion_id``` are not unique- hence the existence of duplicate rows - an id for each row as primary key is also added to the table(through alembic).

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
