### PR TITLE
Fix connection strings in alembic

### DIFF
--- a/qcfractal/postgres_harness.py
+++ b/qcfractal/postgres_harness.py
@@ -200,7 +200,7 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
     def create_tables(self):
         """Create database tables using SQLAlchemy models"""
 
-        uri = self.config.database_uri()
+        uri = self.config.database_uri(safe=False)
         self.logger(f"Creating tables for database: {uri}")
         engine = create_engine(uri, echo=False, pool_size=1)
 
@@ -215,7 +215,7 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
     def update_db_version(self):
         """Update current version of QCFractal in the DB"""
 
-        uri = self.config.database_uri()
+        uri = self.config.database_uri(safe=False)
 
         engine = create_engine(uri, echo=False, pool_size=1)
         session = sessionmaker(bind=engine)()
@@ -367,7 +367,8 @@ Alternatively, you can install a system PostgreSQL manually, please see the foll
         self.logger("\nDatabase server successfully started!")
 
     def alembic_commands(self) -> List[str]:
-        return [shutil.which("alembic"), "-c", self._alembic_ini, "-x", "uri=" + self.config.database_uri()]
+        db_uri = self.config.database_uri(safe=False)
+        return [shutil.which("alembic"), "-c", self._alembic_ini, "-x", "uri=" + db_uri]
 
     def init_database(self) -> None:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

In doing a migration test on the full database, I noticed that the connection string being passed to the alembic command contained stars for the password. This fixes that issue. However, it does open up a small security hole (as the password will be used on the command line and therefore show up with `ps`, etc).



## Changelog description
Fix issue with incorrect passwords used with alembic migrations

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
