### PR TITLE
Small fixes for error handling

### DIFF
--- a/qcfractal/interface/models/common_models.py
+++ b/qcfractal/interface/models/common_models.py
@@ -9,7 +9,7 @@ import bz2
 import gzip
 
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from pydantic import Field, validator
 from qcelemental.models import AutodocBaseSettings, Molecule, ProtoModel, Provenance
@@ -137,7 +137,7 @@ class KVStore(ProtoModel):
     @classmethod
     def compress(
         cls,
-        input_str: str,
+        input_data: Union[Dict[str, str], str],
         compression_type: CompressionEnum = CompressionEnum.none,
         compression_level: Optional[int] = None,
     ):
@@ -148,7 +148,10 @@ class KVStore(ProtoModel):
         If compression_level is None, but a compression_type is specified, an appropriate default level is chosen
         """
 
-        data = input_str.encode()
+        if isinstance(input_data, dict):
+            input_data = json.dumps(input_data)
+
+        data = input_data.encode()
 
         # No compression
         if compression_type is CompressionEnum.none:

--- a/qcfractal/queue/handlers.py
+++ b/qcfractal/queue/handlers.py
@@ -280,8 +280,9 @@ class QueueManagerHandler(APIHandler):
 
             except Exception:
                 msg = "Internal FractalServer Error:\n" + traceback.format_exc()
-                logger.warning("update: ERROR\n{}".format(msg))
-                error_data.append((task_id, msg))
+                error = {"error_type": "internal_fractal_error", "error_message": msg}
+                logger.error("update: ERROR\n{}".format(msg))
+                error_data.append((task_id, error))
                 task_failures += 1
 
         if task_totals:

--- a/qcfractal/tests/test_storage.py
+++ b/qcfractal/tests/test_storage.py
@@ -758,7 +758,9 @@ def test_storage_queue_roundtrip(storage_results, status):
     queue_id2 = storage_results.queue_get_next("test_manager2", ["p1"], ["p1"], limit=1)[0].id
 
     if status == "ERROR":
-        r = storage_results.queue_mark_error([(queue_id, "Error msg"), (queue_id2, "Error msg2")])
+        err1 = {"error_type": "test_error", "error_message": "Error msg"}
+        err2 = {"error_type": "test_error", "error_message": "Error msg2"}
+        r = storage_results.queue_mark_error([(queue_id, err1), (queue_id2, err2)])
     elif status == "COMPLETE":
         r = storage_results.queue_mark_complete([queue_id2, queue_id])
         # Check queue is empty
@@ -778,7 +780,9 @@ def test_storage_queue_roundtrip(storage_results, status):
     if status == "ERROR":
         err_id = res["error"]
         err = storage_results.get_kvstore(err_id)
-        assert err["data"][err_id].get_string() == "Error msg"
+        js = err["data"][err_id].get_json()
+        assert js["error_message"] == "Error msg"
+        assert js["error_type"] == "test_error"
 
 
 def test_queue_submit_many_order(storage_results):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Two small fixes for handling errors

 1. Always pass dictionaries to queue_mark_complete (includes fixing a test)
 2. Compress error data on the server

I don't want to compress the error data on the manager, as there are a few areas that print various pieces of the error, which would require shipping around both the compressed and uncompressed forms at the same time.

Compression for this small amount of data takes ~1ms or less at LZMA level=1, so it shouldn't be too bad.

## Changelog description
Compress errors from managers

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
