### PR TITLE
Fix shutdown of ProcessPoolExecutor workers

### DIFF
--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -741,6 +741,12 @@ def main(args=None):
     if settings.common.adapter == "pool":
         from concurrent.futures import ProcessPoolExecutor
 
+        # TODO: Replace with passing via mp_context to ProcessPoolExecutor
+        # when python 3.6 is dead and buried
+        from multiprocessing import set_start_method
+
+        set_start_method("spawn")
+
         # Error if the number of nodes per jobs is more than 1
         if settings.common.nodes_per_job > 1:
             raise ValueError("Pool adapters only run on a single local node")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Workers using the ProcessPoolExecutor would sometimes fail to shutdown. This was very repeatable on my local machine, and would occasionally happen during CI tests.

The cause is not 100% clear, but is likely related to the presence of threads (for heartbeat, update) in the master process. The default for `multiprocess` seems to be a plain `fork`, which would copy over all the structures related to the threads, but not the threads themselves. This can cause waiting for a thread which doesn't exist, as it doesn't belong to that process, causing a hang.

Changing the behavior of `multiprocess` to `spawn` uses a fresh python interpreter. While slower, this overhead is likely small compared to what we are doing inside the process (a QM calculation).

See: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
https://pythonspeed.com/articles/python-multiprocessing/

May be related to #569 although that maybe deals with shutdown of running workers.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fix hanging of ProcessPoolExecutor workers at shutdown

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [x] Ready to go
