### PR TITLE
[WIP] Improve handling of errored calculation

### DIFF
--- a/qcfractal/interface/models/__init__.py
+++ b/qcfractal/interface/models/__init__.py
@@ -20,7 +20,7 @@ from .common_models import (
 from .gridoptimization import GridOptimizationInput, GridOptimizationRecord
 from .model_builder import build_procedure
 from .model_utils import hash_dictionary, json_encoders, prepare_basis
-from .records import OptimizationRecord, ResultRecord
+from .records import OptimizationRecord, ResultRecord, RecordStatusEnum
 from .rest_models import ComputeResponse, rest_model
 from .task_models import ManagerStatusEnum, PythonComputeSpec, TaskRecord, TaskStatusEnum
 from .torsiondrive import TorsionDriveInput, TorsionDriveRecord

--- a/qcfractal/procedures/__init__.py
+++ b/qcfractal/procedures/__init__.py
@@ -6,9 +6,14 @@ from typing import Union, List
 
 from .single import SingleResultTasks
 from .optimization import OptimizationTasks
+from .failure import FailedOperationHandler
 
 supported_procedures = Union[SingleResultTasks, OptimizationTasks]
-__procedure_map = {"single": SingleResultTasks, "optimization": OptimizationTasks}
+__procedure_map = {
+    "single": SingleResultTasks,
+    "optimization": OptimizationTasks,
+    "failed_operation": FailedOperationHandler,
+}
 
 
 def check_procedure_available(procedure: str) -> List[str]:

--- a/qcfractal/procedures/failure.py
+++ b/qcfractal/procedures/failure.py
@@ -1,0 +1,84 @@
+"""
+Procedure for a failed task
+"""
+
+from datetime import datetime as dt
+from typing import List, Optional
+
+import qcelemental as qcel
+import qcengine as qcng
+
+from .base import BaseTasks
+from ..interface.models import (
+    Molecule,
+    ResultRecord,
+    TaskRecord,
+    KeywordSet,
+    RecordStatusEnum,
+    KVStore,
+    CompressionEnum,
+    build_procedure,
+)
+
+
+class FailedOperationHandler(BaseTasks):
+    """Handles FailedOperation that is sent from a manager
+
+    This handles FailedOperation byt copying any info from that class that might be useful.
+    """
+
+    def verify_input(self, data):
+        raise RuntimeError("verify_input is not available for FailedOperationHandler")
+
+    def parse_input(self, data):
+        raise RuntimeError("parse_input is not available for FailedOperationHandler")
+
+    def handle_completed_output(self, failure_outputs):
+        failed_tasks = []
+
+        for output in failure_outputs:
+            fail_result = output["result"]
+
+            err = fail_result.get("error")
+            if err is None:
+                err = {"error_type": "not_supplied", "error_message": "No error message found on task."}
+
+            # Compress error dicts here. Should be ok since they are small
+            err_compressed = KVStore.compress(err, CompressionEnum.lzma, 1)
+            err_id = self.storage.add_kvstore([err_compressed])["data"][0]
+
+            # A little hacky. Create a dict for stdout,stderr and then use retrieve_outputs
+            # These are stored in input_data for a FailedOperation object
+            inp_data = fail_result.get("input_data")
+
+            if inp_data:
+                prog_outputs = {
+                    "stdout": inp_data.get("stdout"),
+                    "stderr": inp_data.get("stderr"),
+                    "error": fail_result["error"],
+                }
+
+            # Will be a dictionary, but may be a real procedure or a plain result
+            # We are only modifying attributes of base_result, though, so that doesn't
+            # matter
+            rec = self.storage.get_procedures(id=output["base_result_id"])["data"][0]
+
+            rec["error"] = err_id
+            rec["status"] = RecordStatusEnum.error
+            rec["manager_name"] = output["manager_name"]
+            rec["modified_on"] = dt.utcnow()
+
+            # TODO - could use an update_procedures that can take single results, too
+            proc = build_procedure(rec)
+            if rec["procedure"] == "single":
+                self.storage.update_results([proc])
+            else:
+                self.storage.update_procedures([proc])
+
+            failed_tasks.append(output["task_id"])
+
+        self.storage.queue_mark_error(failed_tasks)
+
+        # Return success/failures
+        # (successes is a placeholder for now)
+        return [], failed_tasks

--- a/qcfractal/procedures/optimization.py
+++ b/qcfractal/procedures/optimization.py
@@ -2,13 +2,22 @@
 Optimization procedure/task
 """
 
+from datetime import datetime as dt
 from typing import List, Optional
 
 import qcelemental as qcel
 import qcengine as qcng
 
 from .base import BaseTasks
-from ..interface.models import Molecule, OptimizationRecord, QCSpecification, ResultRecord, TaskRecord, KeywordSet
+from ..interface.models import (
+    Molecule,
+    OptimizationRecord,
+    QCSpecification,
+    ResultRecord,
+    TaskRecord,
+    KeywordSet,
+    RecordStatusEnum,
+)
 from ..interface.models.task_models import PriorityEnum
 from .procedures_util import parse_single_tasks, form_qcinputspec_schema
 
@@ -30,49 +39,7 @@ class OptimizationTasks(BaseTasks):
         return True
 
     def parse_input(self, data, duplicate_id="hash_index"):
-        """Parse input json into internally appropriate format
-
-        json_data = {
-            "meta": {
-                "procedure": "optimization",
-                "option": "default",
-                "program": "geometric",
-                "qc_meta": {
-                    "driver": "energy",
-                    "method": "HF",
-                    "basis": "sto-3g",
-                    "keywords": "default",
-                    "program": "psi4"
-                },
-            },
-            "data": ["mol_id_1", "mol_id_2", ...],
-        }
-
-        qc_schema_input = {
-            "molecule": {
-                "geometry": [
-                    0.0,  0.0, -0.6,
-                    0.0,  0.0,  0.6,
-                ],
-                "symbols": ["H", "H"],
-                "connectivity": [[0, 1, 1]]
-            },
-            "driver": "gradient",
-            "model": {
-                "method": "HF",
-                "basis": "sto-3g"
-            },
-            "keywords": {},
-        }
-        json_data = {
-            "keywords": {
-                "coordsys": "tric",
-                "maxiter": 100,
-                "program": "psi4"
-            },
-        }
-
-        """
+        """Parse input json into internally appropriate format"""
 
         # Get the optimization specification from the input meta dictionary
         opt_spec = data.meta
@@ -233,7 +200,7 @@ class OptimizationTasks(BaseTasks):
         completed_tasks = []
         updates = []
         for output in opt_outputs:
-            rec = self.storage.get_procedures(id=output["base_result"])["data"][0]
+            rec = self.storage.get_procedures(id=output["base_result_id"])["data"][0]
             rec = OptimizationRecord(**rec)
 
             procedure = output["result"]
@@ -254,29 +221,37 @@ class OptimizationTasks(BaseTasks):
             update_dict["final_molecule"] = final_mol
 
             # Parse trajectory computations and add task_id
-            traj_dict = {k: v for k, v in enumerate(procedure["trajectory"])}
+            traj = procedure["trajectory"]
 
-            # Add results for the trajectory to the database
-            for k, v in traj_dict.items():
+            # Add outputs for the trajectory to the database
+            for v in traj:
                 self.retrieve_outputs(v)
 
-            results = parse_single_tasks(self.storage, traj_dict, rec.qc_spec)
-            for k, v in results.items():
-                results[k] = ResultRecord(**v)
+            results = parse_single_tasks(self.storage, traj, rec.qc_spec)
+            results_rec = []
+            for v in results:
+                v["manager_name"] = output["manager_name"]
+                results_rec.append(ResultRecord(**v))
 
-            ret = self.storage.add_results(list(results.values()))
+            ret = self.storage.add_results(results_rec)
             update_dict["trajectory"] = ret["data"]
             update_dict["energies"] = procedure["energies"]
             update_dict["provenance"] = procedure["provenance"]
+            update_dict["status"] = RecordStatusEnum.complete
+            update_dict["manager_name"] = output["manager_name"]
+            update_dict["modified_on"] = dt.utcnow()
+
+            completed_tasks.append(output["task_id"])
 
             rec = OptimizationRecord(**{**rec.dict(), **update_dict})
             updates.append(rec)
-            completed_tasks.append(output["task_id"])
 
         self.storage.update_procedures(updates)
         self.storage.queue_mark_complete(completed_tasks)
 
-        return completed_tasks
+        # Return success/failures
+        # (failures is a placeholder for now)
+        return completed_tasks, []
 
     @staticmethod
     def _build_schema_input(

--- a/qcfractal/procedures/procedures_util.py
+++ b/qcfractal/procedures/procedures_util.py
@@ -8,7 +8,7 @@ from typing import Optional, Dict, Any
 
 from qcelemental.models import ResultInput
 
-from ..interface.models import Molecule, QCSpecification
+from ..interface.models import Molecule, QCSpecification, RecordStatusEnum
 
 
 def unpack_single_task_spec(storage, meta, molecules):
@@ -99,7 +99,7 @@ def parse_single_tasks(storage, results, qc_spec):
 
     """
 
-    for k, v in results.items():
+    for v in results:
         # Flatten data back out
         v["method"] = v["model"]["method"]
         v["basis"] = v["model"]["basis"]
@@ -122,9 +122,9 @@ def parse_single_tasks(storage, results, qc_spec):
         del v["schema_version"]
 
         if v.pop("success"):
-            v["status"] = "COMPLETE"
+            v["status"] = RecordStatusEnum.complete
         else:
-            v["status"] = "ERROR"
+            v["status"] = RecordStatusEnum.error
 
     return results
 

--- a/qcfractal/tests/test_compute.py
+++ b/qcfractal/tests/test_compute.py
@@ -228,8 +228,8 @@ def test_queue_error(fractal_compute_server):
 
     # Force a complete mark and test
     fractal_compute_server.objects["storage_socket"].queue_mark_complete([queue_ret[0].id])
-    result = db.get_results(id=compute_ret.ids)["data"][0]
-    assert result["status"] == "COMPLETE"
+    queue_ret = db.get_queue(status="COMPLETE")["data"]
+    assert len(queue_ret) == 0
 
 
 @testing.using_rdkit


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR aims to improve the storage of errors that get returned by managers.

1. Removes responsibility of modifying base_result in queue_mark_complete and queue_mark_error. This is best handled in the procedures, and reduces the number of database queries required
2. The procedure parsers (handle_completed_output) are now responsible for adding manager_name and modified_on to the result/procedure they are already modifying
3. Removes calls to queue_mark_error from queue handler
4. Creates a semi-dummy procedure class to handle errors. This gets called like any other procedure parser, keeping the handling consistent.

The class mentioned in (4) will properly copy as much data as it can from the FailedOperation that is returned by the managers. Right now, only the error member of that class is copied, stripping it of useful info (including some outputs)

That class can be expanded in many ways, including automatic restarting of calculations.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
