### PR TITLE
Pin gau2grid to 2.0.3

### DIFF
--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -41,6 +41,7 @@ dependencies:
 
 #   Environment specific includes
   - psi4>1.4a2.dev700,<1.4a2
+  - gau2grid=2.0.3
   - rdkit
   - geometric >=0.9.3
   - torsiondrive


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
gau2grid must be pinned to 2.0.3. The psi4 versions we are allowing require this version due to newer versions using an updated soname.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [x] Ready to go
