### PR TITLE
Fix printing of client version

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -159,7 +159,7 @@ class FractalClient(object):
                 )
             client_version = _version_list(__version__)[:2]
             if not server_version_min_client <= client_version <= server_version_max_client:
-                client_ver_str = ".".join([str(i) for i in server_version_min_client])
+                client_ver_str = ".".join([str(i) for i in client_version])
                 server_version_min_str = ".".join([str(i) for i in server_version_min_client])
                 server_version_max_str = ".".join([str(i) for i in server_version_max_client])
                 raise IOError(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Fixes printing of client version when connecting to an incompatible fractal instance.

## Changelog description
Fixes printing of client version when connecting to an incompatible fractal instance.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
