### PR TITLE
Compress outputs on managers

### DIFF
--- a/qcfractal/procedures/procedures_util.py
+++ b/qcfractal/procedures/procedures_util.py
@@ -99,13 +99,6 @@ def parse_single_tasks(storage, results):
     """
 
     for k, v in results.items():
-        outputs = [v["stdout"], v["stderr"], v["error"]]
-        kvstores = [KVStore(data=x) if x is not None else None for x in outputs]
-        stdout, stderr, error = storage.add_kvstore(kvstores)["data"]
-        v["stdout"] = stdout
-        v["stderr"] = stderr
-        v["error"] = error
-
         # Flatten data back out
         v["method"] = v["model"]["method"]
         v["basis"] = v["model"]["basis"]

--- a/qcfractal/queue/compress.py
+++ b/qcfractal/queue/compress.py
@@ -1,0 +1,80 @@
+"""
+Helpers for compressing data to send back to the server
+"""
+
+from typing import Union, Optional, Dict
+from ..interface.models import KVStore, CompressionEnum
+from qcelemental.models import AtomicResult, OptimizationResult
+
+
+def _compress_common(
+    result: Union[AtomicResult, OptimizationResult],
+    compression: CompressionEnum = CompressionEnum.lzma,
+    compression_level: int = None,
+):
+    """
+    Compresses outputs of an AtomicResult or OptimizationResult, storing them in extras
+    """
+
+    stdout = result.stdout
+    stderr = result.stderr
+    error = result.error
+
+    extras = result.extras
+    update = {}
+    if stdout is not None:
+        extras["_qcfractal_compressed_stdout"] = KVStore.compress(stdout, compression, compression_level)
+        update["stdout"] = None
+    if stderr is not None:
+        extras["_qcfractal_compressed_stderr"] = KVStore.compress(stderr, compression, compression_level)
+        update["stderr"] = None
+    if error is not None:
+        extras["_qcfractal_compressed_error"] = KVStore.compress(error, compression, compression_level)
+        update["error"] = None
+
+    update["extras"] = extras
+    return result.copy(update=update)
+
+
+def _compress_optimizationresult(
+    result: OptimizationResult,
+    compression: CompressionEnum = CompressionEnum.lzma,
+    compression_level: Optional[int] = None,
+):
+    """
+    Compresses outputs inside an OptimizationResult, storing them in extras
+
+    Outputs for the AtomicResults stored in the trajectory will be stored in the extras for that AtomicResult
+    """
+
+    # Handle the trajectory
+    trajectory = [_compress_common(x, compression, compression_level) for x in result.trajectory]
+    result = result.copy(update={"trajectory": trajectory})
+
+    # Now handle the outputs of the optimization itself
+    return _compress_common(result, compression, compression_level)
+
+
+def compress_results(
+    results: Dict[str, Union[AtomicResult, OptimizationResult]],
+    compression: CompressionEnum = CompressionEnum.lzma,
+    compression_level: int = None,
+):
+    """
+    Compress outputs inside results, storing them in extras
+
+    The compressed outputs are stored in extras. For OptimizationResult, the outputs for the optimization
+    are stored in the extras field of the OptimizationResult, while the outputs for the trajectory
+    are stored in the extras field for the AtomicResults within the trajectory
+    """
+
+    ret = {}
+    for k, result in results.items():
+        if isinstance(result, AtomicResult):
+            ret[k] = _compress_common(result, compression, compression_level)
+        elif isinstance(result, OptimizationResult):
+            ret[k] = _compress_optimizationresult(result, compression, compression_level)
+        else:
+            ret[k] = result
+
+    return ret

--- a/qcfractal/queue/managers.py
+++ b/qcfractal/queue/managers.py
@@ -17,6 +17,7 @@ from qcfractal.extras import get_information
 
 from ..interface.data import get_molecule
 from .adapters import build_queue_adapter
+from .compress import compress_results
 
 __all__ = ["QueueManager"]
 
@@ -540,6 +541,9 @@ class QueueManager:
         self._update_stale_jobs(allow_shutdown=allow_shutdown)
 
         results = self.queue_adapter.acquire_complete()
+
+        # Compress the outputs
+        results = compress_results(results)
 
         # Stats fetching for running tasks, as close to the time we got the jobs as we can
         last_time = self.statistics.last_update_time


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This is a follow-on to PR #612 

In this PR, stdout/stderr/error are now compressed on the manager side before pushing to the server. The data remains
compressed as it is inserted into the kv_store table.

This additional work on the managers should not cause much of a performance issue.

The entries for stdout, stderr, and error, if they exist, are compressed and stored in extras (and removed from their original places). Then on the server, they are processed and added to the database without decompressing.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
(see PR #612)

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
