### PR TITLE
Enable ability to profile fractal server

### DIFF
--- a/qcfractal/config.py
+++ b/qcfractal/config.py
@@ -110,6 +110,9 @@ class FractalServerSettings(ConfigSettings):
     query_limit: int = Field(1000, description="The maximum number of records to return per query.")
     logfile: Optional[str] = Field("qcfractal_server.log", description="The logfile to write server logs.")
     loglevel: str = Field("info", description="Level of logging to enable (debug, info, warning, error, critical)")
+    cprofile: Optional[str] = Field(
+        None, description="Enable profiling via cProfile, and output cprofile data to this path"
+    )
     service_frequency: int = Field(60, description="The frequency to update the QCFractal services.")
     max_active_services: int = Field(20, description="The maximum number of concurrent active services.")
     heartbeat_frequency: int = Field(1800, description="The frequency (in seconds) to check the heartbeat of workers.")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Some users complain about slow server access. This will allow us to collect some data on a production server to determine any hotspots and hopefully improve those areas.

If a path is given to the `cprofile` argument, then data from cprofile will be stored there after the server exits. This can then be read with the `pstats` package.

I am not aware of any downsides to profiling a complex code this way, other than a bit of overhead. On the production server, I will only run it selectively (maybe up to a day or two at most)

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Enable profiling of a fractal server via cProfile

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [x] Ready to go
