### PR TITLE
Capture stdout for torsion drives

### DIFF
--- a/qcfractal/services/gridoptimization_service.py
+++ b/qcfractal/services/gridoptimization_service.py
@@ -27,6 +27,9 @@ class GridOptimizationService(BaseService):
     # Output
     output: GridOptimizationRecord
 
+    # Storage of the stdout of the torsiondrive package
+    stdout: str = ""
+
     # Temporaries
     grid_optimizations: Dict[str, str] = {}
     seeds: Set[tuple] = set()

--- a/qcfractal/services/gridoptimization_service.py
+++ b/qcfractal/services/gridoptimization_service.py
@@ -27,9 +27,6 @@ class GridOptimizationService(BaseService):
     # Output
     output: GridOptimizationRecord
 
-    # Storage of the stdout of the torsiondrive package
-    stdout: str = ""
-
     # Temporaries
     grid_optimizations: Dict[str, str] = {}
     seeds: Set[tuple] = set()

--- a/qcfractal/services/service_util.py
+++ b/qcfractal/services/service_util.py
@@ -49,13 +49,13 @@ class TaskManager(ProtoModel):
                 if x["status"] != "ERROR":
                     continue
 
-            self.logger.error("Error in service compute as follows:")
+            self.logger.debug("Error in service compute as follows:")
             tasks = self.storage_socket.get_queue()["data"]
             for x in tasks:
                 if "error" not in x:
                     continue
 
-                self.logger.error(x["error"]["error_message"])
+                self.logger.debug(x["error"]["error_message"])
 
             raise KeyError("All tasks did not execute successfully.")
         else:
@@ -127,6 +127,7 @@ class BaseService(ProtoModel, abc.ABC):
 
     status: str = "WAITING"
     error: Optional[ComputeError] = None
+    stdout: str = ""
     tag: Optional[str] = None
 
     # Sorting and priority

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1950,6 +1950,17 @@ class SQLAlchemySocket:
 
             procedure = service.output
             procedure.__dict__["id"] = service.procedure_id
+
+            # Copy the stdout/error from the service itself to its procedure
+            if service.stdout:
+                stdout = KVStore(data=service.stdout)
+                stdout_id = self.add_kvstore([stdout])["data"][0]
+                procedure.__dict__["stdout"] = stdout_id
+            if service.error:
+                error = KVStore(data=service.error)
+                error_id = self.add_kvstore([error])["data"][0]
+                procedure.__dict__["error"] = error_id
+
             self.update_procedures([procedure])
 
             updated_count += 1

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -296,7 +296,7 @@ def test_service_iterate_error(torsiondrive_fixture):
     assert "Service Build" in status[0]["error"]["error_message"]
 
     # Test that the error is propagated to the procedure
-    proc_status = client.query_procedures(ret_ids)
+    proc_status = client.query_procedures(ret.ids)
     assert len(proc_status) == 1
     assert proc_status[0].status == "ERROR"
     assert "Service Build" in proc_status[0].get_error().error_message

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -295,6 +295,12 @@ def test_service_iterate_error(torsiondrive_fixture):
     assert status[0]["status"] == "ERROR"
     assert "Service Build" in status[0]["error"]["error_message"]
 
+    # Test that the error is propagated to the procedure
+    proc_status = client.query_procedures(ret_ids)
+    assert len(proc_status) == 1
+    assert proc_status[0].status == "ERROR"
+    assert "Service Build" in proc_status[0].get_error().error_message
+
 
 def test_service_torsiondrive_compute_error(torsiondrive_fixture):
     """Ensure errors are caught and logged when computing serivces"""
@@ -336,6 +342,9 @@ def test_service_torsiondrive_get_final_results(torsiondrive_fixture):
 
     final_result_records = result.get_final_results()
     assert set(final_result_records.keys()) == {(-90,), (-0,), (90,), (180,)}
+
+    stdout = result.get_stdout()
+    assert "All optimizations converged at lowest energy" in stdout
 
 
 @using_geometric


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Services in general do not capture the output of the service runner itself. This makes some debugging difficult. This PR adds capturing that output and storing it in the service record while it is running, then adding it to the procedure when it is finished.

The torsiondrive package prints its output to stdout, so we can use contextlib to capture that. Previously, it was dumping it to the output of whatever process has the periodics loop running, which is basically useless as it does not capture enough information to meaningfully trace the torsiondrive process.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Capture output of services

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
