### PR TITLE
Insert tasks in bulk rather than one-by-one

### DIFF
--- a/qcfractal/procedures/procedures.py
+++ b/qcfractal/procedures/procedures.py
@@ -139,16 +139,16 @@ class SingleResultTasks(BaseTasks):
         # Retrieve the records that were new
         new_result_records = self.storage.get_results(id=new_task_ids,
                                                       status='INCOMPLETE')['data']
-        molecules = self.storage.get_molecules(
-            id=[r['molecule'] for r in new_result_records]
-        )['data']
+        mol_ids = [r['molecule'] for r in new_result_records]
+        molecules = self.storage.get_molecules(id=mol_ids)['data']
+        molecules = dict((m.id, m) for m in molecules)
 
         # Create the task records for the queue
         new_tasks = []
-        for base_id, record_data, mol in zip(new_task_ids, new_result_records, molecules):
+        for base_id, record_data in zip(new_task_ids, new_result_records):
             # Build the input for the task
             record = ResultRecord(**record_data)
-            inp = record.build_schema_input(mol, keywords)
+            inp = record.build_schema_input(molecules[record.molecule], keywords)
 
             # Make the task record
             task = TaskRecord(

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -33,10 +33,10 @@ def test_compute_queue_stack(fractal_compute_server):
     compute_args = {"driver": "energy", "method": "HF", "basis": "sto-3g", "keywords": kw_id, "program": "psi4"}
 
     # Ask the server to compute a new computation
-    r = client.add_compute("psi4", "HF", "sto-3g", "energy", kw_id, [hydrogen_mol_id, helium])
+    r = client.add_compute("psi4", "HF", "sto-3g", "energy", kw_id, [helium, hydrogen_mol_id])
     assert len(r.ids) == 2
 
-    r2 = client.add_compute(**compute_args, molecule=[hydrogen_mol_id, helium])
+    r2 = client.add_compute(**compute_args, molecule=[helium, hydrogen_mol_id])
     assert len(r2.ids) == 2
     assert len(r2.submitted) == 0
     assert set(r2.ids) == set(r.ids)


### PR DESCRIPTION
## Description
Addresses poor performance when inserting tasks (Fixes #611).

Rather than inserting tasks one-by-one for `compute` requests, add them in bulk. The new implementation requires two additional queries when adding tasks, retrieving result records and molecules in order to create the task records. In tradeoff, the code runs 1000x faster (not joking) when running QCFractal on a system with a slow filesystem (e.g., an HPC login node) when inserting 1000 tasks.

## Changelog description
Faster bulk task creation for compute tasks

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
