### PR TITLE
Add QCExport code to devtools

### DIFF
--- a/devtools/qcexport/README
+++ b/devtools/qcexport/README
@@ -1,0 +1,9 @@
+WARNING
+THIS CODE IS VERY EXPERIMENTAL
+
+This code allows for exporting pieces of a larger database into another
+(empty) database. For now, its only use is to create small subsets of the
+production database to help with development and testing.
+
+Some of this code could eventually be migrated into qcfractal proper, and
+form the basis for the export side of importing/exporting data between servers.

--- a/devtools/qcexport/create_staging.py
+++ b/devtools/qcexport/create_staging.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+"""
+A command line script to copy a sample of the production DB into staging or
+development DB.
+
+"""
+
+import io
+import psycopg2
+import qcexport
+
+from qcfractal.storage_sockets import storage_socket_factory
+
+def create_destination_db(full_uri):
+    '''Creates an empty database
+
+    If the database already exists, an exception is raised
+
+    '''
+    # First, does the database exist?
+    # Any better way to check if a db exists?
+    #  https://dba.stackexchange.com/questions/45143/check-if-postgresql-database-exists-case-insensitive-way
+
+    # Expected that the URI contains the dbname
+    base_uri, dbname = full_uri.rsplit('/', maxsplit=1)
+
+    print(f'* Testing if {dbname} exists in {base_uri}')
+
+    conn = psycopg2.connect(base_uri)
+
+    # Enable autocommit (to allow creating the db)
+    # see https://stackoverflow.com/questions/34484066/create-a-postgres-database-using-python
+    conn.autocommit = True
+
+    cur = conn.cursor()
+    cur.execute("SELECT datname FROM pg_catalog.pg_database WHERE datname = %s", (dbname,))
+
+    # Check if destination db exists. If it does, abort
+    exists = bool(cur.rowcount)
+    if exists:
+        raise RuntimeError(f"Database {dbname} exists! For safety, I will not overwrite")
+
+    print(f'* Creating database {full_uri}')
+    cur.execute(f"CREATE DATABASE {dbname}")
+
+
+def copy_alembic_version(src_uri, dest_uri):
+    ''' Copies the alembic_version table from the source to the destination '''
+
+    print("* Copying alembic information")
+
+    conn_src = psycopg2.connect(src_uri)
+    conn_dest = psycopg2.connect(dest_uri)
+    conn_dest.autocommit = True
+
+    cur_src = conn_src.cursor()
+    cur_dest = conn_dest.cursor()
+
+    # We use a io.StringIO object, which behaves
+    # like a file object that copy_to/copy_from expects
+    alembic_data = io.StringIO()
+
+    # Copy the data from the source
+    cur_src.copy_to(alembic_data, 'alembic_version')
+
+    # Place the internal pointer back to the beginning of the stream
+    # (so that reads start from the beginning)
+    alembic_data.seek(0)
+
+    # Now create the table in the destination and copy the data there
+    cur_dest.execute(f"CREATE TABLE alembic_version (version_num varchar(32) NOT NULL PRIMARY KEY)")
+    cur_dest.copy_from(alembic_data, 'alembic_version')
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Copy a sample of a production QCArchive database into a staging or development database')
+
+    parser.add_argument('src', type=str, help='Source database (usually production)')
+    parser.add_argument('dest', type=str, help='Destination database URI (must not exist)')
+    parser.add_argument('-M', '--maxlimit', type=int, default=100000, help='Maximum value for a LIMIT')
+    args = parser.parse_args()
+
+    print("-"*80)
+    print(f'     Source URI: {args.src}')
+    print(f'Destination URI: {args.dest}')
+    print("-"*80)
+    print()
+
+    # Connect to the source database
+    production_storage = storage_socket_factory(args.src, db_type="sqlalchemy", max_limit=args.maxlimit, skip_version_check=False)
+
+    # Create & connect to the destination database.
+    # If it exists, this function should raise an exception
+    create_destination_db(args.dest)
+    copy_alembic_version(args.src, args.dest)
+
+    # Set up the socket for the destination
+    staging_storage = storage_socket_factory(args.dest, db_type="sqlalchemy", max_limit=args.maxlimit)
+
+    ################################################################
+    # START COPYING DATA
+    ################################################################
+    # indent stores the current output level. This allows for nesting
+    # calls copying some lower-level tables
+    indent = ''
+
+    full_pk_map = {}
+    options = {'dataset_max_entries': 2,
+               'queue_manager_log_max': 50,
+               'truncate_kv_store': False,
+              }
+
+    #############################
+    # Start exporting stuff here
+    #############################
+
+    # Export everything from versions
+    qcexport.general_copy('versions', staging_storage, production_storage, full_pk_map, options, {}, limit=None)
+
+    # Errored Calculations. These should also have tasks and/or services
+    qcexport.general_copy('result', staging_storage, production_storage, full_pk_map, options, {'status': 'error'}, {'id': 'desc'}, 10)
+    qcexport.general_copy('optimization_procedure', staging_storage, production_storage, full_pk_map, options, {'status': 'error'}, {'id': 'desc'}, 10)
+    qcexport.general_copy('grid_optimization_procedure', staging_storage, production_storage, full_pk_map, options, {'status': 'error'}, {'id': 'desc'}, 2)
+    qcexport.general_copy('torsiondrive_procedure', staging_storage, production_storage, full_pk_map, options, {'status': 'error'}, {'id': 'desc'}, 2)
+
+    # Datasets (Energy)
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '155'})
+
+    # Datasets (Hessian)
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '262'})
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '159'})
+
+
+    # OptimizationDataSet
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '50'})
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '253'})
+
+    # GridOptimizationDataSet
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '237'})
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '239'})
+
+    # ReactionDataSet
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '184'})
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '186'})
+
+    # TorsiondriveDataSet
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '48'})
+    qcexport.general_copy('collection', staging_storage, production_storage, full_pk_map, options, {'id': '217'})
+
+    

--- a/devtools/qcexport/qcexport.py
+++ b/devtools/qcexport/qcexport.py
@@ -1,0 +1,506 @@
+'''Import/Export of QCArchive data
+'''
+
+from dataclasses import dataclass
+import typing
+from qcexport_extra import extra_children_map
+
+from sqlalchemy.orm import make_transient, Load
+from sqlalchemy import inspect
+
+from qcfractal.storage_sockets.models import (
+    AccessLogORM,
+    BaseResultORM,
+    CollectionORM,
+    DatasetORM,
+    GridOptimizationProcedureORM,
+    MoleculeORM,
+    KeywordsORM,
+    KVStoreORM,
+    OptimizationProcedureORM,
+    QueueManagerLogORM,
+    QueueManagerORM,
+    ResultORM,
+    ServerStatsLogORM,
+    ServiceQueueORM,
+    QueueManagerORM,
+    TaskQueueORM,
+    TorsionDriveProcedureORM,
+    Trajectory,
+    VersionsORM,
+    WavefunctionStoreORM,
+)
+
+from qcfractal.storage_sockets.models.collections_models import DatasetEntryORM
+from qcfractal.storage_sockets.models.results_models import GridOptimizationAssociation, TorsionInitMol
+
+_all_orm = [
+    AccessLogORM,
+    BaseResultORM,
+    CollectionORM,
+    DatasetORM,
+    DatasetEntryORM,
+    GridOptimizationProcedureORM,
+    GridOptimizationAssociation,
+    MoleculeORM,
+    KeywordsORM,
+    KVStoreORM,
+    OptimizationProcedureORM,
+    QueueManagerLogORM,
+    QueueManagerORM,
+    ResultORM,
+    ServerStatsLogORM,
+    ServiceQueueORM,
+    QueueManagerORM,
+    TaskQueueORM,
+    TorsionDriveProcedureORM,
+    TorsionInitMol,
+    Trajectory,
+    VersionsORM,
+    WavefunctionStoreORM,
+]
+
+# Maps table names to sqlalchemy ORM objects
+_table_orm_map = {orm.__tablename__: orm for orm in _all_orm}
+
+
+class RowKeyValues:
+    '''Generates and stores information about primary and foreign keys of a table
+    '''
+    @dataclass(order=True)
+    class PKInfo:
+        '''Holds information about a row's primary key.
+
+        Holds the column names and the values of the primary key columns.
+        These are lists in order to handle composite primary keys
+        '''
+        table: str
+        columns: list
+        values: list
+
+    @dataclass(order=True)
+    class FKInfo:
+        '''Holds information about a row's foreign key.
+
+        For a single foreign key, holds the source and destination/foreign table names and columns. Also
+        holds the value in the source row.
+        '''
+        src_table: str
+        src_column: str
+        dest_table: str
+        dest_column: str
+        value: 'typing.Any'
+
+    def __init__(self, orm_obj):
+        '''Generates primary and foreign key info given an ORM object'''
+
+        self.orm_type = type(orm_obj)
+        insp = inspect(self.orm_type)
+
+        ###########################################################
+        # First, get which columns are primary and foreign keys
+        ###########################################################
+
+        # Handle if this is a derived class (polymorphic?)
+        # This seems poorly documented. But get the table name of the
+        # base class (if there is one)
+        base_class = insp.inherits.entity if insp.inherits else None
+        base_table = base_class.__tablename__ if base_class else None
+
+        # Get the columns comprising the primary key
+        primary_key_columns = [x.name for x in insp.primary_key]
+
+        # Now foreign keys. Loop over all the columns.
+        # Each column has a set() (which may be empty) stored in foreign_keys
+        foreign_key_info = []
+        for col in insp.columns:
+            for fk in sorted(list(col.foreign_keys)):
+                # Remove foreign keys to base class
+                # The purpose of this function is to get foreign keys that we need to
+                # load. But if it is part of the base class, then no need to do that
+                if not (base_table and fk.column.table.name == base_table):
+                    new_fk = self.FKInfo(col.table.name, col.name, fk.column.table.name, fk.column.name, None)
+                    foreign_key_info.append(new_fk)
+
+        # Not sure if order is always preserved, but sort just in case
+        # so that things are always consistent
+        primary_key_columns = sorted(primary_key_columns)
+        foreign_key_info = sorted(foreign_key_info)
+
+        # Now store in this class
+        self.primary_key = self.PKInfo(self.orm_type.__tablename__, primary_key_columns, None)
+        self.foreign_keys = foreign_key_info
+
+        #######################################################
+        # Obtain values for the primary and foreign key columns
+        #######################################################
+        self.primary_key.values = [getattr(orm_obj, column) for column in self.primary_key.columns]
+        for fk in self.foreign_keys:
+            fk.value = getattr(orm_obj, fk.src_column)
+
+    def is_composite_primary(self):
+        '''Returns True if this represents a composite primary key'''
+        return len(self.primary_key.columns) > 1
+
+    def as_lookup_key(self):
+        '''Return a unique string representing the primary key
+
+        This is used as a key to a dictionary to store already-copied data.
+        '''
+        return repr(self.orm_type) + repr(self.primary_key)
+
+    def remove_primary_key(self, orm_obj):
+        '''Remove primary key values that are integers and not part of
+           a composite primary key'''
+
+        if type(orm_obj) != self.orm_type:
+            raise RuntimeError("Removing primary keys of type f{type(orm_obj)} but I can only handle {self.orm_type}")
+
+        # Don't touch composite primary
+        if self.is_composite_primary():
+            return
+
+        for pk, old_value in zip(self.primary_key.columns, self.primary_key.values):
+            if isinstance(old_value, int):
+                setattr(orm_obj, pk, None)
+
+
+def _add_children(orm_obj, session_dest, session_src, new_pk_map, options, row_key_info, indent=''):
+    '''Given an ORM object, adds the dependent data (through foreign keys)
+
+    Finds all the foreign keys for the object, and adds the dependent data to the DB.
+    It then fixes the values of the foreign keys in the ORM object to match the newly-inserted data.
+
+    Parameters
+    ----------
+    orm_obj
+        An ORM object to add the children of
+    session_dest
+        SQLAlchemy session to write data to
+    session_src
+        SQLAlchemy session to read data from
+    new_pk_map : dict
+        Where to store the mapping of old to new data
+    options : dict
+        Various options to be passed into the internal functions
+    row_key_info : RowKeyValues
+        Information about the row's primary and foreign keys
+    indent : str
+        Prefix to add to all printed output lines
+    '''
+
+    for fk_info in row_key_info.foreign_keys:
+        # Data in that column may be empty/null
+        if fk_info.value is None:
+            continue
+
+        print(indent + "+ Handling child: ")
+        print(
+            indent +
+            f"  - {fk_info.src_table}.{fk_info.src_column}:{fk_info.value}  ->  {fk_info.dest_table}.{fk_info.dest_column}"
+        )
+
+
+        # We need to load from the db (from the foreign/destination table) given the column and value
+        #    in the foreign key info
+        fk_query = {fk_info.dest_column: fk_info.value}
+
+        # Copy the foreign info. This should only return one record
+        # NOTE: This requires going to the source db for info. It is possible that
+        #       we can check new_pk_map here using the info from the foreign key to see if it
+        #       was already done. However, the hit rate would generally be low, and might be error
+        #       prone, especially with esoteric cases.
+        new_info = _general_copy(table_name=fk_info.dest_table,
+                                 session_dest=session_dest,
+                                 session_src=session_src,
+                                 new_pk_map=new_pk_map,
+                                 options=options,
+                                 filter_by=fk_query,
+                                 single=True,
+                                 indent=indent + '  ')
+
+        # Now set the foreign keys to point to the new id
+        setattr(orm_obj, fk_info.src_column, new_info[fk_info.dest_column])
+
+
+def _add_tasks_and_services(base_result_id, session_dest, session_src, new_pk_map, options, indent):
+    '''Adds entries in the task_queue and service_queue given something deriving from base_result
+
+    Should only be called after adding the result or procedure.
+
+    Parameters
+    ----------
+    base_result_id
+        ID of the base_result (result, procedure, ...)
+    session_dest
+        SQLAlchemy session to write data to
+    session_src
+        SQLAlchemy session to read data from
+    new_pk_map : dict
+        Where to store the mapping of old to new data
+    options : dict
+        Various options to be passed into the internal functions
+    indent : str
+        Prefix to add to all printed output lines
+    '''
+
+    print(indent + f"$ Adding task & service queue entries for base_result_id = {base_result_id}")
+
+    # Add anything from the task queue corresponding to the given base result id
+    # (if calculation is completed, task is deleted)
+    _general_copy(table_name='task_queue',
+                  session_dest=session_dest,
+                  session_src=session_src,
+                  new_pk_map=new_pk_map,
+                  options=options,
+                  filter_by={'base_result_id': base_result_id},
+                  indent=indent + '  ')
+
+    # Do the same for the services queue
+    #if int(base_result_id) == 17761750:
+    #    breakpoint()
+    _general_copy(table_name='service_queue',
+                  session_dest=session_dest,
+                  session_src=session_src,
+                  new_pk_map=new_pk_map,
+                  options=options,
+                  filter_by={'procedure_id': base_result_id},
+                  indent=indent + '  ')
+
+
+def _general_copy(table_name,
+                  session_dest,
+                  session_src,
+                  new_pk_map,
+                  options,
+                  filter_by=None,
+                  filter_in=None,
+                  order_by=None,
+                  limit=None,
+                  single=False,
+                  indent=''):
+    ''' 
+    Given queries, copies all results of the query from session_src to session_dest
+
+    Adds data to session_dest, keeping a map of newly-added info and fixing foreign keys
+    to match newly-inserted data.
+    
+    Called recursively to add dependent data through foreign keys.
+
+    Parameters
+    ----------
+    table_name : str
+        Name of the table to copy data from/to
+    session_dest
+        SQLAlchemy session to write data to
+    session_src
+        SQLAlchemy session to read data from
+    new_pk_map : dict
+        Where to store the mapping of old to new data
+    options : dict
+        Various options to be passed into the internal functions
+    filter_by : dict
+        Filters (column: value) to add to the query. ie, {'id': 123}
+    filter_in : dict
+        Filters (column: list(values)) to add to the query using 'in'. ie, {'id': [123,456]}
+    order_by: dict
+        How to order the results of the query. ie {'id': 'desc'}
+    limit : int
+        Limit the number of records returned
+    single : bool
+        If true, expect only one returned record. If not, raise an exception
+    indent : str
+        Prefix to add to all printed output lines
+    '''
+
+    orm_type = _table_orm_map[table_name]
+
+    # Build the query based on filtering, etc
+    query = session_src.query(orm_type)
+
+    if filter_by is not None:
+        query = query.filter_by(**filter_by)
+
+    if filter_in is not None:
+        for key, values in filter_in.items():
+            query = query.filter(getattr(orm_type, key).in_(values))
+
+    if order_by:
+        for column, order in order_by.items():
+            # Gets, for example, Trajectory.opt_id.desc
+            # opt_id = column, desc = bound function
+            o = getattr(orm_type, column)
+            o = getattr(o, order)
+
+            query = query.order_by(o())
+
+    if limit is not None:
+        if single and limit != 1:
+            raise RuntimeError(f'Limit = {limit} but single return is specified')
+        query = query.limit(limit)
+    elif single:
+        limit = 1
+
+    # Disable all relationship loading
+    query = query.options(Load(orm_type).noload('*'))
+
+    data = query.all()
+    return_info = []
+
+    # We have to expunge and make transient everything first
+    # If not, sqlalchemy tries to be smart. After you add the entries found
+    # through foreign keys, the rest of the objects in the data list may change.
+    # But then you will have parts of objects in session_src and parts in session_dest
+    for d in data:
+        session_src.expunge(d)
+        make_transient(d)
+
+    for d in data:
+        # Obtain primary/foreign key columns and values
+        src_rck = RowKeyValues(d)
+
+        # The type of the object may not be the same as we queried (due to polymorphic types)
+        real_orm_type = type(d)
+        real_table_name = real_orm_type.__tablename__
+
+        # real_orm_type should never be BaseResultORM
+        assert real_orm_type != BaseResultORM
+
+        print(indent +
+              f'* Copying {table_name} {str(src_rck.primary_key.columns)} = {str(src_rck.primary_key.values)}')
+
+        if real_orm_type != orm_type:
+            print(indent + f'& But actually using table {real_table_name}')
+            
+        ############################################################
+        ############################################################
+        ## TODO - If working with an existing db, do lookups here ##
+        ##        (this is for future capability of importing     ##
+        ##        into an existing db)                            ##
+        ############################################################
+        ############################################################
+
+        src_lookup_key = src_rck.as_lookup_key()
+        if src_lookup_key in new_pk_map:
+            print(indent + f'  - Already previously done')
+            return_info.append(new_pk_map[src_lookup_key])
+            continue
+
+        # Save src information for laters. When adding extra children, old ids and stuff may be needed
+        src_info = d.to_dict()
+
+        # Loop through foreign keys and recursively add those
+        _add_children(d, session_dest, session_src, new_pk_map, options, src_rck, indent + '  ')
+
+        # Remove the primary key. We will generate a new one on adding
+        src_rck.remove_primary_key(d)
+
+        # Truncate KV store entries by default
+        # (but can be overridden)
+        if table_name == 'kv_store':
+            truncate_kv_store = options.get('truncate_kv_store', True)
+            if truncate_kv_store:
+                d.value = str(d.value)[:2000]
+            
+
+        # Now add it to the session
+        # and obtain the key info
+        session_dest.add(d)
+        session_dest.commit()
+
+        dest_rck = RowKeyValues(d)
+        print(indent + f'! adding {real_table_name} {str(src_rck.primary_key.values)} = {str(dest_rck.primary_key.values)}')
+
+        # Store the info for the entire row
+        # (exception: kvstore)
+        dest_info = d.to_dict()
+
+        # Don't store kvstore data in the dictionary (not needed)
+        if table_name == 'kv_store':
+            dest_info.pop('value')
+
+        # We can't just use primary key, since foreign keys may
+        # reference non-primary-keys of other tables (as long as they are unique)
+        new_pk_map[src_lookup_key] = dest_info
+        return_info.append(dest_info)
+
+        ########################################################################
+        # Now handle children that are not specified by foreign keys
+        # This includes decoupled data like datasets, as well as when foreign
+        # keys are specified in json
+        #
+        # We do that here after adding. Some of these have foreign keys
+        # to this object, so we need the new id (retrieved through new_pk_map)
+        ########################################################################
+        if real_orm_type in extra_children_map:
+            # The function called in extra_children_map may modify the object.
+            # We let the called function do that, then merge it back into the db
+            extra_children_map[real_orm_type](d, src_info, session_dest, session_src, new_pk_map, options, indent + '  ')
+            session_dest.commit()
+
+        ########################################################################
+        # Now add tasks/services if this is a result/procedure
+        ########################################################################
+        if issubclass(real_orm_type, BaseResultORM):
+            _add_tasks_and_services(src_info['id'], session_dest, session_src, new_pk_map, options, indent + '  ')
+
+    # If the caller specified single=True, should only be one record
+    if single:
+        if len(return_info) != 1:
+            raise RuntimeError(f'Wanted single record but got {len(return_info)} instead')
+        return return_info[0]
+    else:
+        return return_info
+
+
+def general_copy(table_name,
+                 storage_dest,
+                 storage_src,
+                 new_pk_map=None,
+                 options={},
+                 filter_by={},
+                 order_by=None,
+                 limit=None,
+                 indent=''):
+    ''' Copies data from the source db to the destination db
+
+    Given queries, copies all results of the query from session_src to session_dest
+
+    Handles copying of data required by foreign keys as well.
+
+    Parameters
+    ----------
+    table_name : str
+        Name of the table to copy data from/to
+    storage_dest
+        Storage object to write data to
+    storage_src
+        Storage object to read data from
+    new_pk_map : dict
+        Where to store the mapping of old to new data
+    options : dict
+        Various options to be passed into the internal functions
+    filter_by : dict
+        Filters (column: value) to add to the query. ie, {'id': 123}
+    order_by: dict
+        How to order the results of the query. ie {'id': 'desc'}
+    limit : int
+        Limit the number of records returned
+    indent : str
+        Prefix to add to all printed output lines
+    '''
+
+    if new_pk_map is None:
+        new_pk_map = dict()
+
+    with storage_src.session_scope() as session_src:
+        with storage_dest.session_scope() as session_dest:
+            _general_copy(table_name,
+                          session_dest,
+                          session_src,
+                          new_pk_map=new_pk_map,
+                          options=options,
+                          filter_by=filter_by,
+                          order_by=order_by,
+                          limit=limit,
+                          indent=indent)

--- a/devtools/qcexport/qcexport_extra.py
+++ b/devtools/qcexport/qcexport_extra.py
@@ -1,0 +1,121 @@
+'''
+Handles special relationships
+'''
+
+##########################################
+# TODO - fix import mess
+# Cannot import _general_copy here since it
+# will result in a circular import
+##########################################
+
+
+from qcexport_extra_collection import _add_collection
+
+from qcfractal.storage_sockets.models import (
+    CollectionORM,
+    QueueManagerORM,
+    OptimizationProcedureORM,
+    GridOptimizationProcedureORM,
+    TorsionDriveProcedureORM
+)
+
+
+def _add_procedure_mixin(procedure_table, orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent):
+    '''Handling of common parts of procedures'''
+
+    from qcexport import _general_copy
+
+    # Fix keywords in the qc_spec column
+    keyword_id = orm_obj.qc_spec['keywords']
+    if keyword_id is not None:
+        # Is it a hash? That is incorrect
+        if not keyword_id.isdecimal():
+            print(indent + f'!!! Keyword {keyword_id} is not an integer!')
+        else:
+            new_kw = _general_copy('keywords',
+                                   session_dest,
+                                   session_src,
+                                   new_pk_map,
+                                   options,
+                                   filter_by={'id': src_info['qc_spec']['keywords']},
+                                   single=True,
+                                   indent=indent + '  ')
+
+            orm_obj.qc_spec['keywords'] = new_kw['id']
+
+
+def _add_optimization_procedure(orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent):
+    from qcexport import _general_copy
+
+    print(indent + f'$ Adding extra children for optimization procedure {src_info["id"]}')
+
+    _general_copy('opt_result_association',
+                  session_dest,
+                  session_src,
+                  new_pk_map,
+                  options,
+                  filter_by={'opt_id': src_info['id']},
+                  indent=indent + '  ')
+
+    _add_procedure_mixin('optimization_procedure', orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent)
+
+
+def _add_gridoptimization_procedure(orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent):
+    from qcexport import _general_copy
+
+    print(indent + f'$ Adding extra children for grid optimization procedure {src_info["id"]}')
+
+    _general_copy('grid_optimization_association',
+                  session_dest,
+                  session_src,
+                  new_pk_map,
+                  options,
+                  filter_by={'grid_opt_id': src_info['id']},
+                  indent=indent + '  ')
+
+    _add_procedure_mixin('grid_optimization_procedure', orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent)
+
+def _add_torsiondrive_procedure(orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent):
+    from qcexport import _general_copy
+
+
+    print(indent + f'$ Adding extra children for torsiondrive procedure {src_info["id"]}')
+
+    _general_copy('torsion_init_mol_association',
+                  session_dest,
+                  session_src,
+                  new_pk_map,
+                  options,
+                  filter_by={'torsion_id': src_info['id']},
+                  indent=indent + '  ')
+
+    _add_procedure_mixin('torsiondrive_procedure', orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent)
+
+
+def _add_queuemanager(orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent):
+    '''Adds extra info for queue managers (ie, logs)'''
+
+    from qcexport import _general_copy
+
+    print(indent + f'$ Adding extra children for queue manager {src_info["id"]}:{src_info["name"]}')
+
+    max_limit = options.get('queue_manager_log_max', None)
+
+    # Add the logs for the queue manager
+    _general_copy(table_name='queue_manager_logs',
+                  session_dest=session_dest,
+                  session_src=session_src,
+                  new_pk_map=new_pk_map,
+                  options=options,
+                  filter_by={'manager_id': src_info['id']},
+                  order_by={'id': 'desc'},
+                  limit=max_limit,
+                  indent=indent + '  ')
+
+
+extra_children_map = {CollectionORM: _add_collection,
+                      QueueManagerORM: _add_queuemanager,
+                      OptimizationProcedureORM: _add_optimization_procedure,
+                      GridOptimizationProcedureORM: _add_gridoptimization_procedure,
+                      TorsionDriveProcedureORM: _add_torsiondrive_procedure,
+                     }

--- a/devtools/qcexport/qcexport_extra_collection.py
+++ b/devtools/qcexport/qcexport_extra_collection.py
@@ -1,0 +1,190 @@
+'''
+Handles special relationships for collections
+'''
+
+##########################################
+# TODO - fix import mess
+# Cannot import _general_copy here since it
+# will result in a circular import
+##########################################
+
+def _add_dataset(entry_table, orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent):
+    '''Adds data for a dataset not specified by foreign keys
+
+    Datasets are loosely coupled to results
+
+    The src_info represents the data as given in the source database (before changing ids, etc)
+    '''
+
+    from qcexport import _general_copy
+
+    # First add the entries (molecules) corresponding to this dataset (dataset_entry table)
+    # Look up the maximum number of entries (molecules)
+    max_entries = options.get('dataset_max_entries', None)
+    entry_info = _general_copy(entry_table,
+                               session_dest,
+                               session_src,
+                               new_pk_map,
+                               options,
+                               filter_by={'dataset_id': src_info['id']},
+                               limit=max_entries,
+                               indent=indent + '  ')
+
+    # Loop over alias_keywords and add them to the db, updating to the corrext keyword id
+    for program, aliases in orm_obj.alias_keywords.items():
+        for alias_name, keyword_id in aliases.items():
+            # Add the keywords (if they exist)
+            if keyword_id is not None:
+                new_kw = _general_copy('keywords',
+                                       session_dest,
+                                       session_src,
+                                       new_pk_map,
+                                       options,
+                                       filter_by={'id': keyword_id},
+                                       single=True,
+                                       indent=indent + '  ')
+                
+                aliases[alias_name] = new_kw['id']
+
+    # Loop through molecules and history to find all the results and copy those
+    # But only those corresponding to the entries (molecules) we copied above (searched by name)
+    added_molecules = [x['name'] for x in entry_info]
+    molecules = [x['molecule_id'] for x in src_info['records'] if x['name'] in added_molecules]
+
+    for history in src_info['history']:
+        history = {k: v for k, v in zip(src_info['history_keys'], history)}
+        program = history['program']
+        keywords = history['keywords']
+
+        ###################################################
+        # Look up the id of the keywords in alias_keywords
+        # And replace in the history dict
+        # This isn't stored back to the ORM object, but is used for looking up results
+
+        # Sometimes, something is not in this alias_keywords dict. Something got lost somewhere
+        # (sometimes happens with dftd3)
+        try:
+            keywords_id = src_info['alias_keywords'][program][keywords]
+        except KeyError:
+            print(indent + f'!!! Alias keywords not found! ["{program}"]["{keywords}"]')
+            continue
+
+        history['keywords'] = keywords_id
+
+        for molecule in molecules:
+            filter_by = history.copy()
+            filter_by['molecule'] = molecule
+
+            # Find and add the corresponding result
+            # We don't store the id anywhere, though
+            _general_copy(table_name='result',
+                          session_dest=session_dest,
+                          session_src=session_src,
+                          new_pk_map=new_pk_map,
+                          options=options,
+                          filter_by=filter_by,
+                          indent=indent)
+
+
+def _add_proceduredataset(procedure_table, orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent):
+    from qcexport import _general_copy
+
+    # Data is stored in the 'object_map' member of 'records' dict
+    # Create a new one with updated procedure IDs
+
+    records = orm_obj.extra.pop('records')
+    orm_obj.extra['records'] = {}
+
+    max_entries = options.get('dataset_max_entries', None)
+
+    # Fix the keywords in qc_spec
+    for spec_name,spec in orm_obj.extra['specs'].items():
+        qc_keyword_id = spec['qc_spec']['keywords']
+        if qc_keyword_id is not None:
+            new_qc_kw = _general_copy('keywords',
+                                      session_dest,
+                                      session_src,
+                                      new_pk_map,
+                                      options,
+                                      filter_by={'id': qc_keyword_id},
+                                      single=True,
+                                      indent=indent + '  ')
+
+            spec['qc_spec']['keywords'] = new_qc_kw['id']
+
+    # Now go through all the records
+    for count,(key,record) in enumerate(records.items()):
+        # Remember that count goes starts at zero, therefore >=
+        if max_entries is not None and count >= max_entries:
+            break
+
+        # Add the initial molecule
+        # Sometimes stored as initial_molecule, initial_molecules, starting_molecule
+        for initial_key in ['initial_molecule', 'initial_molecules', 'starting_molecule']:
+            mol_id = record.get(initial_key, None)
+
+            # Did not exist
+            if mol_id is None:
+                continue
+
+            if isinstance(mol_id, list):
+                initial_molecule = _general_copy(table_name='molecule',
+                                                 session_dest=session_dest,
+                                                 session_src=session_src,
+                                                 new_pk_map=new_pk_map,
+                                                 options=options,
+                                                 filter_in={'id': mol_id},
+                                                 single=False,
+                                                 indent=indent + '  ')
+
+                record[initial_key] = [x["id"] for x in initial_molecule]
+            else:
+                initial_molecule = _general_copy(table_name='molecule',
+                                                 session_dest=session_dest,
+                                                 session_src=session_src,
+                                                 new_pk_map=new_pk_map,
+                                                 options=options,
+                                                 filter_by={'id': mol_id},
+                                                 single=True,
+                                                 indent=indent + '  ')
+
+                record[initial_key] = initial_molecule['id']
+
+        new_object_map = {}
+        for spec_name, procedure_id in record['object_map'].items():
+            print(indent + f'* Adding spec {spec_name} procedure id {procedure_id}')
+
+            filter_by = {'id': procedure_id}
+            opt_procedure = _general_copy(table_name=procedure_table,
+                                          session_dest=session_dest,
+                                          session_src=session_src,
+                                          new_pk_map=new_pk_map,
+                                          options=options,
+                                          filter_by=filter_by,
+                                          single=True,
+                                          indent=indent + '  ')
+            new_object_map[spec_name] = opt_procedure['id']
+
+        record['object_map'] = new_object_map
+        orm_obj.extra['records'][key] = record
+            
+
+def _add_collection(orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent):
+    '''Handles adding loosely-coupled children of collections'''
+    from qcexport import _general_copy
+
+    collection_type = src_info['collection']
+
+    print(indent + f'$ Adding extra children for collection {src_info["id"]} of type {collection_type}')
+    if collection_type == 'dataset':
+        _add_dataset('dataset_entry', orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent + '  ')
+    elif collection_type == 'reactiondataset':
+        _add_dataset('reaction_dataset_entry', orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent + '  ')
+    elif collection_type == 'optimizationdataset':
+        _add_proceduredataset('optimization_procedure', orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent + '  ')
+    elif collection_type == 'torsiondrivedataset':
+        _add_proceduredataset('torsiondrive_procedure', orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent + '  ')
+    elif collection_type == 'gridoptimizationdataset':
+        _add_proceduredataset('grid_optimization_procedure', orm_obj, src_info, session_dest, session_src, new_pk_map, options, indent + '  ')
+    else:
+        raise RuntimeError(f"Unknown collection type {collection_type}")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

**This code is still very experimental.**

This code allows for exporting pieces of a larger database into another database. I use this to set up development environments containing a small but representative portion of the full production database.

I am currently placing it in devtools, but eventually pieces could be migrated into the qcfractal code. This could form the basis of importing/exporting data between instances.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
N/A (probably best to keep it low-key for now)

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
