### PR TITLE
Improves QCPortal's Documentation

### DIFF
--- a/docs/qcportal/source/client-add-query.rst
+++ b/docs/qcportal/source/client-add-query.rst
@@ -5,11 +5,11 @@ Unlike the ``Compute`` object, the ``Molecule``, ``KeywordSet``, ``Collection``,
 objects are always added/queried directly to the server instances as these structures
 are not acted upon by the server itself.
 
-Adding Objects
---------------
+Adding Objects to the Server
+----------------------------
 
 A list of objects can be added to the server via ``client.add_*`` commands
-which returns the :term:`ObjectId` of the object instance.
+which return the :term:`ObjectId` of the object instance.
 
 .. code-block:: python
 
@@ -31,21 +31,21 @@ in the input list.
 
 .. note::
 
-    The :term:`ObjectId` can change between object instances and 
-    is unique to a particular database.
+    The :term:`ObjectId` can change between object instances but 
+    it is unique within a particular database.
 
-Querying Objects
-----------------
+Querying Objects from the Server
+--------------------------------
 
-Each objects has a set of fields that can be queried to obtain the objects in
+Each server object has a set of fields that can be queried to obtain the object instances in
 addition to their :term:`ObjectId`. All queries will return a list of objects.
 
-Molecules
----------
+Interacting with Molecules on the Server
+----------------------------------------
 
-As an example, we can use a molecule that comes with QCPortal and adds it to
-the database as shown. Please note that the Molecule ID (a :term:`ObjectId`)
-shown below will not be the same as your result and is unique to every
+As an example, we can use a molecule that comes with QCPortal and add it to
+the database. Please note that the Molecule ID (a :term:`ObjectId`)
+shown below will not be the same as your result and will be unique for each
 database.
 
 .. code-block:: python

--- a/docs/qcportal/source/client-add-query.rst
+++ b/docs/qcportal/source/client-add-query.rst
@@ -1,15 +1,15 @@
 Add/Query Objects
 =================
 
-``Molecule``, ``KeywordSet``, ``Collection``, and ``KVStore`` objects are
-always added/queried directly to the server unlike compute objects as this
-particular set of structures are not acted upon by the server itself.
+Unlike the ``Compute`` object, the ``Molecule``, ``KeywordSet``, ``Collection``, and ``KVStore``
+objects are always added/queried directly to the server instances as these structures
+are not acted upon by the server itself.
 
 Adding Objects
 --------------
 
-Adding objects to the server uses the ``client.add_*`` commands and takes in a
-list of objects to add and returns the :term:`ObjectId` of the object.
+A list of objects can be added to the server via ``client.add_*`` commands
+which returns the :term:`ObjectId` of the object instance.
 
 .. code-block:: python
 
@@ -17,7 +17,8 @@ list of objects to add and returns the :term:`ObjectId` of the object.
     >>> data = client.add_molecules([helium])
     ['5b882c957b87878925ffaf22']
 
-Adding the same molecule again will not add a new molecule and will always return the same :term:`ObjectId`:
+Any attempt to add the same molecule again will not proceed and the same :term:`ObjectId`
+will always be returned:
 
 .. code-block:: python
 
@@ -25,11 +26,13 @@ Adding the same molecule again will not add a new molecule and will always retur
     >>> data = client.add_molecules([helium, helium])
     ['5b882c957b87878925ffaf22', '5b882c957b87878925ffaf22']
 
-The order of :term:`ObjectId` returned is identical to the order of molecules added.
+Note that the order of :term:`ObjectId`'s are identical to the order of molecules
+in the input list.
 
 .. note::
 
-    The :term:`ObjectId` changes and is unique to a particular database.
+    The :term:`ObjectId` can change between object instances and 
+    is unique to a particular database.
 
 Querying Objects
 ----------------

--- a/docs/qcportal/source/client.rst
+++ b/docs/qcportal/source/client.rst
@@ -2,10 +2,7 @@ Portal Client
 =============
 
 The ``FractalClient`` is the primary entry point to a ``FractalServer`` instance.
-
-We can initialize a ``FractalClient`` by pointing it to a server instance. If
-you would like to start your own server see the setting up a server (NYI)
-section.
+We can initialize a ``FractalClient`` by pointing it to a server instance.
 
 .. code-block:: python
 
@@ -14,18 +11,22 @@ section.
     >>> client
     FractalClient(server='http://localhost:8888/', username='None')
 
-The ``FractalClient`` handles all communication to the ``FractalServer`` from
-the Python API layer. This includes adding new molecules, computations,
-collections, and querying for records. A ``FractalClient`` constructed without
-arguments will automatically connect to the MolSSI QCArchive server.
+The ``FractalClient`` handles all communications between ``FractalServer``
+and the Python API layer. The ``FractalClient`` fascilitates the addition of
+new molecules to the datasets, performing computations, interacting with collections,
+and querying the records. A ``FractalClient`` object instance created by 
+the default constructor (without any arguments) will automatically 
+attempt to connect to the MolSSI QCArchive server.
 
-The ``FractalClient`` can also be initialized from a file which is useful so
-that addresses and username do not have to be retyped for everytime and
-reduces the chance that a username and password could accidentally be added to
-a version control system. Creation from file uses the classmethod
-``FractalClient.from_file()``, by default the client searches for a
-``qcportal_config.yaml`` file in either the current working directory or from
-the canonical ``~/.qca`` folder.
+The ``FractalClient`` can also be initialized using a YAML configuration file. This 
+approach is useful because server address and username do not have to be retyped
+everytime the user initializes a server object. It will also reduces the chance 
+that a username and password could accidentally be added to
+a version control system and be exposed to the public. 
+The above strategy adopts the classmethod ``FractalClient.from_file()`` 
+which by default, searches for the YAML configuration file named
+``qcportal_config.yaml`` under either the current working directory 
+or the canonical ``~/.qca`` folder.
 
 
 

--- a/docs/qcportal/source/client.rst
+++ b/docs/qcportal/source/client.rst
@@ -1,8 +1,8 @@
 Portal Client
 =============
 
-The ``FractalClient`` is the primary entry point to a ``FractalServer`` instance.
-We can initialize a ``FractalClient`` by pointing it to a server instance.
+The ``FractalClient`` is the primary entry point to a ``FractalServer`` instance
+which can be initialized by pointing to a server instance:
 
 .. code-block:: python
 
@@ -20,9 +20,9 @@ attempt to connect to the MolSSI QCArchive server.
 
 The ``FractalClient`` can also be initialized using a YAML configuration file. This 
 approach is useful because server address and username do not have to be retyped
-everytime the user initializes a server object. It will also reduces the chance 
-that a username and password could accidentally be added to
-a version control system and be exposed to the public. 
+everytime the user initializes a server object. It will also reduce the chance 
+for the username and password to be accidentally added to
+a version control system and exposed to the public. 
 The above strategy adopts the classmethod ``FractalClient.from_file()`` 
 which by default, searches for the YAML configuration file named
 ``qcportal_config.yaml`` under either the current working directory 

--- a/docs/qcportal/source/collection-dataset.rst
+++ b/docs/qcportal/source/collection-dataset.rst
@@ -1,5 +1,5 @@
-Dataset
-=======
+Exploring the Dataset
+=====================
 
 The :class:`Dataset <qcportal.collections.Dataset>` collection represents a table whose rows correspond to
 :class:`Molecules <qcportal.models.Molecule>`, and whose columns correspond to properties.
@@ -11,8 +11,8 @@ Existing :class:`Datasets <qcportal.collections.Dataset>` can be listed with
 :meth:`FractalClient.list_collections("Dataset") <qcportal.FractalClient.list_collections>`
 and obtained with :meth:`FractalClient.get_collection("Dataset", name) <qcportal.FractalClient.get_collection>`.
 
-Querying
---------
+Querying the Data
+-----------------
 
 Available result specifications (method, basis set, program, keyword, driver combinations) in a
 :class:`Dataset <qcportal.collections.Dataset>` may be listed with the :meth:`list_values <qcportal.collections.Dataset.list_values>`
@@ -33,8 +33,8 @@ and plotted using the :meth:`visualize <qcportal.collections.Dataset.visualize>`
 For examples of visualizing :class:`Datasets <qcportal.collections.Dataset>`,
 see the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/getting_started.html>`_.
 
-Creating
---------
+Creating the Datasets
+---------------------
 
 Construct an empty :class:`Dataset <qcportal.collections.Dataset>`:
 
@@ -62,8 +62,8 @@ Note that this requires `write permissions <http://docs.qcarchive.molssi.org/pro
 
 .. _dataset-computing:
 
-Computing
----------
+Computational Tasks
+-------------------
 
 Computations on the molecules within the :class:`Datasets <qcportal.collections.Dataset>` can be performed using the
 :meth:`compute <qcportal.collections.Dataset.compute>` command.

--- a/docs/qcportal/source/collection-dataset.rst
+++ b/docs/qcportal/source/collection-dataset.rst
@@ -1,15 +1,15 @@
-Exploring the Dataset
-=====================
+Exploring the Datasets
+======================
 
 The :class:`Dataset <qcportal.collections.Dataset>` collection represents a table whose rows correspond to
-:class:`Molecules <qcportal.models.Molecule>`, and whose columns correspond to properties.
+:class:`Molecules <qcportal.models.Molecule>` and whose columns correspond to properties.
 Columns may either result from QCFractal-based calculations or be contributed from outside sources.
-For example, the QM9 dataset on QCArchive contains small organic molecules with up to 9 heavy atoms, and includes
+For example, the QM9 dataset in QCArchive contains small organic molecules with up to 9 heavy atoms, and includes
 the original reported PBE0 energies, as well as energies calculated with a variety of other density functionals and basis sets.
 
-Existing :class:`Datasets <qcportal.collections.Dataset>` can be listed with
+The existing :class:`Datasets <qcportal.collections.Dataset>` can be listed with
 :meth:`FractalClient.list_collections("Dataset") <qcportal.FractalClient.list_collections>`
-and obtained with :meth:`FractalClient.get_collection("Dataset", name) <qcportal.FractalClient.get_collection>`.
+and obtained using :meth:`FractalClient.get_collection("Dataset", name) <qcportal.FractalClient.get_collection>`.
 
 Querying the Data
 -----------------
@@ -20,14 +20,14 @@ method. Values are queried with the :meth:`get_values <qcportal.collections.Data
 using QCFractal, the underlying :class:`Records <qcportal.models.ResultRecord>`
 are retrieved with :meth:`get_records <qcportal.collections.Dataset.get_records>`.
 
-For examples of querying :class:`Datasets <qcportal.collections.Dataset>`,
+For further details about how to query :class:`Datasets <qcportal.collections.Dataset>`
 see the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/getting_started.html>`_.
 
 Statistics and Visualization
 ----------------------------
 
-Statistics on :class:`Datasets <qcportal.collections.Dataset>` may be computed using the
-:meth:`statistics <qcportal.collections.Dataset.statistics>` command,
+Statistical operations on :class:`Datasets <qcportal.collections.Dataset>` may be performed using
+:meth:`statistics <qcportal.collections.Dataset.statistics>` command
 and plotted using the :meth:`visualize <qcportal.collections.Dataset.visualize>` command.
 
 For examples of visualizing :class:`Datasets <qcportal.collections.Dataset>`,
@@ -52,7 +52,8 @@ The primary index of a :class:`Dataset <qcportal.collections.Dataset>` is a list
 
     >>> ds.add_entry(name, molecule)
 
-Once all :class:`Molecules <qcportal.models.Molecule>` have been added, commit the changes on the server with :meth:`save <qcportal.collections.Dataset.save>`.
+Once all :class:`Molecules <qcportal.models.Molecule>` are added,
+the changes can be committed to the server with :meth:`save <qcportal.collections.Dataset.save>` method.
 Note that this requires `write permissions <http://docs.qcarchive.molssi.org/projects/qcfractal/en/stable/server_user.html#user-permissions>`_.
 
 .. code-block:: python
@@ -87,10 +88,11 @@ they will be reused to avoid recomputation. Note that for perfoming computations
 
 .. note::
 
-    You can set a default program and keyword set for a :class:`Dataset <qcportal.collections.Dataset>`.
-    These defaults will be used in :meth:`compute <qcportal.collections.Dataset.compute>`,
+    A default quantum chemical program and a set of computational 
+    keywords can be specified for a :class:`Dataset <qcportal.collections.Dataset>`.
+    These default values will be used in the :meth:`compute <qcportal.collections.Dataset.compute>`,
     :meth:`get_values <qcportal.collections.Dataset.get_values>`, and
-    :meth:`get_records <qcportal.collections.Dataset.get_records>`.
+    :meth:`get_records <qcportal.collections.Dataset.get_records>` methods.
 
     .. code-block:: python
 

--- a/docs/qcportal/source/collection-dataset.rst
+++ b/docs/qcportal/source/collection-dataset.rst
@@ -40,9 +40,9 @@ Construct an empty :class:`Dataset <qcportal.collections.Dataset>`:
 
 .. code-block:: python
 
-    import qcportal as ptl
-    client = plt.FractalClient()  # add server and login information as needed
-    ds = ptl.collections.Dataset("name", client=client)
+    >>> import qcportal as ptl
+    >>> client = plt.FractalClient()  # add server and login information as needed
+    >>> ds = ptl.collections.Dataset("name", client=client)
 
 The primary index of a :class:`Dataset <qcportal.collections.Dataset>` is a list of :class:`Molecules <qcportal.models.Molecule>`.
 :class:`Molecules <qcportal.models.Molecule>` can be added to a :class:`Dataset <qcportal.collections.Dataset>` with
@@ -50,14 +50,14 @@ The primary index of a :class:`Dataset <qcportal.collections.Dataset>` is a list
 
 .. code-block:: python
 
-    ds.add_entry(name, molecule)
+    >>> ds.add_entry(name, molecule)
 
 Once all :class:`Molecules <qcportal.models.Molecule>` have been added, commit the changes on the server with :meth:`save <qcportal.collections.Dataset.save>`.
 Note that this requires `write permissions <http://docs.qcarchive.molssi.org/projects/qcfractal/en/stable/server_user.html#user-permissions>`_.
 
 .. code-block:: python
 
-   ds.save()
+   >>> ds.save()
 
 
 .. _dataset-computing:
@@ -73,16 +73,16 @@ they will be reused to avoid recomputation. Note that for perfoming computations
 
 .. code-block:: python
 
-    models = {('b3lyp', 'def2-svp'), ('mp2', 'cc-pVDZ')}
+   >>> models = {('b3lyp', 'def2-svp'), ('mp2', 'cc-pVDZ')}
 
-    for method, basis in models:
-        print(method, basis)
-        spec = {"program": "psi4",
-            "method": method,
-            "basis": basis,
-            "keywords": "my_keywords",
-            "tag": "mgwtfm"}
-        ds.compute(**spec)
+   >>> for method, basis in models:
+   >>>     print(method, basis)
+   >>>     spec = {"program": "psi4",
+   >>>         "method": method,
+   >>>         "basis": basis,
+   >>>         "keywords": "my_keywords",
+   >>>         "tag": "mgwtfm"}
+   >>>     ds.compute(**spec)
 
 
 .. note::
@@ -94,15 +94,16 @@ they will be reused to avoid recomputation. Note that for perfoming computations
 
     .. code-block:: python
 
-        ds.set_default_program("psi4")
+        >>> ds.set_default_program("psi4")
 
-        keywords = ptl.models.KeywordSet(values={'maxiter': 1000,
-                                                 'e_convergence': 8,
-                                                 'guess': 'sad',
-                                                 'scf_type': 'df'})
-        ds.add_keywords("my_keywords", "psi4", keywords, default=True)
+        >>> keywords = ptl.models.KeywordSet(values={'maxiter': 1000,
+        >>>                                         'e_convergence': 8,
+        >>>                                         'guess': 'sad',
+        >>>                                         'scf_type': 'df'})
 
-        ds.save()
+        >>> ds.add_keywords("my_keywords", "psi4", keywords, default=True)
+
+        >>> ds.save()
 
 
 API

--- a/docs/qcportal/source/collection-dataset.rst
+++ b/docs/qcportal/source/collection-dataset.rst
@@ -65,11 +65,11 @@ Note that this requires `write permissions <http://docs.qcarchive.molssi.org/pro
 Computing
 ---------
 
-Methods can be computed to the :class:`Dataset <qcportal.collections.Dataset>` and computed using the
+Computations on the molecules within the :class:`Datasets <qcportal.collections.Dataset>` can be performed using the
 :meth:`compute <qcportal.collections.Dataset.compute>` command.
-This command causes a calculation to be requested for every molecule in the :class:`Dataset <qcportal.collections.Dataset>`.
-Any calculations that have previously been done will be automatically added without recomputation.
-Note that this requires `compute permissions <http://docs.qcarchive.molssi.org/projects/qcfractal/en/stable/server_user.html#user-permissions>`_.
+If the results of the requested computation already exist in the :class:`Dataset <qcportal.collections.Dataset>`, 
+they will be reused to avoid recomputation. Note that for perfoming computations,
+`compute permissions <http://docs.qcarchive.molssi.org/projects/qcfractal/en/stable/server_user.html#user-permissions>`_ is required.
 
 .. code-block:: python
 

--- a/docs/qcportal/source/collection-optimization.rst
+++ b/docs/qcportal/source/collection-optimization.rst
@@ -18,81 +18,98 @@ and :meth:`FractalClient.get_collection("OptimizationDataset", name) <qcportal.F
 Querying
 --------
 
-List specifications:
+All available optimization specifications can be listed via 
 
 .. code-block:: python
 
-    ds.list_specifications()
+    >>> ds.list_specifications()
 
-Show status of calculations for a given specification:
-
-.. code-block:: python
-
-    ds.status(["default"])
-
-The number of geometry steps for each molecule can be shown:
+function. In order to show the status of optimization calculations
+for a given set of specifications, one can use:
 
 .. code-block:: python
 
-    ds.counts()
+    >>> ds.status(["default"])
 
-Individual :class:`OptimizationRecords <qcportal.models.OptimizationRecord>` can be extracted:
+For each :class:`Molecule <qcportal.models.Molecule>`, the number of
+steps in a geometry optimization procedure can be queried through calling:
 
 .. code-block:: python
 
-    ds.get_record(name="CCO-0", specification="default")
+    >>> ds.counts()
+
+function. Individual :class:`OptimizationRecords <qcportal.models.OptimizationRecord>`
+can be obtained using:
+
+.. code-block:: python
+
+    >>> ds.get_record(name="CCO-0", specification="default")
 
 
 Visualizing
 -----------
 
-See :class:`qcportal.models.OptimizationRecord.show_history`.
+The trajectory of energy change during the course of geometry optimization
+can be plotted by adopting :class:`qcportal.models.OptimizationRecord.show_history()`
+function.
 
 Creating
 --------
 
-Create a new collection:
+A new collection object for :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>`
+can be created using
 
 .. code-block:: python
 
-    ds = ptl.collections.OptimizationDataset(name = "QM8-T", client=client)
+    >>> ds = ptl.collections.OptimizationDataset(name = "QM8-T", client=client)
 
 Provide a specification:
 
 .. code-block:: python
 
-    spec = {'name': 'default',
-            'description': 'Geometric + Psi4/B3LYP-D3/Def2-SVP.',
-            'optimization_spec': {'program': 'geometric', 'keywords': None},
-            'qc_spec': {'driver': 'gradient',
-            'method': 'b3lyp-d3',
-            'basis': 'def2-svp',
-            'keywords': None,
-            'program': 'psi4'}}
-     ds.add_specification(**spec)
-     ds.save()
+    >>> spec = {'name': 'default',
+    >>>         'description': 'Geometric + Psi4/B3LYP-D3/Def2-SVP.',
+    >>>         'optimization_spec': {'program': 'geometric', 'keywords': None},
+    >>>         'qc_spec': {'driver': 'gradient',
+    >>>         'method': 'b3lyp-d3',
+    >>>         'basis': 'def2-svp',
+    >>>         'keywords': None,
+    >>>         'program': 'psi4'}}
 
-Add molecules to optimize:
+    >>>  ds.add_specification(**spec)
+
+    >>>  ds.save()
+
+:class:`Molecules <qcportal.models.Molecule>` can be added to the
+:class:`OptimizationDataset <qcportal.collections.OptimizationDataset>`
+as new entries for optimization via:
 
 .. code-block:: python
 
      ds.add_entry(name, molecule)
 
-If adding molecules in batches, you may wish to defer saving the dataset to the server until all molecules are added:
+When adding multiple entries of molecules, saving the dataset 
+onto the server should be postponed until after all molecules are added:
 
 .. code-block:: python
 
-    for name, molecule in new_entries:
-        ds.add_entry(name, molecule, save=False)
-    ds.save()
+    >>> for name, molecule in new_entries:
+    >>>     ds.add_entry(name, molecule, save=False)
+
+    >>> ds.save()
 
 Computing
 ---------
 
+In order to run a geometry optimization calculation based on
+a particular set of parameter specification (default set in this case),
+one can adopt the
+
 .. code-block:: python
 
-    ds.compute(specification="default", tag="optional_tag")
+    >>> ds.compute(specification="default", tag="optional_tag")
 
+function from :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` class.
 
 API
 ---

--- a/docs/qcportal/source/collection-optimization.rst
+++ b/docs/qcportal/source/collection-optimization.rst
@@ -1,14 +1,19 @@
 Optimization Dataset
 ====================
-The :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` collection represents geometry optimizations
-performed on a series of :class:`Molecules <qcportal.models.Molecule>`.
-:class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` use specifications to manage parameters of the
-:class:`geometry optimizer <qcportal.models.OptimizationSpecification>` and underlying
-:class:`gradient calculation <qcportal.models.QCSpecification>`.
+The :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` collection 
+represents the results of geometry optimizations calculations performed on 
+a series of :class:`Molecules <qcportal.models.Molecule>`. The
+:class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` 
+uses metadata specifications via 
+:class:`Optimization Specification <qcportal.models.OptimizationSpecification>` and 
+:class:`QCSpecification <qcportal.models.QCSpecification>` classes to manage 
+parameters of the geometry optimizer and the underlying gradient 
+calculation, respectively.
 
-Existing :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` can be listed with
+The existing :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` 
+collections can be listed or selectively returned through
 :meth:`FractalClient.list_collections("OptimizationDataset") <qcportal.FractalClient.list_collections>`
-and obtained with :meth:`FractalClient.get_collection("OptimizationDataset", name) <qcportal.FractalClient.get_collection>`.
+and :meth:`FractalClient.get_collection("OptimizationDataset", name) <qcportal.FractalClient.get_collection>`, respectively.
 
 Querying
 --------

--- a/docs/qcportal/source/collection-optimization.rst
+++ b/docs/qcportal/source/collection-optimization.rst
@@ -15,8 +15,8 @@ collections can be listed or selectively returned through
 :meth:`FractalClient.list_collections("OptimizationDataset") <qcportal.FractalClient.list_collections>`
 and :meth:`FractalClient.get_collection("OptimizationDataset", name) <qcportal.FractalClient.get_collection>`, respectively.
 
-Querying
---------
+Querying the Data
+-----------------
 
 All available optimization specifications can be listed via 
 
@@ -46,15 +46,15 @@ can be obtained using:
     >>> ds.get_record(name="CCO-0", specification="default")
 
 
-Visualizing
------------
+Statistics and Visualization
+----------------------------
 
 The trajectory of energy change during the course of geometry optimization
 can be plotted by adopting :class:`qcportal.models.OptimizationRecord.show_history()`
 function.
 
-Creating
---------
+Creating the Datasets
+---------------------
 
 A new collection object for :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>`
 can be created using
@@ -98,8 +98,8 @@ onto the server should be postponed until after all molecules are added:
 
     >>> ds.save()
 
-Computing
----------
+Computational Tasks
+-------------------
 
 In order to run a geometry optimization calculation based on
 a particular set of parameter specification (default set in this case),

--- a/docs/qcportal/source/collection-optimization.rst
+++ b/docs/qcportal/source/collection-optimization.rst
@@ -1,7 +1,7 @@
 Optimization Dataset
 ====================
 The :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` collection 
-represents the results of geometry optimizations calculations performed on 
+represents the results of geometry optimization calculations performed on 
 a series of :class:`Molecules <qcportal.models.Molecule>`. The
 :class:`OptimizationDataset <qcportal.collections.OptimizationDataset>` 
 uses metadata specifications via 
@@ -18,13 +18,13 @@ and :meth:`FractalClient.get_collection("OptimizationDataset", name) <qcportal.F
 Querying the Data
 -----------------
 
-All available optimization specifications can be listed via 
+All available optimization data specifications can be listed via 
 
 .. code-block:: python
 
     >>> ds.list_specifications()
 
-function. In order to show the status of optimization calculations
+function. In order to show the status of the optimization calculations
 for a given set of specifications, one can use:
 
 .. code-block:: python
@@ -63,7 +63,8 @@ can be created using
 
     >>> ds = ptl.collections.OptimizationDataset(name = "QM8-T", client=client)
 
-Provide a specification:
+Specific set of parameters for geometry optimization can be defined and 
+added to the dataset as follows:
 
 .. code-block:: python
 
@@ -102,7 +103,7 @@ Computational Tasks
 -------------------
 
 In order to run a geometry optimization calculation based on
-a particular set of parameter specification (default set in this case),
+a particular set of parameters (the default set in this case),
 one can adopt the
 
 .. code-block:: python

--- a/docs/qcportal/source/collection-reactiondataset.rst
+++ b/docs/qcportal/source/collection-reactiondataset.rst
@@ -1,7 +1,7 @@
 Reaction Dataset
 ================
 
-:class:`ReactionDatasets <qcportal.collections.ReactionDataset>` are useful for computing many methods for a set of reactions.
+:class:`ReactionDatasets <qcportal.collections.ReactionDataset>` are useful for chemical reaction-based computations.
 There are currently two types of :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`:
 
 - ``rxn`` for datasets based on canonical chemical reactions :math:`A + B \rightarrow C`
@@ -10,19 +10,18 @@ There are currently two types of :class:`ReactionDatasets <qcportal.collections.
 Querying
 --------
 
-Available result specifications (method, basis set, program, keyword, driver combinations) in a
-:class:`ReactionDataset <qcportal.collections.ReactionDataset>` may be listed with
+The result specifications in a :class:`ReactionDataset <qcportal.collections.ReactionDataset>`
+such as *method*, *basis set*, *program*, *keyword*, and *driver* may be listed with
 :meth:`list_values <qcportal.collections.ReactionDataset.list_values>`.
-Beyond those specifications in :class:`Datasets <qcportal.collections.Dataset>`,
-:class:`ReactionDatasets <qcportal.collections.ReactionDataset>` provide a `stoich` field which may be used to
-select different strategies for computation of interaction and reaction energies. By default, the counterpoise-corrected
-(``"cp"``) and uncorrected (``"default"``) values are available.
+In addition to the aforementioned specifications, :class:`ReactionDataset <qcportal.collections.ReactionDataset>` provides
+a ``stoich`` field to select different strategies, including counterpoise-corrected (``"cp"``) and uncorrected (``"default"``),
+for the calculation of interaction and reaction energies.
 
-Reaction values, such as interaction or reaction energies,
-are queried with :meth:`get_values <qcportal.collections.ReactionDataset.get_values>`.
-For results computed using QCFractal, the underlying :class:`Records <qcportal.models.ResultRecord>`
-are retrieved with :meth:`get_records <qcportal.collections.ReactionDataset.get_records>`, and are broken down by
-:class:`Molecule <qcportal.models.Molecule>` within the reaction.
+The computed values of the reaction properties such as interaction or reaction energies
+can be queried using :meth:`get_values <qcportal.collections.ReactionDataset.get_values>`.
+For results calculated with QCFractal, the underlying :class:`Records <qcportal.models.ResultRecord>`
+can be retrieved with :meth:`get_records <qcportal.collections.ReactionDataset.get_records>` and further broken down by
+:class:`Molecule <qcportal.models.Molecule>` within each reaction.
 
 For examples of querying :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`,
 see the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/reaction_datasets.html>`_.
@@ -30,51 +29,55 @@ see the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest
 Visualizing
 -----------
 
-Statistics on :class:`ReactionDatasets <qcportal.collections.ReactionDataset>` may be computed using the
-:meth:`statistics <qcportal.collections.ReactionDataset.statistics>` command,
-and plotted using the :meth:`visualize <qcportal.collections.ReactionDataset.visualize>` command.
-
-For examples of visualizing :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`,
-see the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/reaction_datasets.html>`_.
+Statistical analysis on the :class:`ReactionDatasets <qcportal.collections.ReactionDataset>` 
+can be performed via :meth:`statistics <qcportal.collections.ReactionDataset.statistics>` command
+which can be complemented by the :meth:`visualize <qcportal.collections.ReactionDataset.visualize>` 
+command in order to plot the data. For examples pertinent to data visualization 
+in :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`, see 
+the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/reaction_datasets.html>`_.
 
 
 Creating
 --------
 
-An empty dataset can be constructed by choosing a dataset name and a dataset type (``dtype``).
+The :class:`Dataset <qcportal.collections.Dataset>` constructor can be adopted to create an empty dataset
+object using a dataset name and type (``dtype``) as arguments.
 
 .. code-block:: python
 
-    ds = ptl.collections.Dataset("my_dataset", dtype="rxn")
+    >>> ds = ptl.collections.Dataset("my_dataset", dtype="rxn")
 
-New reactions can be added by providing the linear combination of :class:`Molecules <qcportal.models.Molecule>`
-required to compute the desired quantity. When the :class:`ReactionDataset <qcportal.collections.ReactionDataset>` is queried these
-linear combinations are automatically combined for the caller.
-
-.. code-block:: python
-
-    ds = ptl.collections.Dataset("Atomization Energies", dtype="ie")
-
-    N2 = ptl.Molecule.from_data("""
-    N 0.0 0.0 1.0975
-    N 0.0 0.0 0.0
-    unit angstrom
-    """)
-
-    N_atom = ptl.Molecule.from_data("""
-    0 2
-    N 0.0 0.0 0.0
-    """)
-
-
-    ds.add_rxn("Nitrogen Molecule", [(N2, 1.0), (N_atom, -2.0)])
-
-A given reaction can be examined by using the :meth:`get_rxn <qcportal.collections.ReactionDataset.get_rxn>` function.
-We store the ``molecule_hash`` followed by the reaction coefficient.
+New reactions can be added to the :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`
+by providing a linear combination of :class:`Molecules <qcportal.models.Molecule>`
+in order to compute the desired quantity. When the :class:`ReactionDataset <qcportal.collections.ReactionDataset>`
+is queried, these linear combinations from chemical equations are automatically combined and presented to the caller.
 
 .. code-block:: python
 
-    json.dumps(ds.get_rxn("Nitrogen Molecule"), indent=2)
+    >>> ds = ptl.collections.Dataset("Atomization Energies", dtype="ie")
+
+    >>> N2 = ptl.Molecule.from_data("""
+    >>> N 0.0 0.0 1.0975
+    >>> N 0.0 0.0 0.0
+    >>> unit angstrom
+    >>> """)
+
+    >>> N_atom = ptl.Molecule.from_data("""
+    >>> 0 2
+    >>> N 0.0 0.0 0.0
+    >>> """)
+
+
+    >>> ds.add_rxn("Nitrogen Molecule", [(N2, 1.0), (N_atom, -2.0)])
+
+The details of a given chemical reaction can be obtained through using
+:meth:`get_rxn() <qcportal.collections.ReactionDataset.get_rxn>` function.
+The storage of ``molecule_hash`` in the :class:`ReactionDataset <qcportal.collections.ReactionDataset>`
+is followed by that of the reaction coefficients.
+
+.. code-block:: python
+
+    >>> json.dumps(ds.get_rxn("Nitrogen Molecule"), indent=2)
     {
       "name": "Nitrogen Molecule",
       "stoichiometry": {
@@ -90,20 +93,21 @@ We store the ``molecule_hash`` followed by the reaction coefficient.
     }
 
 
-Datasets of dtype ``ie`` can automatically construct counterpoise-correct
-(``cp``) and non-counterpoise-correct (``default``) n-body expansions. The
-the number after the stoichiometry corresponds to the number of bodies involved in the
-computation.
+Datasets of dtype ``ie`` can automatically construct counterpoise-corrected
+(``cp``) or non-counterpoise-corrected (``default``) n-body expansions. The
+the *key:value* pairs of numbers after the stoichiometry entry correspond to the
+index of each atomic/molecular species and their corresponding number of moles
+(or chemical equivalents) involved in the chemical reaction, respectively.
 
 .. code-block:: python
 
-    ie_ds = ptl.collections.ReactionDataset("my_dataset", dtype="rxn")
+    >>> ie_ds = ptl.collections.ReactionDataset("my_dataset", dtype="rxn")
 
-    water_dimer_stretch = ptl.data.get_molecule("water_dimer_minima.psimol")
-    ie_ds.add_ie_rxn("water dimer minima", water_dimer_stretch)
+    >>> water_dimer_stretch = ptl.data.get_molecule("water_dimer_minima.psimol")
 
-    json.dumps(ie_ds.get_rxn("water dimer minima"), indent=2)
+    >>> ie_ds.add_ie_rxn("water dimer minima", water_dimer_stretch)
 
+    >>> json.dumps(ie_ds.get_rxn("water dimer minima"), indent=2)
     {
       "name": "water dimer minima",
       "stoichiometry": {
@@ -132,8 +136,9 @@ computation.
 Computing
 ---------
 
-Computations are performed in the same manner as for a :class:`Dataset <qcportal.collections.Dataset>`.
-See the :ref:`Dataset Documentation <dataset-computing>` for more information.
+Computations on the :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`
+are performed in the same manner as mentioned in :ref:`Dataset Documentation <dataset-computing>`
+section.
 
 API
 ---

--- a/docs/qcportal/source/collection-reactiondataset.rst
+++ b/docs/qcportal/source/collection-reactiondataset.rst
@@ -7,8 +7,8 @@ There are currently two types of :class:`ReactionDatasets <qcportal.collections.
 - ``rxn`` for datasets based on canonical chemical reactions :math:`A + B \rightarrow C`
 - ``ie`` for interaction energy datasets :math:`M_{complex} \rightarrow M_{monomer_1} + M_{monomer_2}`
 
-Querying
---------
+Querying the Data
+-----------------
 
 The result specifications in a :class:`ReactionDataset <qcportal.collections.ReactionDataset>`
 such as *method*, *basis set*, *program*, *keyword*, and *driver* may be listed with
@@ -26,8 +26,8 @@ can be retrieved with :meth:`get_records <qcportal.collections.ReactionDataset.g
 For examples of querying :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`,
 see the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/reaction_datasets.html>`_.
 
-Visualizing
------------
+Statistics and Visualization
+----------------------------
 
 Statistical analysis on the :class:`ReactionDatasets <qcportal.collections.ReactionDataset>` 
 can be performed via :meth:`statistics <qcportal.collections.ReactionDataset.statistics>` command
@@ -37,8 +37,8 @@ in :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`, see
 the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/reaction_datasets.html>`_.
 
 
-Creating
---------
+Creating the Datasets
+---------------------
 
 The :class:`Dataset <qcportal.collections.Dataset>` constructor can be adopted to create an empty dataset
 object using a dataset name and type (``dtype``) as arguments.
@@ -133,8 +133,8 @@ index of each atomic/molecular species and their corresponding number of moles
     }
 
 
-Computing
----------
+Computational Tasks
+-------------------
 
 Computations on the :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`
 are performed in the same manner as mentioned in :ref:`Dataset Documentation <dataset-computing>`

--- a/docs/qcportal/source/collection-reactiondataset.rst
+++ b/docs/qcportal/source/collection-reactiondataset.rst
@@ -2,10 +2,10 @@ Reaction Dataset
 ================
 
 :class:`ReactionDatasets <qcportal.collections.ReactionDataset>` are useful for chemical reaction-based computations.
-There are currently two types of :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`:
+Currently, there are two types of :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`:
 
-- ``rxn`` for datasets based on canonical chemical reactions :math:`A + B \rightarrow C`
-- ``ie`` for interaction energy datasets :math:`M_{complex} \rightarrow M_{monomer_1} + M_{monomer_2}`
+- canonical chemical reaction datasets, ``rxn``: :math:`A + B \rightarrow C`,
+- interaction energy datasets, ``ie``: :math:`M_{complex} \rightarrow M_{monomer_1} + M_{monomer_2}`.
 
 Querying the Data
 -----------------
@@ -33,9 +33,8 @@ Statistical analysis on the :class:`ReactionDatasets <qcportal.collections.React
 can be performed via :meth:`statistics <qcportal.collections.ReactionDataset.statistics>` command
 which can be complemented by the :meth:`visualize <qcportal.collections.ReactionDataset.visualize>` 
 command in order to plot the data. For examples pertinent to data visualization 
-in :class:`ReactionDatasets <qcportal.collections.ReactionDataset>`, see 
+in :class:`ReactionDatasets <qcportal.collections.ReactionDataset>` see 
 the `QCArchive examples <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/reaction_datasets.html>`_.
-
 
 Creating the Datasets
 ---------------------

--- a/docs/qcportal/source/collection-tasks.rst
+++ b/docs/qcportal/source/collection-tasks.rst
@@ -4,67 +4,71 @@ Common Tasks
 Check computation progress
 ++++++++++++++++++++++++++
 
-The :meth:`FractalClient.query_tasks <qcportal.FractalClient.query_tasks>` method returns information on active tasks.
+The :meth:`FractalClient.query_tasks() <qcportal.FractalClient.query_tasks>` 
+method returns information on active tasks.
 
 .. code-block:: python
 
-    client = qcportal.FractalClient(...)
-    client.query_tasks(status='WAITING')  # return tasks in queue
-    client.query_tasks(status='RUNNING')  # return running tasks
+    >>> client = qcportal.FractalClient(...)
+    >>> client.query_tasks(status='WAITING')  # return tasks in queue
+    >>> client.query_tasks(status='RUNNING')  # return running tasks
 
-The ``tag`` and ``manager`` fields may be used to find only your tasks.
+The ``tag`` and ``manager`` fields can be used to find user-defined tasks.
 
 
-Find Errors and Restart Jobs
-****************************
+Finding Errors and Restarting Jobs
+**********************************
 
-Some jobs may fail, and will end up in the ``ERROR`` state.
-
-.. code-block:: python
-
-    myerrs = client.query_tasks(status='ERROR')  # return errored tasks
-
-Errored jobs may be inspected:
+During each task's lifetime, errors might occur and the jobs
+end up in the ``ERROR`` state.
 
 .. code-block:: python
 
-    record = client.query_results(mye[0].base_result.id)[0]
-    print(record.stdout)  # Standard output
-    print(record.stderr)  # Standard error
-    print(client.query_kvstore(record.error)[0])  # Error message
+    >>> myerrs = client.query_tasks(status='ERROR')  # return errored tasks
 
-and restarted:
+Failed jobs may be inspected as follows:
 
 .. code-block:: python
 
-    res = client.modify_tasks("restart", [e.base_result.id for e in myerrs])
-    print(res.n_updated)
+    >>> record = client.query_results(mye[0].base_result.id)[0]
+    >>> print(record.stdout)  # Standard output
+    >>> print(record.stderr)  # Standard error
+    >>> print(client.query_kvstore(record.error)[0])  # Error message
+
+One can restart the failed tasks via the following steps:
+
+.. code-block:: python
+
+    >>> res = client.modify_tasks("restart", [e.base_result.id for e in myerrs])
+    >>> print(res.n_updated)
 
 Delete a column
 +++++++++++++++
 
-You may wish to remove a model from a :class:`Dataset <qcportal.collections.Dataset>`
-or :class:`ReactionDataset <qcportal.collections.ReactionDataset>`.
-Models are stored in ``Dataset.data.history``, and can be removed from there:
+Models are stored in ``Dataset.data.history``,
 
 .. code-block:: python
 
-    print(ds.data.history)
-    # Output e.g.
-    # {('energy', 'psi4', 'b3lyp', 'def2-svp', 'scf_default'),
-    # ('energy', 'psi4', 'hf', 'sto-3g', 'scf_default'),
-    # ('energy', 'psi4', 'lda', 'sto-3g', 'scf_default')}
+    >>> print(ds.data.history)
+        # Example output
+        # {('energy', 'psi4', 'b3lyp', 'def2-svp', 'scf_default'),
+        # ('energy', 'psi4', 'hf', 'sto-3g', 'scf_default'),
+        # ('energy', 'psi4', 'lda', 'sto-3g', 'scf_default')}
 
-    ds.data.history.remove(('energy', 'psi4', 'lda', 'sto-3g', 'scf_default'))
-    ds.save()
+and can be removed from a
+:class:`Dataset <qcportal.collections.Dataset>` or
+:class:`ReactionDataset <qcportal.collections.ReactionDataset>` via:
 
-    ds = client.get_collection(...)
-    print(ds.data.history)
-    # Output e.g.
-    # {('energy', 'psi4', 'b3lyp', 'def2-svp', 'scf_default'),
-    # ('energy', 'psi4', 'hf', 'sto-3g', 'scf_default')}
+.. code-block:: python
 
-See also
-++++++++
+    >>> ds.data.history.remove(('energy', 'psi4', 'lda', 'sto-3g', 'scf_default'))
+    >>> ds.save()
 
-Many examples of interacting with collections hosted on QCArchive are provided on the `QCArchive Examples <https://qcarchive.molssi.org/examples/>`_ page.
+    >>> ds = client.get_collection(...)
+    >>> print(ds.data.history)
+        # Example output
+        # {('energy', 'psi4', 'b3lyp', 'def2-svp', 'scf_default'),
+        # ('energy', 'psi4', 'hf', 'sto-3g', 'scf_default')}
+
+For further examples on how to interact with collections hosted on 
+QCArchive see the `QCArchive examples <https://qcarchive.molssi.org/examples/>`_.

--- a/docs/qcportal/source/collection-tasks.rst
+++ b/docs/qcportal/source/collection-tasks.rst
@@ -20,7 +20,7 @@ Finding Errors and Restarting Jobs
 **********************************
 
 During each task's lifetime, errors might occur and the jobs
-end up in the ``ERROR`` state.
+may end up in the ``ERROR`` state.
 
 .. code-block:: python
 
@@ -70,5 +70,5 @@ and can be removed from a
         # {('energy', 'psi4', 'b3lyp', 'def2-svp', 'scf_default'),
         # ('energy', 'psi4', 'hf', 'sto-3g', 'scf_default')}
 
-For further examples on how to interact with collections hosted on 
+For further examples on how to interact with dataset collections hosted on 
 QCArchive see the `QCArchive examples <https://qcarchive.molssi.org/examples/>`_.

--- a/docs/qcportal/source/collection-torsiondrive.rst
+++ b/docs/qcportal/source/collection-torsiondrive.rst
@@ -4,12 +4,12 @@ TorsionDrive Dataset
 host the results of TorsionDrive computations. Each row of the
 :class:`TorsionDriveDataset <qcfractal.interface.collections.TorsionDriveDataset>` 
 is comprised of an ``Entry`` which contains a list of starting molecules for the
-``TorsionDrive``, a specific set of dihedral angles (in this case zero-indexed),
-and the angular scan resolution. Each column represents a particular detail 
+``TorsionDrive``, a specific set of dihedral angles (zero-indexed),
+and the angular scan resolution. Each column represents a particular property detail 
 pertinent to the corresponding ``TorsionDrive`` ``Entry``.
 The :class:`TorsionDriveDataset <qcfractal.interface.collections.TorsionDriveDataset>` 
 is a procedure-style dataset within which, the :term:`ObjectId` for
-each TorsionDrive computation is recorded as metadata.
+each ``TorsionDrive`` computation is recorded as metadata.
 
 For additional details about :class:`TorsionDriveDatasets <qcfractal.interface.collections.TorsionDriveDataset>`
 see `here <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/torsiondrive_datasets.html>`_.

--- a/docs/qcportal/source/collection-torsiondrive.rst
+++ b/docs/qcportal/source/collection-torsiondrive.rst
@@ -14,14 +14,14 @@ each TorsionDrive computation is recorded as metadata.
 For additional details about :class:`TorsionDriveDatasets <qcfractal.interface.collections.TorsionDriveDataset>`
 see `here <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/torsiondrive_datasets.html>`_.
 
-Querying
---------
+Querying the Data
+-----------------
 
-Visualizing
------------
+Statistics and Visualization
+----------------------------
 
-Creating
---------
+Creating the Datasets
+---------------------
 
 A empty instance of the :class:`TorsionDriveDataset <qcfractal.interface.collections.TorsionDriveDataset>` 
 object (here, named ``My Torsions``) can be constructed as
@@ -32,8 +32,8 @@ object (here, named ``My Torsions``) can be constructed as
     >>> ds = ptl.collections.TorsionDriveDataset("My Torsions")
 
 
-Computing
----------
+Computational Tasks
+-------------------
 
 API
 ---

--- a/docs/qcportal/source/collection-torsiondrive.rst
+++ b/docs/qcportal/source/collection-torsiondrive.rst
@@ -1,13 +1,18 @@
 TorsionDrive Dataset
 ====================
+:class:`TorsionDriveDatasets <qcfractal.interface.collections.TorsionDriveDataset>`
+host the results of TorsionDrive computations. Each row of the
+:class:`TorsionDriveDataset <qcfractal.interface.collections.TorsionDriveDataset>` 
+is comprised of an ``Entry`` which contains a list of starting molecules for the
+``TorsionDrive``, a specific set of dihedral angles (in this case zero-indexed),
+and the angular scan resolution. Each column represents a particular detail 
+pertinent to the corresponding ``TorsionDrive`` ``Entry``.
+The :class:`TorsionDriveDataset <qcfractal.interface.collections.TorsionDriveDataset>` 
+is a procedure-style dataset within which, the :term:`ObjectId` for
+each TorsionDrive computation is recorded as metadata.
 
-See also the `QCArchive example <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/torsiondrive_datasets.html>`_ for TorsionDrive datasets.
-
-TorsionDriveDatasets are sets of TorsionDrive computations where the primary
-index a set of starting molecules and each column is represented by a new
-TorsionDrive specification. This Dataset is a procedure-style dataset where a
-record of the :term:`ObjectId` of each TorsionDrive computation are recorded
-in the metadata.
+For additional details about :class:`TorsionDriveDatasets <qcfractal.interface.collections.TorsionDriveDataset>`
+see `here <https://qcarchivetutorials.readthedocs.io/en/latest/basic_examples/torsiondrive_datasets.html>`_.
 
 Querying
 --------
@@ -18,12 +23,13 @@ Visualizing
 Creating
 --------
 
-A empty TorsionDriveDataset can be constructed by choosing a dataset name.
+A empty instance of the :class:`TorsionDriveDataset <qcfractal.interface.collections.TorsionDriveDataset>` 
+object (here, named ``My Torsions``) can be constructed as
 
 .. code-block:: python
 
-    client = ptl.FractalClient("localhost:7777")
-    ds = ptl.collections.TorsionDriveDataset("My Torsions")
+    >>> client = ptl.FractalClient("localhost:7777")
+    >>> ds = ptl.collections.TorsionDriveDataset("My Torsions")
 
 
 Computing

--- a/docs/qcportal/source/collections.rst
+++ b/docs/qcportal/source/collections.rst
@@ -1,14 +1,14 @@
 Overview
 ========
 
-Collections are an organizational objects that keep track of collections of
-results, compute new results, and provide helper functions for analysis and visualization.
+Collections are organizational objects that keep track of or compute new results, 
+and provide helper functions for analysis and visualization.
 
 
 Collections querying
 ---------------------
 
-Once a :class:`FractalClient <qcportal.FractalClient>` has been created, the client can query a list of all
+Once a :class:`FractalClient <qcportal.FractalClient>` has been created, it can query a list of all
 collections currently held on the server.
 
 .. code-block:: python

--- a/docs/qcportal/source/collections.rst
+++ b/docs/qcportal/source/collections.rst
@@ -29,8 +29,8 @@ Available collections
 Below is a complete list of collection types available from QCPortal.
 All collections support the possibility of computing with and comparing multiple methods.
 
-* :doc:`collection-dataset` - A collection for a set of molecules and their computed properties.
-* :doc:`collection-reactiondataset` - A collection for chemical reactions and intermolecular interactions.
-* :doc:`collection-optimization` - A collection for geometry optimization of a set of molecules.
-* :doc:`collection-torsiondrive` - A collection for the TorsionDrive pipeline.
+* :doc:`collection-dataset` - A collection of molecular sets and their computed properties.
+* :doc:`collection-reactiondataset` - A collection of chemical reactions and intermolecular interactions.
+* :doc:`collection-optimization` - A collection of geometry optimization results for molecular sets.
+* :doc:`collection-torsiondrive` - A collection of TorsionDrive pipeline data.
 

--- a/docs/qcportal/source/install.rst
+++ b/docs/qcportal/source/install.rst
@@ -10,7 +10,7 @@ You can install qcportal using `conda <https://www.anaconda.com/download/>`_:
 
 .. code-block:: console
 
-    >>> conda install qcportal -c conda-forge
+   >>> conda install qcportal -c conda-forge
 
 This installs QCPortal and its dependencies. The qcportal package is maintained on the
 `conda-forge channel <https://conda-forge.github.io/>`_.
@@ -53,6 +53,6 @@ Then, run the following command:
 Developing from Source
 ----------------------
 
-The QCPortal package is part of the QCFractal package and is the ``qcfractal.interface`` folder. If you are a developer
-and want to make contributions Portal, you can access the source code from
-`github <https://github.com/molssi/qcfractal>`_ and the aforementioned folder.
+The QCPortal package is part of the QCFractal package residing in ``qcfractal.interface`` folder. 
+If you are a developer and want to make contributions to QCPortal, you can access the source code
+`here <https://github.com/MolSSI/QCFractal/tree/master/qcfractal/interface>`_.

--- a/docs/qcportal/source/install.rst
+++ b/docs/qcportal/source/install.rst
@@ -1,49 +1,51 @@
 Install QCPortal
 =================
 
-You can install ``qcportal`` with ``conda`` or with ``pip``.
+QCPortal can be installed using ``conda`` or ``pip``.
 
 Conda
 -----
 
-You can install qcportal using `conda <https://www.anaconda.com/download/>`_:
+The following command installs QCPortal and its dependencies 
+using `conda <https://www.anaconda.com/download/>`_:
 
 .. code-block:: console
 
    >>> conda install qcportal -c conda-forge
 
-This installs QCPortal and its dependencies. The qcportal package is maintained on the
+The QCPortal package is maintained on the 
 `conda-forge channel <https://conda-forge.github.io/>`_.
-
 
 Pip
 ---
 
-you can also install QCPortal using ``pip``:
+QCPortal can also be installed using ``pip``:
 
 .. code-block:: console
 
    >>> pip install qcportal
 
 
-Test the Installation
----------------------
+Testing the Installation
+------------------------
 
-You can test to make sure that QCPortal is installed correctly by first installing ``pytest``.
-
-From ``conda``:
+The installation process for QCPortal can be verified
+using ``pytest`` through running the tests.
+The ``pytest`` package can be installed using ``conda``:
 
 .. code-block:: console
 
    >>> conda install pytest -c conda-forge
 
-From ``pip``:
+or ``pip``:
 
 .. code-block:: console
 
    >>> pip install pytest
 
-Then, run the following command:
+After installing ``pytest``, the following command 
+collects the tests and runs them individually in order to 
+verify the installation:
 
 .. code-block::
 
@@ -53,6 +55,6 @@ Then, run the following command:
 Developing from Source
 ----------------------
 
-The QCPortal package is part of the QCFractal package residing in ``qcfractal.interface`` folder. 
-If you are a developer and want to make contributions to QCPortal, you can access the source code
+The QCPortal is a part of the QCFractal package and resides in the ``qcfractal.interface`` folder.
+Developers can make contributions to QCPortal by accessing the source code
 `here <https://github.com/MolSSI/QCFractal/tree/master/qcfractal/interface>`_.

--- a/docs/qcportal/source/record-optimization.rst
+++ b/docs/qcportal/source/record-optimization.rst
@@ -1,7 +1,7 @@
 Optimization
 ============
 
-The record of a geometry optimization.
+The ``record`` of a geometry optimization.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/qcportal/source/record-optimization.rst
+++ b/docs/qcportal/source/record-optimization.rst
@@ -1,7 +1,7 @@
 Optimization
 ============
 
-The ``record`` of a geometry optimization.
+The ``Record`` of a geometry optimization.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/qcportal/source/record-overview.rst
+++ b/docs/qcportal/source/record-overview.rst
@@ -1,13 +1,14 @@
 Overview
 ========
 
-A :term:`Record` is the stored values of a completed computation. Each ``Record`` type corresponds to a specific operation that QCArchive has formatted.
+:term:`Records` are the stored values of a completed computation.
+Each ``record`` type corresponds to a specific operation formatted by QCArchive.
+Several ``record`` examples include:
 
-Several examples are:
+- :doc:`Result <record-result>` - data from a single (often quantum chemical) energy, gradient, Hesssian, or property computation,
+- :doc:`Optimization <record-optimization>` - data resulted from a geometry optimization at a given level of theory,
+- ``GridOptimization`` - results of a chain of geometry optimizations where starting structures at each step depends on previous structures, or
+- ``TorsionDrive`` - the outcome of a special type of ``GridOptimization`` specifically for torsion scans that is able to find global minimum structures
+  on the potential energy surfaces.
 
-- :doc:`Result <record-result>` - A single quantum chemistry (or quantum chemistry-like) energy, gradient, Hesssian, or property computation.
-- :doc:`Optimization <record-optimization>` - A geometry optimization at a given level of theory.
-- ``GridOptimization`` - Chains of geometry optimizations where starting structures depend on previous structures.
-- ``TorsionDrive`` - A special type of GridOptimization specifically for torsion scans that is able to overcome local minimum structures to find globally optimal ones.
-
-In general records are indexed based off a hash and are often found and queried through a Collection rather than directly.
+In general, ``records`` are indexed by hashes and therefore, can be easily queried within a dataset ``Collection``.

--- a/docs/qcportal/source/record-overview.rst
+++ b/docs/qcportal/source/record-overview.rst
@@ -2,8 +2,8 @@ Overview
 ========
 
 :term:`Records` are the stored values of a completed computation.
-Each ``record`` type corresponds to a specific operation formatted by QCArchive.
-Several ``record`` examples include:
+Each ``Record`` type corresponds to a specific operation formatted by QCArchive.
+Several ``Record`` examples include:
 
 - :doc:`Result <record-result>` - data from a single (often quantum chemical) energy, gradient, Hesssian, or property computation,
 - :doc:`Optimization <record-optimization>` - data resulted from a geometry optimization at a given level of theory,
@@ -11,4 +11,4 @@ Several ``record`` examples include:
 - ``TorsionDrive`` - the outcome of a special type of ``GridOptimization`` specifically for torsion scans that is able to find global minimum structures
   on the potential energy surfaces.
 
-In general, ``records`` are indexed by hashes and therefore, can be easily queried within a dataset ``Collection``.
+In general, ``Records`` are indexed by hashes and therefore, can be easily queried within a dataset ``Collection``.

--- a/docs/qcportal/source/record-result.rst
+++ b/docs/qcportal/source/record-result.rst
@@ -1,7 +1,8 @@
 Results
 ========
 
-A result is a single quantum chemistry method evaluation, which can be an energy, gradient, Hessian, or property computation.
+The ``result`` of a single (often quantum chemical) calculation 
+which can correspond to an energy, gradient, Hessian, or property computation.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Description
Improves the QCPortal documentation.

## Status
- The **TorsionDrive Dataset** subsections: (i) _Querying the Data_, (ii) _Statistics and Visualization_, and (iii) _Computational Tasks_ and also **Fractal Client** subsections: (i) _Records Querying_, and (ii) _New Compute Tasks_ have not been documented.

- [ ] Ready to go
