### PR TITLE
Update OpenFF prod envs with MM tooling

### DIFF
--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -1,8 +1,9 @@
 name: qcarchive
 channels:
   - defaults
-  - psi4/label/dev
   - conda-forge
+  - psi4/label/dev
+  - omnia
 dependencies:
   - python
 
@@ -38,13 +39,19 @@ dependencies:
   - pytest-cov
   - requests-mock
 
-#   Environment specific includes
+  # Environment specific includes
   - psi4 >1.4a2.dev700,<1.4a2
   - rdkit
   - geometric >=0.9.3
   - torsiondrive
   - dftd3
 
-#   QCArchive includes
+  # QCArchive includes
   - qcengine >=0.11.0
   - qcelemental >=0.13.1
+
+  # MM calculations
+  - openforcefield >=0.7.1
+  - openforcefields >=1.2.0
+  - openmm >=7.4.2
+  - openmmforcefields >=0.8.0

--- a/devtools/prod-envs/qcarchive_worker_openff.yaml
+++ b/devtools/prod-envs/qcarchive_worker_openff.yaml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - conda-forge
   - psi4/label/dev
+  - omnia
 dependencies:
   - python <=3.7
   - qcfractal
@@ -12,10 +13,16 @@ dependencies:
   - dftd3
   - gcp
   - rdkit
-  - qcengine >=0.13.0
+  - qcengine >=0.15.0
     
     # Procedures
   - geometric
 
     # Testing
   - pytest
+
+    # MM calculations
+  - openforcefield >=0.7.1
+  - openforcefields >=1.2.0
+  - openmm >=7.4.2
+  - openmmforcefields >=0.8.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

To begin performing MM calculations with QCFractal, the OpenFF conda environments require the following additional tools:
  - openforcefield >=0.7.1
  - openforcefields >=1.2.0
  - openmm >=7.4.2
  - openmmforcefields >=0.8.0

These are sourced from the [omnia](https://anaconda.org/omnia) channel.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Added openforcefield and openmm tools to OpenFF conda environments.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
