### PR TITLE
Generalized upsert functionality in socket

### DIFF
--- a/qcfractal/interface/models/common_models.py
+++ b/qcfractal/interface/models/common_models.py
@@ -140,12 +140,15 @@ class KVStore(ProtoModel):
         input_data: Union[Dict[str, str], str],
         compression_type: CompressionEnum = CompressionEnum.none,
         compression_level: Optional[int] = None,
+        id=None,
     ):
         """Compresses a string given a compression scheme and level
 
         Returns an object of type `cls`
 
         If compression_level is None, but a compression_type is specified, an appropriate default level is chosen
+
+        If id is specified, the internal id is set to that value
         """
 
         if isinstance(input_data, dict):
@@ -182,7 +185,7 @@ class KVStore(ProtoModel):
             # Shouldn't ever happen, unless we change CompressionEnum but not the rest of this function
             raise TypeError("Unknown compression type??")
 
-        return cls(data=data, compression=compression_type, compression_level=compression_level)
+        return cls(data=data, compression=compression_type, compression_level=compression_level, id=id)
 
     def get_string(self):
         """

--- a/qcfractal/procedures/base.py
+++ b/qcfractal/procedures/base.py
@@ -73,12 +73,16 @@ class BaseTasks(abc.ABC):
             self.logger.warning(f"Found uncompressed error for result id {rdata['id']}")
             error = KVStore(data=rdata["error"])
 
-        # Now add to the database and set the ids in the diction
-        outputs = [stdout, stderr, error]
-        stdout_id, stderr_id, error_id = self.storage.add_kvstore(outputs)["data"]
-        rdata["stdout"] = stdout_id
-        rdata["stderr"] = stderr_id
-        rdata["error"] = error_id
+        # Now add to the database and set the ids in the dictionary
+        if stdout is not None:
+            _, stdout_add = self.storage.add_kvstore([stdout])
+            rdata["stdout"] = stdout_add[0].id
+        if stderr is not None:
+            _, stderr_add = self.storage.add_kvstore([stderr])
+            rdata["stderr"] = stderr_add[0].id
+        if error is not None:
+            _, error_add = self.storage.add_kvstore([error])
+            rdata["error"] = error_add[0].id
 
     @abc.abstractmethod
     def verify_input(self, data):

--- a/qcfractal/procedures/single.py
+++ b/qcfractal/procedures/single.py
@@ -227,7 +227,6 @@ class SingleResultTasks(BaseTasks):
 
             # Some consistency checks:
             # Is this marked as incomplete?
-            # TODO: Check manager, although that information isn't sent to us right now
             if existing_result["status"] != "INCOMPLETE":
                 self.logger.warning(f"Skipping returned results for base_id={base_id}, as it is not marked incomplete")
                 continue

--- a/qcfractal/storage_sockets/models/sql_models.py
+++ b/qcfractal/storage_sockets/models/sql_models.py
@@ -28,7 +28,7 @@ from sqlalchemy.sql import text
 
 from qcfractal.interface.models.task_models import ManagerStatusEnum, PriorityEnum, TaskStatusEnum
 from qcfractal.interface.models.common_models import CompressionEnum
-from qcfractal.interface.models import KVStore
+from qcfractal.interface.models import KVStore, KeywordSet
 from qcfractal.storage_sockets.models.sql_base import Base, MsgpackExt
 
 
@@ -218,6 +218,13 @@ class KeywordsORM(Base):
 
     __table_args__ = (Index("ix_keywords_hash_index", "hash_index", unique=True),)
     # meta = {'indexes': [{'fields': ('hash_index', ), 'unique': True}]}
+
+    def to_pydantic_model(self):
+        """
+        Converts KeywordsORM to KeywordSet
+        """
+
+        return KeywordSet(**self.to_dict())
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/qcfractal/storage_sockets/sqlalchemy_common.py
+++ b/qcfractal/storage_sockets/sqlalchemy_common.py
@@ -1,0 +1,192 @@
+from .storage_meta import UpsertMetadata, InsertMetadata
+
+from typing import Sequence, Iterable, List, Tuple, Union, TypeVar
+from qcfractal.storage_sockets.models import Base
+
+ORM_T = TypeVar("ORM_T", bound=Base)
+
+
+def _upsert_general(
+    session: "sqlalchemy.orm.session.Session",
+    data: Sequence[ORM_T],
+    search_cols: Iterable[str],
+    update_cols: Iterable[str],
+) -> Tuple[UpsertMetadata, List[Union[ORM_T, None]]]:
+    """
+    Perform a general insert/update, taking into account existing data
+
+    For each ORM object in data, check if the object/row already exists in the database. If it doesn't exist,
+    add it to the database. If the row does exist, the columns listed in update_cols will be updated and committed
+    to the database. The columns passed to search_cols will be used to determine if the data/row already exists.
+
+    If the row does not exist, but the input record has an auto-incremented primary key set, then
+    that is considered an error.
+
+    A list of ORM objects is returned. The order is the same as was given in the data list. These will
+    correspond to rows in the database and will have primary keys, etc, filled in. These may alias variables
+    in the data parameter. If an error occurs for a particular record, that index in the returned data will be None.
+
+    The returned ORM objects are attached to the given session, but the records are committed
+
+    Objects contained in the data parameter may be modified.
+
+
+    Parameters
+    ----------
+    session: sqlalchemy.orm.session.Session
+        An existing SQLAlchemy session to use for adding/updating
+    data: Sequence[ORM_T]
+        List/Sequence of ORM objects to be added to the database. These objects may be modified in-place.
+    search_cols: Iterable[str]
+        What columns to use to determine if data already exists in the database.
+    update_cols: Iterable[str]
+        For existing data, update these columns in the table to values given in the data dictionary
+
+    Returns
+    -------
+    Tuple[UpsertMetadata, List[Union[Base, None]]
+        Metadata showing what was added/updated, and a list of ORM objects. These
+        ORM objects reflect updated or automatically-generated database fields (for example, ids).
+        If an error occurs, the corresponding entry in the list will be None.
+    """
+
+    # These are the records/ORM objects to be returned
+    ret = []
+
+    # Indices of the returned list corresponding to inserted and existing records
+    inserted_idx = []
+    updated_idx = []
+    errors = []
+
+    # This is the type of the ORM. It should be the same for all items in the list
+    orm_type = type(data[0])
+    assert all(type(x) == orm_type for x in data)
+
+    for idx, rec in enumerate(data):
+        # Build up the filter dictionary
+        query = {}
+        for c in search_cols:
+            query[c] = getattr(rec, c)
+
+        # Now, does this record exist?
+        existing = session.query(orm_type).filter_by(**query).all()
+
+        # More than one record is an error
+        if len(existing) > 1:
+            err_msg = f"Cannot upsert with multiple returned records. orm_type = {str(orm_type)}, query = {str(query)}"
+            errors.append((idx, err_msg))
+            ret.append(None)
+        elif len(existing) == 0:
+            # Nothing found. We need to add
+            # If an auto-incremented primary key is set in the input, then that is an error
+            auto_pkey = rec.get_autoincrement_pkey()
+
+            if getattr(rec, auto_pkey) is not None:
+                err_msg = f"Attempting to insert with {auto_pkey} set, but does not exist in the database"
+                errors.append((idx, err_msg))
+                ret.append(None)
+            else:
+                session.add(rec)
+                inserted_idx.append(idx)
+                ret.append(rec)
+        else:
+            # Existing record found
+            updated_idx.append(idx)
+
+            # Do update. These changes are propagated to the database on commit
+            for c in update_cols:
+                new_value = getattr(rec, c)
+                setattr(existing[0], c, new_value)
+
+            ret.append(existing[0])
+
+    session.commit()
+
+    meta = UpsertMetadata(inserted_idx=inserted_idx, updated_idx=updated_idx, errors=errors)
+    return meta, ret
+
+
+def _insert_general(
+    session: "sqlalchemy.orm.session.Session", data: Sequence[ORM_T], search_cols: Iterable[str]
+) -> Tuple[UpsertMetadata, List[Union[ORM_T, None]]]:
+    """
+    Perform a general insert, taking into account existing data
+
+    For each ORM object in data, check if the object/row already exists in the database. If it doesn't exist,
+    add it to the database. If the row does exist, the existing record will be returned.
+    to the database. The columns passed to search_cols will be used to determine if the data/row already exists.
+
+    If the row does not exist, but the input record has an auto-incremented primary key set, then
+    that is considered an error.
+
+    A list of ORM objects is returned. The order is the same as was given in the data list. These will
+    correspond to rows in the database and will have primary keys, etc, filled in. These may alias variables
+    in the data parameter. If an error occurs for a particular record, that index in the returned data will be None.
+
+    The returned ORM objects are attached to the given session, but the records are committed
+
+    Objects contained in the data parameter may be modified.
+
+
+    Parameters
+    ----------
+    session: sqlalchemy.orm.session.Session
+        An existing SQLAlchemy session to use for adding/updating
+    data: Sequence[ORM_T]
+        List/Sequence of ORM objects to be added to the database. These objects may be modified in-place.
+    search_cols: Iterable[str]
+        What columns to use to determine if data already exists in the database.
+
+    Returns
+    -------
+    Tuple[InsertMetadata, List[Union[Base, None]]
+        Metadata showing what was added/updated, and a list of ORM objects. These
+        ORM objects reflect existing or automatically-generated database fields (for example, ids).
+        If an error occurs, the corresponding entry in the list will be None.
+    """
+
+    # These are the records/ORM objects to be returned
+    ret = []
+
+    # Indices of the returned list corresponding to inserted and existing records
+    inserted_idx = []
+    existing_idx = []
+    errors = []
+
+    # This is the type of the ORM. It should be the same for all items in the list
+    orm_type = type(data[0])
+    assert all(type(x) == orm_type for x in data)
+
+    for idx, rec in enumerate(data):
+        # Build up the filter dictionary
+        query = {}
+        for c in search_cols:
+            query[c] = getattr(rec, c)
+
+        # Now, does this record exist?
+        existing = session.query(orm_type).filter_by(**query).all()
+
+        # More than one record is ok (?)
+        if len(existing) == 0:
+            # Nothing found. We need to add
+            # If an auto-incremented primary key is set in the input, then that is an error
+            auto_pkey = rec.get_autoincrement_pkey()
+
+            if getattr(rec, auto_pkey) is not None:
+                err_msg = f"Attempting to insert with {auto_pkey} set, but does not exist in the database"
+                errors.append((idx, err_msg))
+                ret.append(None)
+            else:
+                session.add(rec)
+                inserted_idx.append(idx)
+                ret.append(rec)
+        else:
+            # Existing record found
+            # We may have found more than one, but we will just take the first one
+            existing_idx.append(idx)
+            ret.append(existing[0])
+
+    session.commit()
+
+    meta = InsertMetadata(inserted_idx=inserted_idx, existing_idx=existing_idx, errors=errors)
+    return meta, ret

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -19,7 +19,7 @@ import secrets
 from collections.abc import Iterable
 from contextlib import contextmanager
 from datetime import datetime as dt
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import bcrypt
 
@@ -42,6 +42,7 @@ from qcfractal.interface.models.records import RecordStatusEnum
 
 from qcfractal.storage_sockets.db_queries import QUERY_CLASSES
 from qcfractal.storage_sockets.models import (
+    Base,
     AccessLogORM,
     BaseResultORM,
     CollectionORM,
@@ -65,22 +66,12 @@ from qcfractal.storage_sockets.models import (
 )
 from qcfractal.storage_sockets.storage_utils import add_metadata_template, get_metadata_template
 
-from .models import Base
-
-if TYPE_CHECKING:
-    from ..services.service_util import BaseService
-
 # for version checking
 import qcelemental, qcfractal, qcengine
 
 _null_keys = {"basis", "keywords"}
-_id_keys = {"id", "molecule", "keywords", "procedure_id"}
 _lower_func = lambda x: x.lower()
 _prepare_keys = {"program": _lower_func, "basis": prepare_basis, "method": _lower_func, "procedure": _lower_func}
-
-
-def dict_from_tuple(keys, values):
-    return [dict(zip(keys, row)) for row in values]
 
 
 def format_query(ORMClass, **query: Dict[str, Union[str, List[str]]]) -> Dict[str, Union[str, List[str]]]:

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -8,6 +8,8 @@ try:
     from sqlalchemy.orm import sessionmaker, with_polymorphic
     from sqlalchemy.sql.expression import desc
     from sqlalchemy.sql.expression import case as expression_case
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from sqlalchemy import delete as sql_delete
 except ImportError:
     raise ImportError(
         "SQLAlchemy_socket requires sqlalchemy, please install this python " "module or try a different db_socket."
@@ -521,6 +523,25 @@ class SQLAlchemySocket:
         meta["success"] = True
 
         return {"data": output_ids, "meta": meta}
+
+    def delete_kvstore(self, ids: List[ObjectId]) -> int:
+        """
+        Removes kv_store data on its id.
+
+        Parameters
+        ----------
+        ids : List[ObjectID]
+            ids of the kvstore objects
+
+        Returns
+        -------
+        int
+           number of deleted kvstore objects
+        """
+
+        with self.session_scope() as session:
+            count = session.query(KVStoreORM).filter(KVStoreORM.id.in_(ids)).delete(synchronize_session=False)
+        return count
 
     def get_kvstore(self, id: List[ObjectId] = None, limit: int = None, skip: int = 0):
         """

--- a/qcfractal/storage_sockets/storage_meta.py
+++ b/qcfractal/storage_sockets/storage_meta.py
@@ -1,0 +1,119 @@
+from pydantic.dataclasses import dataclass
+import dataclasses
+from typing import List, Optional, Tuple
+
+
+@dataclass
+class UpsertMetadata:
+    """
+    Metadata returned by upsert_* functions
+    """
+
+    # Integers in errors, inserted, existing are indices in the input/output list
+    error_description: Optional[bool] = None
+    errors: List[Tuple[int, str]] = dataclasses.field(default_factory=list)
+    inserted_idx: List[int] = dataclasses.field(default_factory=list)  # inserted into the db
+    updated_idx: List[int] = dataclasses.field(default_factory=list)  # existing and updated
+
+    @property
+    def n_inserted(self):
+        return len(self.inserted_idx)
+
+    @property
+    def n_updated(self):
+        return len(self.updated_idx)
+
+    @property
+    def error_idx(self):
+        return [x[0] for x in self.errors]
+
+    @property
+    def success(self):
+        return self.error_description is None and len(self.errors) == 0
+
+
+@dataclass
+class InsertMetadata:
+    """
+    Metadata returned by insert_* functions
+    """
+
+    # Integers in errors, inserted, existing are indices in the input/output list
+    error_description: Optional[bool] = None
+    errors: List[Tuple[int, str]] = dataclasses.field(default_factory=list)
+    inserted_idx: List[int] = dataclasses.field(default_factory=list)  # inserted into the db
+    existing_idx: List[int] = dataclasses.field(default_factory=list)  # existing but not updated
+
+    @property
+    def n_inserted(self):
+        return len(self.inserted_idx)
+
+    @property
+    def n_existing(self):
+        return len(self.existing_idx)
+
+    @property
+    def error_idx(self):
+        return [x[0] for x in self.errors]
+
+    @property
+    def success(self):
+        return self.error_description is None and len(self.errors) == 0
+
+
+@dataclass
+class GetMetadata:
+    """
+    Metadata returned by get_* functions
+    """
+
+    # Integers in errors, missing, found are indices in the input/output list
+    error_description: Optional[bool] = None
+    errors: List[Tuple[int, str]] = dataclasses.field(default_factory=list)
+    missing_idx: List[int] = dataclasses.field(default_factory=list)
+    found_idx: List[int] = dataclasses.field(default_factory=list)
+
+    @property
+    def n_found(self):
+        return len(self.found_idx)
+
+    @property
+    def n_missing(self):
+        return len(self.missing_idx)
+
+    @property
+    def error_idx(self):
+        return [x[0] for x in self.errors]
+
+    @property
+    def success(self):
+        return self.error_description is None and len(self.errors) == 0
+
+
+@dataclass
+class DeleteMetadata:
+    """
+    Metadata returned by delete_* functions
+    """
+
+    # Integers in errors, missing, found are indices in the input/output list
+    error_description: Optional[bool] = None
+    errors: List[Tuple[int, str]] = dataclasses.field(default_factory=list)
+    deleted_idx: List[int] = dataclasses.field(default_factory=list)
+    missing_idx: List[int] = dataclasses.field(default_factory=list)
+
+    @property
+    def n_deleted(self):
+        return len(self.deleted_idx)
+
+    @property
+    def n_missing(self):
+        return len(self.missing_idx)
+
+    @property
+    def error_idx(self):
+        return [x[0] for x in self.errors]
+
+    @property
+    def success(self):
+        return self.error_description is None and len(self.errors) == 0

--- a/qcfractal/storage_sockets/storage_utils.py
+++ b/qcfractal/storage_sockets/storage_utils.py
@@ -36,3 +36,18 @@ def add_metadata_template():
 
 def to_pydantic_models(orms: Sequence[Union["Base", None]]) -> List[Union["ProtoModel", None]]:
     return [x.to_pydantic_model() if x is not None else None for x in orms]
+
+
+def find_indices(list1, list2):
+    """
+    For each element in list1, find the index of the element in list2
+
+    If, for a value in list1, there are multiple occurances in list2, that index will be duplicated in the
+    returned list.
+
+    The resulting list will always be sorted
+    """
+    ret = []
+    for idx, v in enumerate(list1):
+        ret.extend(i for i, x in enumerate(list2) if x == v)
+    return sorted(ret)

--- a/qcfractal/storage_sockets/storage_utils.py
+++ b/qcfractal/storage_sockets/storage_utils.py
@@ -3,6 +3,7 @@ Contains a number of utility functions for storage sockets.
 """
 
 import json
+from typing import Union, List, Sequence
 
 # Constants
 _get_metadata = json.dumps({"errors": [], "n_found": 0, "success": False, "missing": [], "error_description": False})
@@ -31,3 +32,7 @@ def add_metadata_template():
     Returns a copy of the metadata for database save/updates.
     """
     return json.loads(_add_metadata)
+
+
+def to_pydantic_models(orms: Sequence[Union["Base", None]]) -> List[Union["ProtoModel", None]]:
+    return [x.to_pydantic_model() if x is not None else None for x in orms]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
There are many functions in the socket that manually perform upserts (update or insert). This pulls that functionality
into a general function, hopefully cleaning up a lot of existing code and making it less error prone.

This will possibly enable a future optimization, where we use postgres upsert functionality (`ON CONFLICT DO ...`), increasing the performance. For now, this function is doing the slower, but more explicit way.

This PR adds two functions: One for upsert, and one for a pure insert that checks for existing records based on search keys.
These new functions are used for `kv_store` (upsert), and the keywords table (insert).

This PR also adds an improved way for returning metadata from the socket. This is implemented via dataclasses rather than dictionaries, and via multiple return. This is done for the kvstore functions. The hope is to move to a more standardized way of reporting this information outside the socket.

Because the add_keywords function is more user-facing, the return is left as is, which a shim converting to the old type of metadata. This has the benefit of not requiring changes anywhere else in the code including tests (for now).

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Start using common upsert/insert functions in the storage socket

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Write upsert function
  - [X] General functionality
  - [x] Proper autoincrement primary key handling (error)
- [x] Code base linted
- [x] Ready to go
