### PR TITLE
Fix ordering of initial/final molecule in torsiondrive service

### DIFF
--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -143,11 +143,14 @@ class TorsionDriveService(BaseService):
                 ret = complete_tasks[task_id]
 
                 # Lookup molecules
-                mol_keys = self.storage_socket.get_molecules(id=[ret["initial_molecule"], ret["final_molecule"]])[
-                    "data"
-                ]
+                initial_id = ret["initial_molecule"]
+                final_id = ret["final_molecule"]
 
-                task_results[key].append((mol_keys[0].geometry, mol_keys[1].geometry, ret["energies"][-1]))
+                mol_ids = [initial_id, final_id]
+                mol_data = self.storage_socket.get_molecules(id=mol_ids)["data"]
+                mol_map = {x.id: x.geometry for x in mol_data}
+
+                task_results[key].append((mol_map[initial_id], mol_map[final_id], ret["energies"][-1]))
 
         # The torsiondrive package uses print, so capture that using
         # contextlib


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
In the torsiondrive service, a call to `get_molecules` is used to get the initial and final geometries. However, order is not
guaranteed by `get_molecules`.

This creates a simple map to ensure that the initial and final molecules are correct.

This should fix some spurious CI errors, as well as some errors we do see on the production server.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fix bug in ordering of initial/final molecules inside torsion drive service

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
