### PR TITLE
Fix extra task_id in old service records

### DIFF
--- a/qcfractal/services/gridoptimization_service.py
+++ b/qcfractal/services/gridoptimization_service.py
@@ -49,8 +49,11 @@ class GridOptimizationService(BaseService):
     def initialize_from_api(cls, storage_socket, logger, service_input, tag=None, priority=None):
 
         # Build the record
+        # TODO: This removes the task_id which may exist on old records, but does not exist
+        # in newer GridOptimizationRecords.
+        # If a proper migration is ever done,
         output = GridOptimizationRecord(
-            **service_input.dict(exclude={"initial_molecule"}),
+            **service_input.dict(exclude={"initial_molecule", "task_id"}),
             initial_molecule=service_input.initial_molecule.id,
             starting_molecule=service_input.initial_molecule.id,
             provenance={

--- a/qcfractal/services/torsiondrive_service.py
+++ b/qcfractal/services/torsiondrive_service.py
@@ -59,8 +59,11 @@ class TorsionDriveService(BaseService):
         from torsiondrive import td_api
 
         # Build the record
+        # TODO: This removes the task_id which may exist on old records, but does not exist
+        # in newer TorsionDriveRecords.
+        # If a proper migration is ever done,
         output = TorsionDriveRecord(
-            **service_input.dict(exclude={"initial_molecule"}),
+            **service_input.dict(exclude={"initial_molecule", "task_id"}),
             initial_molecule=[x.id for x in service_input.initial_molecule],
             provenance={
                 "creator": "torsiondrive",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Description
<!-- Provide a brief description of the PR's purpose here. -->

Release 0.15.1 has a bug where previously-created services would not run due to `task_id` being stored in the `output` dictionary. TorsionDriveRecord/GridOptimizationRecord no longer have that field, so an exception was raised when trying to create the service object.

This does not fix another error that surfaces when `construct_service` raises an exception.

Given the urgency, this fix will do. There may be a proper migration in the future, but that can wait.

```
    Traceback (most recent call last):
      File "/home/qcarchive/miniconda3/envs/qcaprod_v15_1/lib/python3.9/site-packages/qcfractal/server.py", line 522, in update_services
        service = construct_service(self.storage, self.logger, data)
      File "/home/qcarchive/miniconda3/envs/qcaprod_v15_1/lib/python3.9/site-packages/qcfractal/services/services.py", line 69, in construct_service
        return _service_chooser(name)(**data, storage_socket=storage_socket, logger=logger)
      File "/home/qcarchive/miniconda3/envs/qcaprod_v15_1/lib/python3.9/site-packages/qcfractal/services/service_util.py", line 148, in __init__
        super().__init__(**data)
      File "pydantic/main.py", line 362, in pydantic.main.BaseModel.__init__
    pydantic.error_wrappers.ValidationError: 1 validation error for GridOptimizationService
    output -> task_id
      extra fields not permitted (type=value_error.extra)

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/home/qcarchive/miniconda3/envs/qcaprod_v15_1/lib/python3.9/site-packages/tornado/ioloop.py", line 905, in _run
        return self.callback()
      File "/home/qcarchive/miniconda3/envs/qcaprod_v15_1/lib/python3.9/site-packages/qcfractal/server.py", line 527, in update_services
        service.status = "ERROR"
    UnboundLocalError: local variable 'service' referenced before assignment
```


## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fix inability to run previously-generated services due to extra task_id field

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
