### PR TITLE
Remove _qcfractal_tags from optimizations extras

### DIFF
--- a/qcfractal/procedures/optimization.py
+++ b/qcfractal/procedures/optimization.py
@@ -201,10 +201,6 @@ class OptimizationTasks(BaseTasks):
         new_tasks = []
         for rec, mol, kw in zip(records, molecules, qc_keywords):
             inp = self._build_schema_input(rec, mol, kw)
-            inp.input_specification.extras["_qcfractal_tags"] = {
-                "program": rec.qc_spec.program,
-                "keywords": rec.qc_spec.keywords,  # Just the id?
-            }
 
             # Build task object
             task = TaskRecord(
@@ -264,7 +260,7 @@ class OptimizationTasks(BaseTasks):
             for k, v in traj_dict.items():
                 self.retrieve_outputs(v)
 
-            results = parse_single_tasks(self.storage, traj_dict)
+            results = parse_single_tasks(self.storage, traj_dict, rec.qc_spec)
             for k, v in results.items():
                 results[k] = ResultRecord(**v)
 

--- a/qcfractal/procedures/procedures_util.py
+++ b/qcfractal/procedures/procedures_util.py
@@ -64,7 +64,6 @@ def unpack_single_task_spec(storage, meta, molecules):
             "driver": meta["driver"],
             "keywords": keyword_set,
             "model": {"method": meta["method"], "basis": meta["basis"]},
-            "extras": {"_qcfractal_tags": {"program": meta["program"], "keywords": meta["keywords"]}},
         }
     )
 
@@ -82,7 +81,7 @@ def unpack_single_task_spec(storage, meta, molecules):
     return tasks, []
 
 
-def parse_single_tasks(storage, results):
+def parse_single_tasks(storage, results, qc_spec):
     """Summary
 
     Parameters
@@ -109,9 +108,16 @@ def parse_single_tasks(storage, results):
         # Molecule should be by ID
         v["molecule"] = storage.add_molecules([Molecule(**v["molecule"])])["data"][0]
 
-        v["keywords"] = v["extras"]["_qcfractal_tags"]["keywords"]
-        v["program"] = v["extras"]["_qcfractal_tags"]["program"]
-        del v["extras"]["_qcfractal_tags"]
+        v["keywords"] = qc_spec.keywords
+        v["program"] = qc_spec.program
+
+        # Old tags that may still exist if the task was created with previous versions.
+        # It is harmless if they do, but may as well do a consistency check
+        if "_qcfractal_tags" in v["extras"]:
+            assert int(v["extras"]["_qcfractal_tags"]["keywords"]) == int(qc_spec.keywords)
+            assert v["extras"]["_qcfractal_tags"]["program"] == qc_spec.program
+            del v["extras"]["_qcfractal_tags"]
+
         del v["schema_name"]
         del v["schema_version"]
 

--- a/qcfractal/tests/test_procedures.py
+++ b/qcfractal/tests/test_procedures.py
@@ -153,8 +153,11 @@ def test_procedure_optimization_single(fractal_compute_server):
 
         # Check individual elements
         for ind in range(len(opt_result.trajectory)):
+            assert traj[ind].program == "psi4"
+
             # Check keywords went through
             assert traj[ind].provenance.creator.lower() == "psi4"
+            assert int(traj[ind].keywords) == int(kw_id)
             assert "SCF QUADRUPOLE XY" in traj[ind].extras["qcvars"]
             assert "WIBERG_LOWDIN_INDICES" in traj[ind].extras["qcvars"]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Removes `_qcfractal_tag` from optimizations. The record has all the information it needs, and so no need to pass this around.

Existing tasks with the `_qcfractal_tag` do not need to be migrated. It will be ignored.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Remove unneeded `_qcfractal_tag` from optimizations

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [x] Ready to go
