### PR TITLE
Service errors should always be compute errors

### DIFF
--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -550,6 +550,8 @@ class FractalServer:
         if len(completed_services):
             self.logger.info(f"Completed {len(completed_services)} services.")
 
+        self.logger.debug(f"Done updating services.")
+
         # Add new procedures and services
         self.storage.services_completed(completed_services)
 

--- a/qcfractal/server.py
+++ b/qcfractal/server.py
@@ -10,6 +10,7 @@ import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional, Union
+from qcelemental.models import ComputeError
 
 import tornado.ioloop
 import tornado.log
@@ -531,7 +532,7 @@ class FractalServer:
                 error_message = "FractalServer Service Build and Iterate Error:\n{}".format(traceback.format_exc())
                 self.logger.error(error_message)
                 service.status = "ERROR"
-                service.error = {"error_type": "iteration_error", "error_message": error_message}
+                service.error = ComputeError(error_type="iteration_error", error_message=error_message)
                 finished = False
 
             self.storage.update_services([service])

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1958,7 +1958,7 @@ class SQLAlchemySocket:
                 stdout_id = self.add_kvstore([stdout])["data"][0]
                 procedure.__dict__["stdout"] = stdout_id
             if service.error:
-                error = KVStore(data=service.error)
+                error = KVStore(data=service.error.dict())
                 error_id = self.add_kvstore([error])["data"][0]
                 procedure.__dict__["error"] = error_id
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fixes exception where an error is expected to be a dictionary but can sometimes be a ComputeError

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
