### PR TITLE
Re-enable test_torsiondrive_dataset

### DIFF
--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1275,7 +1275,6 @@ def test_missing_collection(fractal_compute_server):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(reason="Flaky on Travis CI, see #427.")
 @testing.using_torsiondrive
 @testing.using_geometric
 @testing.using_rdkit

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -1297,17 +1297,18 @@ def test_torsiondrive_dataset(fractal_compute_server):
 
     ncompute = ds.compute("spec1")
     assert ncompute == 2
-    assert ds.status("spec1")["Spec1"].sum() == 2  # Might have completed from previous run.
+    assert ds.status("Spec1")["Spec1"].sum() == 2
 
     ds.save()
 
     fractal_compute_server.await_services(max_iter=1)
 
     # Check status
+    ds.query("Spec1", force=True)
     status_basic = ds.status()
-    assert status_basic.loc("COMPLETE", "Spec1") == 1
+    assert status_basic.loc["RUNNING", "Spec1"] == 2
     status_spec = ds.status("Spec1")
-    assert status_basic.loc("COMPLETE", "Spec1") == 1
+    assert status_basic.loc["RUNNING", "Spec1"] == 2
 
     status_detail = ds.status("Spec1", detail=True)
     assert status_detail.loc["hooh2", "Complete Tasks"] == 1


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Re-enables a test that was marked as xfail. The issue described in #427  should
be fixed in #632 

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
N/A

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
