### PR TITLE
[WIP] PortalClient - MVP 01

### DIFF
--- a/qcfractal/__init__.py
+++ b/qcfractal/__init__.py
@@ -2,7 +2,8 @@
 Main init function for qcfractal
 """
 
-from . import interface
+#from . import interface
+from . import portal
 
 # Handle versioneer
 from .extras import get_information

--- a/qcfractal/interface/collections/collection_utils.py
+++ b/qcfractal/interface/collections/collection_utils.py
@@ -44,7 +44,7 @@ def register_collection(collection: "Collection") -> None:
 
 
 def collection_factory(data: Dict[str, Any], client: "FractalClient" = None) -> "Collection":
-    """Creates a new Collection class from a JSON blob.
+    """Creates a new Collection instance from a JSON blob.
 
     Parameters
     ----------

--- a/qcfractal/interface/models/__init__.py
+++ b/qcfractal/interface/models/__init__.py
@@ -20,7 +20,7 @@ from .common_models import (
 from .gridoptimization import GridOptimizationInput, GridOptimizationRecord
 from .model_builder import build_procedure
 from .model_utils import hash_dictionary, json_encoders, prepare_basis
-from .records import OptimizationRecord, ResultRecord
+from .records import OptimizationRecord, SingleResultRecord
 from .rest_models import ComputeResponse, rest_model
 from .task_models import ManagerStatusEnum, PythonComputeSpec, TaskRecord, TaskStatusEnum
 from .torsiondrive import TorsionDriveInput, TorsionDriveRecord

--- a/qcfractal/interface/models/model_builder.py
+++ b/qcfractal/interface/models/model_builder.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 
 from .gridoptimization import GridOptimizationRecord
-from .records import OptimizationRecord, ResultRecord
+from .records import OptimizationRecord, SingleResultRecord
 from .torsiondrive import TorsionDriveRecord
 
 
@@ -47,7 +47,7 @@ def build_procedure(
     # import json
     # print(json.dumps(data, indent=2))
     if data["procedure"].lower() == "single":
-        return ResultRecord(**data, client=client)
+        return SingleResultRecord(**data, client=client)
     elif data["procedure"].lower() == "torsiondrive":
         return TorsionDriveRecord(**data, client=client)
     elif data["procedure"].lower() == "gridoptimization":

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -421,6 +421,10 @@ class OptimizationRecord(RecordBase):
         "``initial_molecule`` will be the first index, and ``final_molecule`` will be the last index.",
     )
 
+    @property
+    def df(self):
+        pass
+
     class Config(RecordBase.Config):
         pass
 

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -248,7 +248,7 @@ class RecordBase(ProtoModel, abc.ABC):
             return value
 
 
-class ResultRecord(RecordBase):
+class SingleResultRecord(RecordBase):
 
     # Classdata
     _hash_indices = {"driver", "method", "basis", "molecule", "keywords", "program"}

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from .common_models import KeywordSet, Molecule
 
-__all__ = ["OptimizationRecord", "ResultRecord", "OptimizationRecord", "RecordBase"]
+__all__ = ["OptimizationRecord", "SingleResultRecord", "OptimizationRecord", "RecordBase"]
 
 
 class RecordStatusEnum(str, Enum):
@@ -254,7 +254,7 @@ class SingleResultRecord(RecordBase):
     _hash_indices = {"driver", "method", "basis", "molecule", "keywords", "program"}
 
     # Version data
-    version: int = Field(1, description="Version of the ResultRecord Model which this data was created with.")
+    version: int = Field(1, description="Version of the SingleResultRecord Model which this data was created with.")
     procedure: constr(strip_whitespace=True, regex="single") = Field(
         "single", description='Procedure is fixed as "single" because this is single quantum chemistry result.'
     )
@@ -290,7 +290,7 @@ class SingleResultRecord(RecordBase):
     wavefunction_data_id: Optional[ObjectId] = Field(None, description="The id of the wavefunction")
 
     class Config(RecordBase.Config):
-        """A hash index is not used for ResultRecords as they can be
+        """A hash index is not used for SingleResultRecords as they can be
         uniquely determined with queryable keys.
         """
 
@@ -442,12 +442,12 @@ class OptimizationRecord(RecordBase):
         """
         return self.energies[-1]
 
-    def get_trajectory(self) -> List[ResultRecord]:
+    def get_trajectory(self) -> List[SingleResultRecord]:
         """Returns the Result records for each gradient evaluation in the trajectory.
 
         Returns
         -------
-        List['ResultRecord']
+        List['SingleResultRecord']
             A ordered list of Result record gradient computations.
 
         """

--- a/qcfractal/interface/models/records.py
+++ b/qcfractal/interface/models/records.py
@@ -421,10 +421,6 @@ class OptimizationRecord(RecordBase):
         "``initial_molecule`` will be the first index, and ``final_molecule`` will be the last index.",
     )
 
-    @property
-    def df(self):
-        pass
-
     class Config(RecordBase.Config):
         pass
 

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -11,7 +11,7 @@ from qcelemental.util import get_base_docs
 
 from .common_models import KeywordSet, Molecule, ObjectId, ProtoModel, KVStore
 from .gridoptimization import GridOptimizationInput
-from .records import ResultRecord
+from .records import SingleResultRecord
 from .task_models import PriorityEnum, TaskRecord
 from .torsiondrive import TorsionDriveInput
 
@@ -647,9 +647,9 @@ class ResultGETBody(ProtoModel):
 class ResultGETResponse(ProtoModel):
     meta: ResponseGETMeta = Field(..., description=common_docs[ResponseGETMeta])
     # Either a record or dict depending if projection
-    data: Union[List[ResultRecord], List[Dict[str, Any]]] = Field(
+    data: Union[List[SingleResultRecord], List[Dict[str, Any]]] = Field(
         ...,
-        description="Results found from the query. This is a list of :class:`ResultRecord` in most cases, however, "
+        description="Results found from the query. This is a list of :class:`SingleResultRecord` in most cases, however, "
         "if a projection was specified in the GET request, then a dict is returned with mappings based "
         "on the projection.",
     )
@@ -761,7 +761,7 @@ class TaskQueueGETBody(ProtoModel):
             None,
             description="The exact Id of the Result which this Task is linked to. If this is set as a "
             "search condition, there is no reason to set anything else as this will be unique in the "
-            "database, if it exists. See also :class:`ResultRecord`.",
+            "database, if it exists. See also :class:`SingleResultRecord`.",
         )
         tag: QueryStr = Field(None, description="Tasks will be searched based on their associated tag.")
         manager: QueryStr = Field(
@@ -834,7 +834,7 @@ class TaskQueuePUTBody(ProtoModel):
             None,
             description="The exact Id of a result which this Task is slated to write to. If this is set as a "
             "search condition, there is no reason to set anything else as this will be unique in the "
-            "database, if it exists. See also :class:`ResultRecord`.",
+            "database, if it exists. See also :class:`SingleResultRecord`.",
         )
         new_tag: Optional[str] = Field(
             None,
@@ -1130,7 +1130,7 @@ class OptimizationFinalMoleculeBody(ProtoModel):
 class ResultResponse(ProtoModel):
     meta: ResponseGETMeta = Field(..., description=common_docs[ResponseGETMeta])
     # Either a record or dict depending if projection
-    data: Union[Dict[str, ResultRecord], Dict[str, Any]] = Field(
+    data: Union[Dict[str, SingleResultRecord], Dict[str, Any]] = Field(
         ..., description="A List of Results found from the query per optimization id."
     )
 
@@ -1138,7 +1138,7 @@ class ResultResponse(ProtoModel):
 class ListResultResponse(ProtoModel):
     meta: ResponseGETMeta = Field(..., description=common_docs[ResponseGETMeta])
     # Either a record or dict depending if projection
-    data: Union[Dict[str, List[ResultRecord]], Dict[str, Any]] = Field(
+    data: Union[Dict[str, List[SingleResultRecord]], Dict[str, Any]] = Field(
         ..., description="A List of Results found from the query per optimization id."
     )
 

--- a/qcfractal/interface/models/rest_models.py
+++ b/qcfractal/interface/models/rest_models.py
@@ -67,7 +67,7 @@ def rest_model(resource: str, rest: str) -> Tuple[ProtoModel, ProtoModel]:
     resource : str
         The REST endpoint resource name.
     rest : str
-        The REST endpoint type: GET, POST, PUT, DELETE
+        The method to use on the REST endpoint: GET, POST, PUT, DELETE
 
     Returns
     -------

--- a/qcfractal/portal/__init__.py
+++ b/qcfractal/portal/__init__.py
@@ -6,7 +6,8 @@ from . import collections
 
 # Add imports here
 from .client import PortalClient
-#from .models import Molecule
+
+# from .models import Molecule
 
 # We are running inside QCPortal repo
 try:

--- a/qcfractal/portal/__init__.py
+++ b/qcfractal/portal/__init__.py
@@ -1,0 +1,28 @@
+"""
+DQM Client base folder
+"""
+
+from . import collections
+
+# Add imports here
+from .client import PortalClient
+#from .models import Molecule
+
+# We are running inside QCPortal repo
+try:
+    # The _version file exists only in the QCPortal package
+    from . import _version  # lgtm [py/import-own-module]
+
+    versions = _version.get_versions()
+    __version__ = versions["version"]
+    __git_revision__ = versions["full-revisionid"]
+    _isportal = True
+
+# We are running inside QCFractal
+except ImportError:
+    from ..extras import get_information
+
+    __version__ = "inplace-{}".format(get_information("version"))
+    __git_revision__ = get_information("git_revision")
+    _isportal = False
+    del get_information

--- a/qcfractal/portal/cache.py
+++ b/qcfractal/portal/cache.py
@@ -8,8 +8,7 @@ import bz2
 
 from typing import Union, List, Dict
 
-from ..interface.models.records import RecordBase
-from ..interface.models import build_procedure
+from .records import record_factory
 from .collections.collection_utils import collection_factory
 
 
@@ -69,7 +68,7 @@ class PortalCache:
         # add to fs cache
         cachefile = os.path.join(self.cachedir, "{}.json.bz2".format(id))
         with open(cachefile, "wb") as f:
-            f.write(bz2.compress(record.json().encode("utf-8")))
+            f.write(bz2.compress(record.to_json().encode("utf-8")))
 
     def get(self, ids: Union[List[str], str]):
         if isinstance(ids, list):
@@ -100,7 +99,7 @@ class PortalCache:
         cachefile = os.path.join(self.cachedir, "{}.json.bz2".format(id))
         if os.path.exists(cachefile):
             with open(cachefile, "rb") as f:
-                self.memcache[id] = build_procedure(json.loads(bz2.decompress(f.read()).decode()))
+                self.memcache[id] = record_factory(json.loads(bz2.decompress(f.read()).decode()))
                 return self.memcache[id]
 
         else:

--- a/qcfractal/portal/cache.py
+++ b/qcfractal/portal/cache.py
@@ -1,0 +1,10 @@
+"""PortalClient cache interface.
+
+"""
+
+
+class PortalCache:
+
+    def __init__(self, client, cachedir):
+        self.client = client
+        self.cachedir = cachedir

--- a/qcfractal/portal/cache.py
+++ b/qcfractal/portal/cache.py
@@ -98,12 +98,11 @@ class PortalCache:
         cachefile = os.path.join(self.cachedir, "{}.json.bz2".format(id))
         if os.path.exists(cachefile):
             with open(cachefile, 'rb') as f:
-                return build_procedure(json.loads(bz2.decompress(f.read()).decode()))
-                #return build_procedure(json.load(f))
+                self.memcache[id] = build_procedure(json.loads(bz2.decompress(f.read()).decode()))
+                return self.memcache[id]
+
         else:
             return
-
-
 
 
     def stamp_cache(self):
@@ -124,5 +123,3 @@ class PortalCache:
             # is there some kind of fingerprint the server keeps for itself?
             if meta['server'] != self.client.address:
                 raise Exception("Existing cache directory corresponds to a different QCFractal Server")
-
-

--- a/qcfractal/portal/cache.py
+++ b/qcfractal/portal/cache.py
@@ -14,6 +14,9 @@ from .collections.collection_utils import collection_factory
 
 
 # TODO: make caching for different servers a layer beneath, ultimately transparent for most users
+# TODO: evaluate use of joblib as the cache implementation instead
+#       should assess possible performance, maintainability improvements
+#       also where would it fall short?
 class PortalCache:
     def __init__(self, client, cachedir):
         self.client = client

--- a/qcfractal/portal/cache.py
+++ b/qcfractal/portal/cache.py
@@ -2,9 +2,127 @@
 
 """
 
+import os
+import json
+import bz2
 
+from typing import Union, List, Dict
+
+from ..interface.models.records import RecordBase
+from ..interface.models import build_procedure 
+from .collections.collection_utils import collection_factory
+
+
+# TODO: make caching for different servers a layer beneath, ultimately transparent for most users
 class PortalCache:
 
     def __init__(self, client, cachedir):
         self.client = client
-        self.cachedir = cachedir
+        self.cachedir = os.path.abspath(cachedir)
+        self.metafile = os.path.join(self.cachedir, 'meta.json')
+
+        os.makedirs(self.cachedir, exist_ok=True)
+
+        # writeout metadata for reload later, exception handling if server/cache mismatch
+        if not os.path.exists(self.metafile):
+            self.stamp_cache()
+        else:
+            self.check_cache()
+
+        # TODO: make this an LRU cache with finite size
+        self.memcache = {}
+
+    def _get_writelock(self):
+        """Context manager for applying cross-platform filesystem lock to cache lockfile.
+        
+        Only required for write to cache.
+        Allows multiple clients to write without further coordination.
+
+        """
+        pass
+
+    def put(self, records: Union[List[Dict], Dict]):
+        if isinstance(records, list):
+            for rec in records:
+                self._put(rec)
+        elif rec is None:
+            return
+        else:
+            self._put(rec)
+                
+    def _put(self, record):
+
+        if isinstance(record, dict):
+            id = record['id']
+        else:
+            id = record.id
+
+        # if we already have this in memcache, no further action
+        if id in self.memcache:
+            return
+        
+        # add to memcache
+        self.memcache[id] = record
+
+        # add to fs cache
+        cachefile = os.path.join(self.cachedir, "{}.json.bz2".format(id))
+        with open(cachefile, 'wb') as f:
+            f.write(bz2.compress(record.json().encode('utf-8')))
+
+    def get(self, ids: Union[List[str], str]):
+        if isinstance(ids, list):
+            records = {}
+            for id in ids:
+                rec = self._get(id)
+                if rec is not None:
+                    records[id] = rec
+            return records
+        elif id is None:
+            return []
+        else:
+            return self._get(id)
+
+    def _get(self, id):
+
+        # cast to string if not already
+        id = str(id)
+
+        # first check memcache (fast)
+        # if found, return
+        record = self.memcache.get(id, None)
+        if record is not None:
+            return record
+
+        # check fs cache (slower)
+        # return if found, otherwise return None
+        cachefile = os.path.join(self.cachedir, "{}.json.bz2".format(id))
+        if os.path.exists(cachefile):
+            with open(cachefile, 'rb') as f:
+                return build_procedure(json.loads(bz2.decompress(f.read()).decode()))
+                #return build_procedure(json.load(f))
+        else:
+            return
+
+
+
+
+    def stamp_cache(self):
+        """Place metadata indicating which server this cache belongs to.
+
+        """
+        meta = {'purpose': "QCFractal PortalClient cache",
+                'server': self.client.address}
+
+        with open(self.metafile, 'w') as f:
+            json.dump(meta, f)
+
+    def check_cache(self):
+        with open(self.metafile, 'r') as f:
+            meta = json.load(f)
+
+            # TODO: consider other ways to verify same server besides URI
+            # is there some kind of fingerprint the server keeps for itself?
+            if meta['server'] != self.client.address:
+                raise Exception("Existing cache directory corresponds to a different QCFractal Server")
+
+

--- a/qcfractal/portal/client.py
+++ b/qcfractal/portal/client.py
@@ -11,8 +11,8 @@ from pydantic import ValidationError
 import pandas as pd
 
 from ..interface.models.rest_models import rest_model
-from ..interface.models import build_procedure
 from .collections import collection_factory, collections_name_map
+from .records import record_factory, record_name_map
 from .cache import PortalCache
 
 _ssl_error_msg = (
@@ -425,7 +425,7 @@ class PortalClient:
 
         if not include:
             for ind in range(len(response.data)):
-                response.data[ind] = build_procedure(response.data[ind], client=self)
+                response.data[ind] = record_factory(response.data[ind], client=self)
 
         if full_return:
             return response

--- a/qcfractal/portal/client.py
+++ b/qcfractal/portal/client.py
@@ -341,6 +341,16 @@ class PortalClient:
     #        chunk_ids = query_ids[i : i + self.client.query_limit]
     #        procedures.extend(self.client._query_procedures(id=chunk_ids))
 
+    # TODO: simplified alternative to `_query_procedures`
+    #       can always use cache
+    def _get_by_id():
+
+        pass
+
+
+    # TODO: would like to merge the functionality of
+    #       `query_result`, `query_procedure`, `query_service`.
+    #       perhaps just `query_record`?
     def _query_procedures(
         self,
         id: Optional["QueryObjectId"] = None,
@@ -430,8 +440,8 @@ class PortalClient:
         collection_type: Optional[str] = None,
         full: bool = False,
         taglines: bool = False,
-        aslist: bool = False,
-        asdf: bool = False,
+        as_list: bool = False,
+        as_df: bool = False,
         group: Optional[str] = "default",
         show_hidden: bool = False,
         tag: Optional[Union[str, List[str]]] = None,
@@ -447,9 +457,9 @@ class PortalClient:
             Whether to include tags, group in output; default False.
         taglines : bool, optional
             Whether to include taglines in output; default False.
-        aslist : bool, optional
+        as_list : bool, optional
             Return output as a list instead of printing.
-        asdf : bool, optional
+        as_df : bool, optional
             Return output as a `pandas` DataFrame instead of printing.
         group : Optional[str], optional
             Show only collections belonging to a specified group.
@@ -462,7 +472,7 @@ class PortalClient:
         Returns
         -------
         Union[None, List]
-            Prints output as table to screen; if `aslist=True`,
+            Prints output as table to screen; if `as_list=True`,
             returns list of output content instead.
         """
         from tabulate import tabulate
@@ -515,9 +525,9 @@ class PortalClient:
                 output.append(trimmed)
 
         # give representation
-        if not (aslist or asdf):
+        if not (as_list or as_df):
             print(tabulate(output, headers="keys"))
-        elif aslist:
+        elif as_list:
             return output
-        elif asdf:
+        elif as_df:
             return pd.DataFrame(output)

--- a/qcfractal/portal/client.py
+++ b/qcfractal/portal/client.py
@@ -21,6 +21,7 @@ _ssl_error_msg = (
 )
 _connection_error_msg = "\n\nCould not connect to server {}, please check the address and try again."
 
+
 def _version_list(version):
     version_match = re.search(r"\d+\.\d+\.\d+", version)
     if version_match is None:
@@ -31,9 +32,9 @@ def _version_list(version):
     version = version_match.group(0)
     return [int(x) for x in version.split(".")]
 
+
 # TODO : built-in query limit chunking, progress bars, fs caching and invalidation
 class PortalClient:
-
     def __init__(
         self,
         address: Union[str, "FractalServer"] = "api.qcarchive.molssi.org:443",
@@ -60,7 +61,7 @@ class PortalClient:
         cache : str, optional
             Path to directory to use for cache.
             If None, only in-memory caching used.
-            
+
         """
 
         if hasattr(address, "get_address"):
@@ -252,18 +253,17 @@ class PortalClient:
         else:
             return response.data
 
-
     @property
     def cache(self):
         return os.path.relpath(self._cache.cachedir)
-    
+
     def get_collection(
         self,
         collection_type: str,
         name: str,
         full_return: bool = False,
-        include: "QueryListStr" = None, # TODO: WHAT ARE THESE FOR?
-        exclude: "QueryListStr" = None, # TODO: WHAT ARE THESE FOR?
+        include: "QueryListStr" = None,  # TODO: WHAT ARE THESE FOR?
+        exclude: "QueryListStr" = None,  # TODO: WHAT ARE THESE FOR?
     ) -> "Collection":
         """Returns a given collection from the server.
 
@@ -335,12 +335,11 @@ class PortalClient:
 
     # TODO: what are the query_limit rules exactly?
     #       does it use the total count of query terms, including mixed-and-matching fields
-    #def _chunk_request(self, items):
+    # def _chunk_request(self, items):
     #    procedures: List[Dict[str, Any]] = []
     #    for i in range(0, len(items), self.query_limit):
     #        chunk_ids = query_ids[i : i + self.client.query_limit]
     #        procedures.extend(self.client._query_procedures(id=chunk_ids))
-
 
     def _query_procedures(
         self,
@@ -423,7 +422,7 @@ class PortalClient:
         else:
             # NOTE: no particular order returned here
             # could put the "only complete" logic into the cache itself as a policy
-            self._cache.put([proc for proc in response.data if proc.status == 'COMPLETE'])
+            self._cache.put([proc for proc in response.data if proc.status == "COMPLETE"])
             return response.data + list(procs.values())
 
     def list_collections(
@@ -484,40 +483,40 @@ class PortalClient:
 
         # apply filters
         if not show_hidden:
-            collection_data = [item for item in collection_data if item['visibility']]
+            collection_data = [item for item in collection_data if item["visibility"]]
         if group is not None:
-            collection_data = [item for item in collection_data if item['group'] == group]
+            collection_data = [item for item in collection_data if item["group"] == group]
         if tag is not None:
-            collection_data = [item for item in collection_data if set(item['tags']).intersection(tag)]
+            collection_data = [item for item in collection_data if set(item["tags"]).intersection(tag)]
         if collection_type is not None:
-            collection_data = [item for item in collection_data if item['collection']]
+            collection_data = [item for item in collection_data if item["collection"]]
 
         name_map = collections_name_map()
         output = []
         for item in collection_data:
-            if item['collection'] in name_map:
+            if item["collection"] in name_map:
                 trimmed = {}
-                collection_type_i = name_map[item['collection']]
-                
+                collection_type_i = name_map[item["collection"]]
+
                 if collection_type is not None:
                     if collection_type_i.lower() != collection_type.lower():
                         continue
                 else:
-                    trimmed['Collection Type'] = collection_type_i
+                    trimmed["Collection Type"] = collection_type_i
 
-                trimmed['Collection Name'] = item['name']
+                trimmed["Collection Name"] = item["name"]
 
                 if full:
-                    trimmed['Tags'] = item['tags']
-                    trimmed['Group'] = item['group']
+                    trimmed["Tags"] = item["tags"]
+                    trimmed["Group"] = item["group"]
 
                 if taglines:
-                    trimmed['Tagline'] = item['tagline']
+                    trimmed["Tagline"] = item["tagline"]
                 output.append(trimmed)
-            
+
         # give representation
         if not (aslist or asdf):
-            print(tabulate(output, headers='keys'))
+            print(tabulate(output, headers="keys"))
         elif aslist:
             return output
         elif asdf:

--- a/qcfractal/portal/client.py
+++ b/qcfractal/portal/client.py
@@ -425,7 +425,7 @@ class PortalClient:
 
         if not include:
             for ind in range(len(response.data)):
-                response.data[ind] = record_factory(response.data[ind], client=self)
+                response.data[ind] = record_factory(response.data[ind])
 
         if full_return:
             return response

--- a/qcfractal/portal/client.py
+++ b/qcfractal/portal/client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Tuple,
 from pathlib import Path
 
 from pydantic import ValidationError
+import pandas as pd
 
 from ..interface.models.rest_models import rest_model
 from ..interface.models import build_procedure
@@ -261,8 +262,8 @@ class PortalClient:
         collection_type: str,
         name: str,
         full_return: bool = False,
-        include: "QueryListStr" = None,
-        exclude: "QueryListStr" = None,
+        include: "QueryListStr" = None, # TODO: WHAT ARE THESE FOR?
+        exclude: "QueryListStr" = None, # TODO: WHAT ARE THESE FOR?
     ) -> "Collection":
         """Returns a given collection from the server.
 
@@ -431,11 +432,12 @@ class PortalClient:
         full: bool = False,
         taglines: bool = False,
         aslist: bool = False,
+        asdf: bool = False,
         group: Optional[str] = "default",
         show_hidden: bool = False,
         tag: Optional[Union[str, List[str]]] = None,
-    ) -> Dict:
-        """Print the available collections currently on the server.
+    ) -> Union[None, List]:
+        """Print or return the available collections currently on the server.
 
         Parameters
         ----------
@@ -448,6 +450,8 @@ class PortalClient:
             Whether to include taglines in output; default False.
         aslist : bool, optional
             Return output as a list instead of printing.
+        asdf : bool, optional
+            Return output as a `pandas` DataFrame instead of printing.
         group : Optional[str], optional
             Show only collections belonging to a specified group.
             To explicitly return all collections, set group=None
@@ -504,15 +508,17 @@ class PortalClient:
                 trimmed['Collection Name'] = item['name']
 
                 if full:
-                    trimmed['tags'] = item['tags']
-                    trimmed['group'] = item['group']
+                    trimmed['Tags'] = item['tags']
+                    trimmed['Group'] = item['group']
 
                 if taglines:
-                    trimmed['tagline'] = item['tagline']
+                    trimmed['Tagline'] = item['tagline']
                 output.append(trimmed)
             
         # give representation
-        if not aslist:
+        if not (aslist or asdf):
             print(tabulate(output, headers='keys'))
         elif aslist:
             return output
+        elif asdf:
+            return pd.DataFrame(output)

--- a/qcfractal/portal/client.py
+++ b/qcfractal/portal/client.py
@@ -1,0 +1,394 @@
+from collections import defaultdict
+import re
+
+import requests
+
+from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Tuple, Union
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from ..interface.models.rest_models import rest_model
+from ..interface.models import build_procedure
+from .collections import collection_factory, collections_name_map
+from .cache import PortalCache
+
+_ssl_error_msg = (
+    "\n\nSSL handshake failed. This is likely caused by a failure to retrieve 3rd party SSL certificates.\n"
+    "If you trust the server you are connecting to, try 'PortalClient(... verify=False)'"
+)
+_connection_error_msg = "\n\nCould not connect to server {}, please check the address and try again."
+
+def _version_list(version):
+    version_match = re.search(r"\d+\.\d+\.\d+", version)
+    if version_match is None:
+        raise ValueError(
+            f"Could not read version of form XX.YY.ZZ from {version}. There is something very "
+            f"malformed about the version string. Please report this to the Fractal developers."
+        )
+    version = version_match.group(0)
+    return [int(x) for x in version.split(".")]
+
+# TODO : built-in query limit chunking, progress bars, fs caching and invalidation
+class PortalClient:
+
+    def __init__(
+        self,
+        address: Union[str, "FractalServer"] = "api.qcarchive.molssi.org:443",
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        verify: bool = True,
+        cachedir: Optional[Union[str, Path]] = None,
+    ) -> None:
+        """Initializes a PortalClient instance from an address and verification information.
+
+        Parameters
+        ----------
+        address : str or FractalServer
+            The IP and port of the FractalServer instance ("192.168.1.1:8888") or
+            a FractalServer instance
+        username : None, optional
+            The username to authenticate with.
+        password : None, optional
+            The password to authenticate with.
+        verify : bool, optional
+            Verifies the SSL connection with a third party server. This may be False if a
+            FractalServer was not provided a SSL certificate and defaults back to self-signed
+            SSL keys.
+        cachedir : str, optional
+            
+        """
+
+        if hasattr(address, "get_address"):
+            # We are a FractalServer-like object
+            verify = address.client_verify
+            address = address.get_address()
+
+        if "http" not in address:
+            address = "https://" + address
+
+        # If we are `http`, ignore all SSL directives
+        if not address.startswith("https"):
+            self._verify = True
+
+        if not address.endswith("/"):
+            address += "/"
+
+        self.address = address
+        self.username = username
+        self._verify = verify
+        self._headers: Dict[str, str] = {}
+        self.encoding = "msgpack-ext"
+        self.cachedir = None
+
+        # Mode toggle for network error testing, not public facing
+        self._mock_network_error = False
+
+        # If no 3rd party verification, quiet urllib
+        if self._verify is False:
+            from urllib3.exceptions import InsecureRequestWarning
+
+            requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+
+        if (username is not None) or (password is not None):
+            self._headers["Authorization"] = json.dumps({"username": username, "password": password})
+
+        from . import __version__  # Import here to avoid circular import
+        from . import _isportal
+
+        self._headers["Content-Type"] = f"application/{self.encoding}"
+        self._headers["User-Agent"] = f"qcportal/{__version__}"
+
+        self._request_counter: DefaultDict[Tuple[str, str], int] = defaultdict(int)
+
+        ### Define all attributes before this line
+
+        # Try to connect and pull general data
+        self.server_info = self._automodel_request("information", "get", {}, full_return=True).dict()
+
+        self.server_name = self.server_info["name"]
+        self.query_limit: int = self.server_info["query_limit"]
+
+        if _isportal:
+            try:
+                server_version_min_client = _version_list(self.server_info["client_lower_version_limit"])[:2]
+                server_version_max_client = _version_list(self.server_info["client_upper_version_limit"])[:2]
+            except KeyError:
+                server_ver_str = ".".join([str(i) for i in self.server_info["version"]])
+                raise IOError(
+                    f"The Server at {self.address}, version {self.server_info['version']} does not report "
+                    f"what Client versions it accepts! It can be almost asserted your Client is too new for "
+                    f"the Server you are connecting to. Please downgrade your Client with "
+                    f"the one of following commands (pip or conda):"
+                    f"\n\t- pip install qcportal=={server_ver_str}"
+                    f"\n\t- conda install -c conda-forge qcportal=={server_ver_str}"
+                    f"\n(Only MAJOR.MINOR versions are checked)"
+                )
+            client_version = _version_list(__version__)[:2]
+            if not server_version_min_client <= client_version <= server_version_max_client:
+                client_ver_str = ".".join([str(i) for i in client_version])
+                server_version_min_str = ".".join([str(i) for i in server_version_min_client])
+                server_version_max_str = ".".join([str(i) for i in server_version_max_client])
+                raise IOError(
+                    f"This Client of version {client_ver_str} does not fall within the Server's allowed "
+                    f"Client versions of [{server_version_min_str}, {server_version_max_str}] at "
+                    f"Server address: {self.address}. Please change your Client version with one of the "
+                    f"following commands:"
+                    f"\n\t- pip install qcportal=={server_version_max_str}.*"
+                    f"\n\t- conda install -c conda-forge qcportal=={server_version_max_str}.*"
+                    f"\n(Only MAJOR.MINOR versions are checked and shown)"
+                )
+
+        if self.cachedir is not None:
+            self._cache = PortalCache(self, cachedir)
+
+    def __repr__(self) -> str:
+        """A short representation of the current PortalClient.
+
+        Returns
+        -------
+        str
+            The desired representation.
+        """
+        ret = "PortalClient(server_name='{}', address='{}', username='{}')".format(
+            self.server_name, self.address, self.username
+        )
+        return ret
+
+    def _repr_html_(self) -> str:
+
+        output = f"""
+        <h3>PortalClient</h3>
+        <ul>
+          <li><b>Server:   &nbsp; </b>{self.server_name}</li>
+          <li><b>Address:  &nbsp; </b>{self.address}</li>
+          <li><b>Username: &nbsp; </b>{self.username}</li>
+        </ul>
+        """
+
+        # postprocess due to raw spacing above
+        return "\n".join([substr.strip() for substr in output.split("\n")])
+
+    def _request(
+        self,
+        method: str,
+        service: str,
+        *,
+        data: Optional[str] = None,
+        noraise: bool = False,
+        timeout: Optional[int] = None,
+    ) -> requests.Response:
+
+        addr = self.address + service
+        kwargs = {"data": data, "timeout": timeout, "headers": self._headers, "verify": self._verify}
+
+        if self._mock_network_error:
+            raise requests.exceptions.RequestException("mock_network_error is on, failing by design!")
+
+        try:
+            if method == "get":
+                r = requests.get(addr, **kwargs)
+            elif method == "post":
+                r = requests.post(addr, **kwargs)
+            elif method == "put":
+                r = requests.put(addr, **kwargs)
+            elif method == "delete":
+                r = requests.delete(addr, **kwargs)
+            else:
+                raise KeyError("Method not understood: '{}'".format(method))
+        except requests.exceptions.SSLError:
+            raise ConnectionRefusedError(_ssl_error_msg) from None
+        except requests.exceptions.ConnectionError:
+            raise ConnectionRefusedError(_connection_error_msg.format(self.address)) from None
+
+        if (r.status_code != 200) and (not noraise):
+            raise IOError("Server communication failure. Reason: {}".format(r.reason))
+
+        return r
+
+
+    def _automodel_request(
+        self, name: str, rest: str, payload: Dict[str, Any], full_return: bool = False, timeout: int = None
+    ) -> Any:
+        """Automatic model request profiling and creation using rest_models
+
+        Parameters
+        ----------
+        name : str
+            The name of the REST endpoint
+        rest : str
+            The method to use on the REST endpoint: GET, POST, PUT, DELETE
+        payload : Dict[str, Any]
+            The input dictionary
+        full_return : bool, optional
+            Returns the full server response if True that contains additional metadata.
+        timeout : int, optional
+            Timeout time
+
+        Returns
+        -------
+        Any
+            The REST response object
+        """
+        sname = name.strip("/")
+        self._request_counter[(sname, rest)] += 1
+
+        body_model, response_model = rest_model(sname, rest)
+
+        # Provide a reasonable traceback
+        try:
+            payload = body_model(**payload)
+        except ValidationError as exc:
+            raise TypeError(str(exc))
+
+        r = self._request(rest, name, data=payload.serialize(self.encoding), timeout=timeout)
+        encoding = r.headers["Content-Type"].split("/")[1]
+        response = response_model.parse_raw(r.content, encoding=encoding)
+
+        if full_return:
+            return response
+        else:
+            return response.data
+
+    def get_collection(
+        self,
+        collection_type: str,
+        name: str,
+        full_return: bool = False,
+        include: "QueryListStr" = None,
+        exclude: "QueryListStr" = None,
+    ) -> "Collection":
+        """Returns a given collection from the server.
+
+        Parameters
+        ----------
+        collection_type : str
+            The collection type.
+        name : str
+            The name of the collection.
+        full_return : bool, optional
+            If True, returns the full server response.
+        include : QueryListStr, optional
+            Return only these columns.
+        exclude : QueryListStr, optional
+            Return all but these columns.
+        Returns
+        -------
+        Collection
+            A Collection object if the given collection was found; otherwise returns `None`.
+
+        """
+
+        payload = {"meta": {}, "data": {"collection": collection_type, "name": name}}
+        if include is None and exclude is None:
+            if collection_type.lower() in ["dataset", "reactiondataset"]:  # XXX
+                payload["meta"]["exclude"] = ["contributed_values", "records"]
+        else:
+            payload["meta"]["include"] = include
+            payload["meta"]["exclude"] = exclude
+
+        response = self._automodel_request("collection", "get", payload, full_return=True)
+        if full_return:
+            return response
+
+        # Watching for nothing found
+        if len(response.data):
+            return collection_factory(response.data[0], client=self)
+        else:
+            raise KeyError("Collection '{}:{}' not found.".format(collection_type, name))
+
+    # TODO: make this just take collections themselves, not dicts
+    def add_collection(
+        self, collection: Dict[str, Any], overwrite: bool = False, full_return: bool = False
+    ) -> Union["CollectionGETResponse", List["ObjectId"]]:
+        """Adds a new Collection to the server.
+
+        Parameters
+        ----------
+        collection : Dict[str, Any]
+            The full collection data representation.
+        overwrite : bool, optional
+            Overwrites the collection if it already exists in the database, used for updating collection.
+        full_return : bool, optional
+            Returns the full server response if True that contains additional metadata.
+
+        Returns
+        -------
+        List[ObjectId]
+            The ObjectId's of the added collection.
+
+        """
+        # Can take in either molecule or lists
+
+        if overwrite and ("id" not in collection or collection["id"] == "local"):
+            raise KeyError("Attempting to overwrite collection, but no server ID found (cannot use 'local').")
+
+        payload = {"meta": {"overwrite": overwrite}, "data": collection}
+        return self._automodel_request("collection", "post", payload, full_return=full_return)
+
+    def _query_procedures(
+        self,
+        id: Optional["QueryObjectId"] = None,
+        task_id: Optional["QueryObjectId"] = None,
+        procedure: Optional["QueryStr"] = None,
+        program: Optional["QueryStr"] = None,
+        hash_index: Optional["QueryStr"] = None,
+        status: "QueryStr" = "COMPLETE",
+        limit: Optional[int] = None,
+        skip: int = 0,
+        include: Optional["QueryListStr"] = None,
+        full_return: bool = False,
+    ) -> Union["ProcedureGETResponse", List[Dict[str, Any]]]:
+        """Queries Procedures from the server.
+
+        Parameters
+        ----------
+        id : QueryObjectId, optional
+            Queries the Procedure ``id`` field.
+        task_id : QueryObjectId, optional
+            Queries the Procedure ``task_id`` field.
+        procedure : QueryStr, optional
+            Queries the Procedure ``procedure`` field.
+        program : QueryStr, optional
+            Queries the Procedure ``program`` field.
+        hash_index : QueryStr, optional
+            Queries the Procedure ``hash_index`` field.
+        status : QueryStr, optional
+            Queries the Procedure ``status`` field.
+        limit : Optional[int], optional
+            The maximum number of Procedures to query
+        skip : int, optional
+            The number of Procedures to skip in the query, used during pagination
+        include : QueryListStr, optional
+            Filters the returned fields, will return a dictionary rather than an object.
+        full_return : bool, optional
+            Returns the full server response if True that contains additional metadata.
+
+        Returns
+        -------
+        Union[List['RecordBase'], Dict[str, Any]]
+            Returns a List of found RecordResult's without include, or a
+            dictionary of results with include.
+        """
+
+        payload = {
+            "meta": {"limit": limit, "skip": skip, "include": include},
+            "data": {
+                "id": id,
+                "task_id": task_id,
+                "program": program,
+                "procedure": procedure,
+                "hash_index": hash_index,
+                "status": status,
+            },
+        }
+        response = self._automodel_request("procedure", "get", payload, full_return=True)
+
+        if not include:
+            for ind in range(len(response.data)):
+                response.data[ind] = build_procedure(response.data[ind], client=self)
+
+        if full_return:
+            return response
+        else:
+            return response.data

--- a/qcfractal/portal/collections/__init__.py
+++ b/qcfractal/portal/collections/__init__.py
@@ -1,0 +1,3 @@
+
+from .collection_utils import collection_factory, collections_name_map, register_collection
+from .optimization_dataset import OptimizationDataset

--- a/qcfractal/portal/collections/__init__.py
+++ b/qcfractal/portal/collections/__init__.py
@@ -1,3 +1,2 @@
-
 from .collection_utils import collection_factory, collections_name_map, register_collection
 from .optimization_dataset import OptimizationDataset

--- a/qcfractal/portal/collections/collection.py
+++ b/qcfractal/portal/collections/collection.py
@@ -14,7 +14,7 @@ from ...interface.models import ProtoModel
 from ...interface.models.records import RecordBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .. import PortalClient 
+    from .. import PortalClient
     from ..models import ObjectId
 
 
@@ -123,7 +123,7 @@ class Collection(abc.ABC):
 
         Parameters
         ----------
-        client : PortalClient 
+        client : PortalClient
             A PortalClient connected to a server.
         name : str
             The name of the collection to pull from.
@@ -278,7 +278,6 @@ class Collection(abc.ABC):
 
 
 class BaseProcedureDataset(Collection):
-
     class _DataModel(Collection._DataModel):
 
         records: Dict[str, Any] = {}
@@ -307,7 +306,7 @@ class BaseProcedureDataset(Collection):
 
         super().__init__(name, client=client, **kwargs)
 
-    def __getitem__(self, spec : Union[List[str], str]):
+    def __getitem__(self, spec: Union[List[str], str]):
         if isinstance(spec, list):
             pad = max(map(len, spec))
             return {sp: self._query(sp, pad=pad) for sp in spec}
@@ -386,9 +385,7 @@ class BaseProcedureDataset(Collection):
 
     @property
     def entries(self):
-        """A dictionary with entry names as keys and entry content as values.
-
-        """
+        """A dictionary with entry names as keys and entry content as values."""
         return dict(self._data.records)
 
     def get_specification(self, name: str) -> Any:
@@ -560,8 +557,10 @@ class BaseProcedureDataset(Collection):
 
         # Chunk up the queries
         procedures: List[Dict[str, Any]] = []
-        for i in tqdm(range(0, len(query_ids), self._client.query_limit),
-                desc="{} || {} ".format(specification.rjust(pad), self._client.address)):
+        for i in tqdm(
+            range(0, len(query_ids), self._client.query_limit),
+            desc="{} || {} ".format(specification.rjust(pad), self._client.address),
+        ):
             chunk_ids = query_ids[i : i + self._client.query_limit]
             procedures.extend(self._client._query_procedures(id=chunk_ids))
 
@@ -637,12 +636,12 @@ class BaseProcedureDataset(Collection):
             output = status_data
         else:
             output = status_data.apply(lambda x: x.value_counts())
-            output.index.name = 'status'
+            output.index.name = "status"
 
         # give representation
         if not (aslist or asdf):
-            print(tabulate(output.reset_index().to_dict('records'), headers='keys'))
+            print(tabulate(output.reset_index().to_dict("records"), headers="keys"))
         elif aslist:
-            return output.reset_index().to_dict('records')
+            return output.reset_index().to_dict("records")
         elif asdf:
             return output

--- a/qcfractal/portal/collections/collection.py
+++ b/qcfractal/portal/collections/collection.py
@@ -380,8 +380,12 @@ class BaseProcedureDataset(Collection):
         return self.list_specifications()
 
     @property
-    def index(self):
+    def entry_names(self):
         return self._get_index()
+
+    @property
+    def entries(self):
+        return dict(self._data.records)
 
     def get_specification(self, name: str) -> Any:
         """Get full parameters for the given named specification.

--- a/qcfractal/portal/collections/collection.py
+++ b/qcfractal/portal/collections/collection.py
@@ -1,7 +1,5 @@
-"""
-QCDB Abstract basic Collection class
+"""Base Collection classes.
 
-Helper
 """
 
 import abc
@@ -10,6 +8,7 @@ import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import pandas as pd
+from tqdm import tqdm
 
 from ...interface.models import ProtoModel
 
@@ -110,7 +109,7 @@ class Collection(abc.ABC):
         return f"<{self}>"
 
     def _check_client(self):
-        if self.client is None:
+        if self._client is None:
             raise AttributeError("This method requires a PortalClient and no client was set")
 
     @property
@@ -124,7 +123,7 @@ class Collection(abc.ABC):
         Parameters
         ----------
         client : PortalClient 
-            A PortalClient connected to a server
+            A PortalClient connected to a server.
         name : str
             The name of the collection to pull from.
 
@@ -239,7 +238,7 @@ class Collection(abc.ABC):
 
         if client is None:
             self._check_client()
-            client = self.client
+            client = self._client
 
         self._pre_save_prep(client)
 
@@ -278,6 +277,16 @@ class Collection(abc.ABC):
 
 
 class BaseProcedureDataset(Collection):
+
+    class _DataModel(Collection._DataModel):
+
+        records: Dict[str, Any] = {}
+        history: Set[str] = set()
+        specs: Dict[str, Any] = {}
+
+        class Config(Collection._DataModel.Config):
+            pass
+
     def __init__(self, name: str, client: "PortalClient" = None, **kwargs):
         """Initialize a ProcedureDataset Collection.
 
@@ -297,32 +306,18 @@ class BaseProcedureDataset(Collection):
 
         super().__init__(name, client=client, **kwargs)
 
-        self._df = None
-
-    
-
-    @property
-    def df(self):
-        """Return a DataFrame view of the collection.
-
-        """
-        return pd.DataFrame(index=self._get_index())
-
-
-    class _DataModel(Collection._DataModel):
-
-        records: Dict[str, Any] = {}
-        history: Set[str] = set()
-        specs: Dict[str, Any] = {}
-
-        class Config(Collection.DataModel.Config):
-            pass
+    def __getitem__(self, spec : Union[List[str], str]):
+        if isinstance(spec, list):
+            pad = max(map(len, spec))
+            return {sp: self._query(sp, pad=pad) for sp in spec}
+        else:
+            return self._query(spec)
 
     @abc.abstractmethod
     def _internal_compute_add(self, spec: Any, entry: Any, tag: str, priority: str) -> "ObjectId":
         pass
 
-    def _pre_save_prep(self, client: "PortalClient") -> None:
+    def _pre_sync_prep(self, client: "PortalClient") -> None:
         pass
 
     def _get_index(self):
@@ -349,15 +344,14 @@ class BaseProcedureDataset(Collection):
         self.sync()
 
     def _get_procedure_ids(self, spec: str, sieve: Optional[List[str]] = None) -> Dict[str, "ObjectId"]:
-        """Aquires the
+        """Get a mapping of record names to its object ID in the database.
 
         Parameters
         ----------
         spec : str
-            The specification to get the map of
+            The specification to get mapping for.
         sieve : Optional[List[str]], optional
-            A
-            Description
+            List of record names to restrict the mapping to.
 
         Returns
         -------
@@ -381,12 +375,21 @@ class BaseProcedureDataset(Collection):
 
         return mapper
 
+    @property
+    def specs(self):
+        return self.list_specifications()
+
+    @property
+    def index(self):
+        return self._get_index()
+
     def get_specification(self, name: str) -> Any:
-        """
+        """Get full parameters for the given named specification.
+
         Parameters
         ----------
         name : str
-            The name of the specification
+            The name of the specification.
 
         Returns
         -------
@@ -399,24 +402,22 @@ class BaseProcedureDataset(Collection):
         except KeyError:
             raise KeyError(f"Specification '{name}' not found.")
 
-    def list_specifications(self, description=True) -> Union[List[str], pd.DataFrame]:
-        """Lists all available specifications
+    def list_specifications(self, description=False) -> Union[List[str], Dict[str, str]]:
+        """Gives all available specifications.
 
         Parameters
         ----------
         description : bool, optional
-            If True returns a DataFrame with
-            Description
+            If True, returns a dictionary with spec names as keys, descriptions as values.
 
         Returns
         -------
-        Union[List[str], 'DataFrame']
-            A list of known specification names.
+        Union[List[str], Dict[str, str]]
+            Known specification names.
 
         """
         if description:
-            data = [(x.name, x.description) for x in self.data.specs.values()]
-            return pd.DataFrame(data, columns=["Name", "Description"]).set_index("Name")
+            return {x.name: x.description for x in self._data.specs.values()}
         else:
             return [x.name for x in self._data.specs.values()]
 
@@ -436,10 +437,10 @@ class BaseProcedureDataset(Collection):
         self._check_entry_exists(name)
         self.data.records[name.lower()] = record
         if save:
-            self.save()
+            self.sync()
 
     def _get_entry(self, name: str) -> Any:
-        """Obtains a record from the Dataset
+        """Obtains an entry from the Dataset
 
         Parameters
         ----------
@@ -449,7 +450,7 @@ class BaseProcedureDataset(Collection):
         Returns
         -------
         Record
-            The requested record
+            The requested entry.
         """
         try:
             return self.data.records[name.lower()]
@@ -478,7 +479,7 @@ class BaseProcedureDataset(Collection):
         if rec_id is None:
             raise KeyError(f"Could not find a record for ({name}: {specification}).")
 
-        return self.client._query_procedures(id=rec_id)[0]
+        return self._client._query_procedures(id=rec_id)[0]
 
     def compute(
         self, specification: str, subset: Set[str] = None, tag: Optional[str] = None, priority: Optional[str] = None
@@ -522,56 +523,55 @@ class BaseProcedureDataset(Collection):
 
         # Nothing to save
         if submitted:
-            self.save()
+            self.sync()
 
         return submitted
 
-    def query(self, specification: str, force: bool = False) -> pd.Series:
-        """Queries a given specification from the server
+    def _query(self, specification: str, series: bool = False, pad: int = 0) -> Union[Dict, pd.Series]:
+        """Queries a given specification from the server.
 
         Parameters
         ----------
         specification : str
-            The specification name to query
-        force : bool, optional
-            Force a fresh query if the specification already exists.
+            The specification name to query.
+        series : bool
+            If True, return a `pandas.Series`.
+        pad : int
+            Spaces to pad spec names in progress output
 
         Returns
         -------
-        pd.Series
-            Records collected from the server
+        Union[Dict, pd.Series]
+            Records collected from the server.
         """
-        # Try to get the specification, will throw if not found.
+        # Try to get the specification, will exception if not found.
         spec = self.get_specification(specification)
-
-        if not force and (spec.name in self.df):
-            return spec.name
 
         mapper = self._get_procedure_ids(spec.name)
         query_ids = list(mapper.values())
 
         # Chunk up the queries
         procedures: List[Dict[str, Any]] = []
-        for i in range(0, len(query_ids), self.client.query_limit):
-            chunk_ids = query_ids[i : i + self.client.query_limit]
-            procedures.extend(self.client._query_procedures(id=chunk_ids))
+        for i in tqdm(range(0, len(query_ids), self._client.query_limit),
+                desc="{} || {} ".format(specification.rjust(pad), self._client.address)):
+            chunk_ids = query_ids[i : i + self._client.query_limit]
+            procedures.extend(self._client._query_procedures(id=chunk_ids))
 
         proc_lookup = {x.id: x for x in procedures}
 
-        data = []
+        data = {}
         for name, oid in mapper.items():
             try:
-                data.append([name, proc_lookup[oid]])
+                data[name] = proc_lookup[oid]
             except KeyError:
-                data.append([name, None])
+                data[name] = None
 
-        df = pd.DataFrame(data, columns=["index", spec.name])
-        df.set_index("index", inplace=True)
+        if series:
+            return pd.Series(data)
+        else:
+            return data
 
-        self.df[spec.name] = df[spec.name]
-
-        return df[spec.name]
-
+    # TODO: make status stateless; no df manipulation
     def status(
         self,
         specs: Optional[Union[str, List[str]]] = None,
@@ -607,12 +607,6 @@ class BaseProcedureDataset(Collection):
             elif specs is None:
                 specs = self.list_specifications(description=False)
 
-            # Query all of the specs and make sure they are valid
-            # Specs may not be loaded to self.df yet. This can be accomplished
-            #     with self.query, which stores the info in self.df
-            for spec in specs:
-                self.query(spec)
-
             def get_status(item):
                 try:
                     return item.status.value
@@ -620,7 +614,7 @@ class BaseProcedureDataset(Collection):
                     return None
 
             # apply status by column then by row
-            df = self.df[specs].apply(lambda col: col.apply(get_status))
+            df = pd.DataFrame(self[specs]).apply(lambda col: col.apply(get_status))
 
             if status:
                 df = df[(df == status.upper()).all(axis=1)]
@@ -645,7 +639,7 @@ class BaseProcedureDataset(Collection):
 
         mapper = self._get_procedure_ids(specs)
         reverse_map = {v: k for k, v in mapper.items()}
-        procedures = self.client._query_procedures(id=list(mapper.values()))
+        procedures = self._client._query_procedures(id=list(mapper.values()))
 
         data = []
 

--- a/qcfractal/portal/collections/collection.py
+++ b/qcfractal/portal/collections/collection.py
@@ -582,8 +582,8 @@ class BaseProcedureDataset(Collection):
         self,
         specs: Optional[Union[str, List[str]]] = None,
         full: bool = False,
-        aslist: bool = False,
-        asdf: bool = False,
+        as_list: bool = False,
+        as_df: bool = False,
         status: Optional[Union[str, List[str]]] = None,
     ) -> Union[None, List]:
         """Print or return a status report for all existing compute specifications.
@@ -594,9 +594,9 @@ class BaseProcedureDataset(Collection):
             If given, only yield status of the listed compute specifications.
         full : bool, optional
             If True, expand to give status per entry.
-        aslist: bool, optional
+        as_list: bool, optional
             Return output as a list instead of printing.
-        asdf : bool, optional
+        as_df : bool, optional
             Return output as a `pandas` DataFrame instead of printing.
         status : Optional[Union[str, List[str]]], optional
             If not None, only returns results that match the provided statuses.
@@ -639,9 +639,9 @@ class BaseProcedureDataset(Collection):
             output.index.name = "status"
 
         # give representation
-        if not (aslist or asdf):
+        if not (as_list or as_df):
             print(tabulate(output.reset_index().to_dict("records"), headers="keys"))
-        elif aslist:
+        elif as_list:
             return output.reset_index().to_dict("records")
-        elif asdf:
+        elif as_df:
             return output

--- a/qcfractal/portal/collections/collection.py
+++ b/qcfractal/portal/collections/collection.py
@@ -11,6 +11,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from ...interface.models import ProtoModel
+from ...interface.models.records import RecordBase
 
 if TYPE_CHECKING:  # pragma: no cover
     from .. import PortalClient 
@@ -385,6 +386,9 @@ class BaseProcedureDataset(Collection):
 
     @property
     def entries(self):
+        """A dictionary with entry names as keys and entry content as values.
+
+        """
         return dict(self._data.records)
 
     def get_specification(self, name: str) -> Any:
@@ -575,93 +579,70 @@ class BaseProcedureDataset(Collection):
         else:
             return data
 
-    # TODO: make status stateless; no df manipulation
     def status(
         self,
         specs: Optional[Union[str, List[str]]] = None,
-        collapse: bool = True,
-        status: Optional[str] = None,
-        detail: bool = False,
-    ) -> pd.DataFrame:
-        """Return the status of all existing compute specifications.
+        full: bool = False,
+        aslist: bool = False,
+        asdf: bool = False,
+        status: Optional[Union[str, List[str]]] = None,
+    ) -> Union[None, List]:
+        """Print or return a status report for all existing compute specifications.
 
         Parameters
         ----------
         specs : Optional[Union[str, List[str]]]
             If given, only yield status of the listed compute specifications.
-        collapse : bool, optional
-            If True, collapse the status into summaries per specification.
-        status : Optional[str], optional
-            If not None, only returns results that match the provided status.
-        detail : bool, optional
-            Shows a detailed description of the current status of incomplete jobs.
+        full : bool, optional
+            If True, expand to give status per entry.
+        aslist: bool, optional
+            Return output as a list instead of printing.
+        asdf : bool, optional
+            Return output as a `pandas` DataFrame instead of printing.
+        status : Optional[Union[str, List[str]]], optional
+            If not None, only returns results that match the provided statuses.
 
         Returns
         -------
-        DataFrame
-            A DataFrame of all known statuses
+        Union[None, List]
+            Prints output as table to screen; if `aslist=True`,
+            returns list of output content instead.
 
         """
-        # Simple no detail case
-        if detail is False:
-            # detail = False can handle multiple specifications
-            # If specs is None, then use all (via list_specifications)
-            if isinstance(specs, str):
-                specs = [specs]
-            elif specs is None:
-                specs = self.list_specifications(description=False)
+        # TODO: consider instead creating a `status` REST API endpoint
+        # no real need for us to populate data objects to get this
+        from tabulate import tabulate
 
-            def get_status(item):
-                try:
-                    return item.status.value
-                except AttributeError:
-                    return None
+        # preprocess inputs
+        if specs is None:
+            specs = self.list_specifications(description=False)
+        elif isinstance(specs, str):
+            specs = [specs]
 
-            # apply status by column then by row
-            df = pd.DataFrame(self[specs]).apply(lambda col: col.apply(get_status))
+        if isinstance(status, str):
+            status = [status.lower()]
+        elif isinstance(status, list):
+            status = [s.lower() for s in status]
 
-            if status:
-                df = df[(df == status.upper()).all(axis=1)]
+        records = self[specs]
 
-            if collapse:
-                return df.apply(lambda x: x.value_counts())
-            else:
-                return df
+        status_data = pd.DataFrame(records).applymap(lambda x: x.status.value if isinstance(x, RecordBase) else None)
 
-        if status not in [None, "INCOMPLETE"]:
-            raise KeyError("Detailed status is only available for incomplete procedures.")
+        # apply filters
+        if status is not None:
+            status_data = status_data[status_data.applymap(lambda x: x in status).any(axis=0)]
 
-        # Can only do detailed status for a single spec
-        # If specs is a string, ok. If it is a list, then it should have length = 1
-        if not (isinstance(specs, str) or len(specs) == 1):
-            raise KeyError("Detailed status is only available for a single specification at a time.")
+        # apply transformations
+        if full:
+            output = status_data
+        else:
+            output = status_data.apply(lambda x: x.value_counts())
+            output.index.name = 'status'
 
-        # If specs is a list (of length = 1, checked above), then make it a string
-        # (_get_procedure_ids expects a string)
-        if not isinstance(specs, str):
-            specs = specs[0]
-
-        mapper = self._get_procedure_ids(specs)
-        reverse_map = {v: k for k, v in mapper.items()}
-        procedures = self._client._query_procedures(id=list(mapper.values()))
-
-        data = []
-
-        for proc in procedures:
-            if proc.status == "COMPLETE":
-                continue
-
-            try:
-                blob = proc.detailed_status()
-            except:
-                raise AttributeError("Detailed statuses are not available for this dataset type.")
-
-            blob["Name"] = reverse_map[proc.id]
-            data.append(blob)
-
-        df = pd.DataFrame(data)
-        df.rename(columns={x: x.replace("_", " ").title() for x in df.columns}, inplace=True)
-        if df.shape[0]:
-            df = df.set_index("Name")
-
-        return df
+        # give representation
+        if not (aslist or asdf):
+            print(tabulate(output.reset_index().to_dict('records'), headers='keys'))
+        elif aslist:
+            return output.reset_index().to_dict('records')
+        elif asdf:
+            return output

--- a/qcfractal/portal/collections/collection_utils.py
+++ b/qcfractal/portal/collections/collection_utils.py
@@ -19,8 +19,6 @@ def register_collection(collection: "Collection") -> None:
     """
 
     class_name = collection.__name__.lower()
-    # if class_name in __registered_collections:
-    #     raise KeyError("Collection type '{}' already registered".format(class_name))
     __registered_collections[class_name] = collection
 
 
@@ -32,16 +30,16 @@ def collection_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "
     data : Dict[str, Any]
         The JSON blob to create a new class from.
     client : PortalClient, optional
-        A PortalClient connected to a server
+        A PortalClient connected to a server.
 
     Returns
     -------
     Collection
-        A ODM of the data.
+        An object representation of the data.
 
     """
     if "collection" not in data:
-        raise KeyError("Attempted to create Collection from JSON, but no `collection` field found.")
+        raise KeyError("Attempted to create Collection from data, but no `collection` field found.")
 
     if data["collection"].lower() not in __registered_collections:
         raise KeyError("Attempted to create Collection of unknown type '{}'.".format(data["collection"]))

--- a/qcfractal/portal/collections/collection_utils.py
+++ b/qcfractal/portal/collections/collection_utils.py
@@ -25,7 +25,7 @@ def register_collection(collection: "Collection") -> None:
 
 
 def collection_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "Collection":
-    """Creates a new Collection class from a JSON blob.
+    """Returns a Collection object from data deserialized from JSON.
 
     Parameters
     ----------

--- a/qcfractal/portal/collections/collection_utils.py
+++ b/qcfractal/portal/collections/collection_utils.py
@@ -1,0 +1,61 @@
+"""
+A set of utility functions to help the Collections
+"""
+
+import math
+from typing import Any, Dict, List
+
+__registered_collections = {}
+
+
+def register_collection(collection: "Collection") -> None:
+    """Registers a collection for use by the factory.
+
+    Parameters
+    ----------
+    collection : Collection
+        The Collection class to be registered
+
+    """
+
+    class_name = collection.__name__.lower()
+    # if class_name in __registered_collections:
+    #     raise KeyError("Collection type '{}' already registered".format(class_name))
+    __registered_collections[class_name] = collection
+
+
+def collection_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "Collection":
+    """Creates a new Collection class from a JSON blob.
+
+    Parameters
+    ----------
+    data : Dict[str, Any]
+        The JSON blob to create a new class from.
+    client : PortalClient, optional
+        A PortalClient connected to a server
+
+    Returns
+    -------
+    Collection
+        A ODM of the data.
+
+    """
+    if "collection" not in data:
+        raise KeyError("Attempted to create Collection from JSON, but no `collection` field found.")
+
+    if data["collection"].lower() not in __registered_collections:
+        raise KeyError("Attempted to create Collection of unknown type '{}'.".format(data["collection"]))
+
+    return __registered_collections[data["collection"].lower()].from_json(data, client=client)
+
+
+def collections_name_map() -> Dict[str, str]:
+    """
+    Returns a map of internal name to external Collection name.
+
+    Returns
+    -------
+    Dict[str, str]
+        Map of {'internal': 'user fiendly name'}
+    """
+    return {k: v.__name__ for k, v in __registered_collections.items()}

--- a/qcfractal/portal/collections/collection_utils.py
+++ b/qcfractal/portal/collections/collection_utils.py
@@ -44,7 +44,7 @@ def collection_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "
     if data["collection"].lower() not in __registered_collections:
         raise KeyError("Attempted to create Collection of unknown type '{}'.".format(data["collection"]))
 
-    return __registered_collections[data["collection"].lower()].from_json(data, client=client)
+    return __registered_collections[data["collection"].lower()].from_dict(data, client=client)
 
 
 def collections_name_map() -> Dict[str, str]:

--- a/qcfractal/portal/collections/dataset.py
+++ b/qcfractal/portal/collections/dataset.py
@@ -1,0 +1,1747 @@
+"""
+QCPortal Database ODM
+"""
+import gzip
+import tempfile
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+
+import numpy as np
+import pandas as pd
+import requests
+from pydantic import Field, validator
+from qcelemental import constants
+from qcelemental.models.types import Array
+from tqdm import tqdm
+
+from ..models import Citation, ComputeResponse, ObjectId, ProtoModel
+from ..statistics import wrap_statistics
+from ..visualization import bar_plot, violin_plot
+from .collection import Collection
+from .collection_utils import composition_planner, register_collection
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .. import FractalClient
+    from ..models import KeywordSet, Molecule, ResultRecord
+    from . import DatasetView
+
+
+class MoleculeEntry(ProtoModel):
+    name: str = Field(..., description="The name of entry.")
+    molecule_id: ObjectId = Field(..., description="The id of the Molecule the entry references.")
+    comment: Optional[str] = Field(None, description="A comment for the entry")
+    local_results: Dict[str, Any] = Field({}, description="Additional local values.")
+
+
+class ContributedValues(ProtoModel):
+    name: str = Field(..., description="The name of the contributed values.")
+    values: Any = Field(..., description="The values in the contributed values.")
+    index: Array[str] = Field(
+        ..., description="The entry index for the contributed values, matches the order of the `values` array."
+    )
+    values_structure: Dict[str, Any] = Field(
+        {}, description="A machine readable description of the values structure. Typically not needed."
+    )
+
+    theory_level: Union[str, Dict[str, str]] = Field(..., description="A string representation of the theory level.")
+    units: str = Field(..., description="The units of the values, can be any valid QCElemental unit.")
+    theory_level_details: Optional[Union[str, Dict[str, Optional[str]]]] = Field(
+        None, description="A detailed reprsentation of the theory level."
+    )
+
+    citations: Optional[List[Citation]] = Field(None, description="Citations associated with the contributed values.")
+    external_url: Optional[str] = Field(None, description="An external URL to the raw contributed values data.")
+    doi: Optional[str] = Field(None, description="A DOI for the contributed values data.")
+
+    comments: Optional[str] = Field(None, description="Additional comments about the contributed values")
+
+    @validator("values")
+    def _make_array(cls, v):
+        if isinstance(v, (list, tuple)) and isinstance(v[0], (float, int, str, bool)):
+            v = np.array(v)
+
+        return v
+
+
+class Dataset(Collection):
+    """
+    The Dataset class for homogeneous computations on many molecules.
+
+    Attributes
+    ----------
+    client : client.FractalClient
+        A FractalClient connected to a server
+    data : dict
+        JSON representation of the database backbone
+    df : pd.DataFrame
+        The underlying dataframe for the Dataset object
+    """
+
+    def __init__(self, name: str, client: Optional["FractalClient"] = None, **kwargs: Any) -> None:
+        """
+        Initializer for the Dataset object. If no Portal is supplied or the database name
+        is not present on the server that the Portal is connected to a blank database will be
+        created.
+
+        Parameters
+        ----------
+        name : str
+            The name of the Dataset
+        client : Optional['FractalClient'], optional
+            A Portal client to connected to a server
+        **kwargs : Dict[str, Any]
+            Additional kwargs to pass to the collection
+        """
+        super().__init__(name, client=client, **kwargs)
+
+        self._units = self.data.default_units
+
+        # If we making a new database we may need new hashes and json objects
+        self._new_molecules: Dict[str, Molecule] = {}
+        self._new_keywords: Dict[Tuple[str, str], KeywordSet] = {}
+        self._new_records: List[Dict[str, Any]] = []
+        self._updated_state = False
+
+        self._view: Optional[DatasetView] = None
+        if self.data.view_available:
+            from . import RemoteView
+
+            self._view = RemoteView(client, self.data.id)
+        self._disable_view: bool = False  # for debugging and testing
+        self._disable_query_limit: bool = False  # for debugging and testing
+
+        # Initialize internal data frames and load in contrib
+        self.df = pd.DataFrame()
+        self._column_metadata: Dict[str, Any] = {}
+
+        # If this is a brand new dataset, initialize the records and cv fields
+        if self.data.id == "local":
+            if self.data.records is None:
+                self.data.__dict__["records"] = []
+            if self.data.contributed_values is None:
+                self.data.__dict__["contributed_values"] = {}
+
+    class DataModel(Collection.DataModel):
+
+        # Defaults
+        default_program: Optional[str] = None
+        default_keywords: Dict[str, str] = {}
+        default_driver: str = "energy"
+        default_units: str = "kcal / mol"
+        default_benchmark: Optional[str] = None
+
+        alias_keywords: Dict[str, Dict[str, str]] = {}
+
+        # Data
+        records: Optional[List[MoleculeEntry]] = None
+        contributed_values: Dict[str, ContributedValues] = None
+
+        # History: driver, program, method (basis, keywords)
+        history: Set[Tuple[str, str, str, Optional[str], Optional[str]]] = set()
+        history_keys: Tuple[str, str, str, str, str] = ("driver", "program", "method", "basis", "keywords")
+
+    def set_view(self, path: Union[str, Path]) -> None:
+        """
+        Set a dataset to use a local view.
+
+        Parameters
+        ----------
+        path: Union[str, Path]
+            path to an hdf5 file representing a view for this dataset
+        """
+        from . import HDF5View
+
+        self._view = HDF5View(path)
+
+    def download(
+        self, local_path: Optional[Union[str, Path]] = None, verify: bool = True, progress_bar: bool = True
+    ) -> None:
+        """
+        Download a remote view if available. The dataset will use this view to avoid server queries for calls to:
+        - get_entries
+        - get_molecules
+        - get_values
+        - list_values
+
+        Parameters
+        ----------
+        local_path: Optional[Union[str, Path]], optional
+            Local path the store downloaded view. If None, the view will be stored in a temporary file and deleted on exit.
+        verify: bool, optional
+            Verify download checksum. Default: True.
+        progress_bar: bool, optional
+            Display a download progress bar. Default: True
+        """
+        chunk_size = 8192
+        if self.data.view_url_hdf5 is None:
+            raise ValueError("A view for this dataset is not available on the server")
+
+        if local_path is not None:
+            local_path = Path(local_path)
+        else:
+            self._view_tempfile = tempfile.NamedTemporaryFile()  # keep temp file alive until self is destroyed
+            local_path = self._view_tempfile.name
+
+        r = requests.get(self.data.view_url_hdf5, stream=True)
+        pbar = None
+        if progress_bar:
+            try:
+                file_length = int(r.headers.get("content-length"))
+                pbar = tqdm(total=file_length, initial=0, unit="B", unit_scale=True)
+            except Exception:
+                warnings.warn("Failed to create download progress bar", RuntimeWarning)
+
+        with open(local_path, "wb") as fd:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                fd.write(chunk)
+                if pbar is not None:
+                    pbar.update(chunk_size)
+
+        with open(local_path, "rb") as f:
+            magic = f.read(2)
+            gzipped = magic == b"\x1f\x8b"
+        if gzipped:
+            extract_tempfile = tempfile.NamedTemporaryFile()  # keep temp file alive until self is destroyed
+            with gzip.open(local_path, "rb") as fgz:
+                with open(extract_tempfile.name, "wb") as f:
+                    f.write(fgz.read())
+            self._view_tempfile = extract_tempfile
+            local_path = self._view_tempfile.name
+
+        if verify:
+            remote_checksum = self.data.view_metadata["blake2b_checksum"]
+            from . import HDF5View
+
+            local_checksum = HDF5View(local_path).hash()
+            if remote_checksum != local_checksum:
+                raise ValueError(f"Checksum verification failed. Expected: {remote_checksum}, Got: {local_checksum}")
+
+        self.set_view(local_path)
+
+    def to_file(self, path: Union[str, Path], encoding: str) -> None:
+        """
+        Writes a view of the dataset to a file
+
+        Parameters
+        ----------
+        path: Union[str, Path]
+            Where to write the file
+        encoding: str
+            Options: plaintext, hdf5
+        """
+        if encoding.lower() == "plaintext":
+            from . import PlainTextView
+
+            PlainTextView(path).write(self)
+        elif encoding.lower() in ["hdf5", "h5"]:
+            from . import HDF5View
+
+            HDF5View(path).write(self)
+        else:
+            raise NotImplementedError(f"Unsupported encoding: {encoding}")
+
+    def _get_data_records_from_db(self):
+        self._check_client()
+        # This is hacky. What we want to do is get records and contributed values correctly unpacked into pydantic
+        # objects. So what we do is call get_collection with include. But we have to also include collection and
+        # name in the query because they are required in the collection DataModel. But we can use these to check that
+        # we got back the right data, so that's nice.
+        response = self.client.get_collection(
+            self.__class__.__name__.lower(),
+            self.name,
+            full_return=False,
+            include=["records", "contributed_values", "collection", "name", "id"],
+        )
+        if not (response.data.id == self.data.id and response.data.name == self.name):
+            raise ValueError("Got the wrong records and contributed values from the server.")
+        # This works because get_collection builds a validated Dataset object
+        self.data.__dict__["records"] = response.data.records
+        self.data.__dict__["contributed_values"] = response.data.contributed_values
+
+    def _entry_index(self, subset: Optional[List[str]] = None) -> pd.DataFrame:
+        # TODO: make this fast for subsets
+        if self.data.records is None:
+            self._get_data_records_from_db()
+
+        ret = pd.DataFrame(
+            [[entry.name, entry.molecule_id] for entry in self.data.records], columns=["name", "molecule_id"]
+        )
+        if subset is None:
+            return ret
+        else:
+            return ret.reset_index().set_index("name").loc[subset].reset_index().set_index("index")
+
+    def _check_state(self) -> None:
+        if self._new_molecules or self._new_keywords or self._new_records or self._updated_state:
+            raise ValueError("New molecules, keywords, or records detected, run save before submitting new tasks.")
+
+    def _canonical_pre_save(self, client: "FractalClient") -> None:
+        self._ensure_contributed_values()
+        if self.data.records is None:
+            self._get_data_records_from_db()
+        for k in list(self._new_keywords.keys()):
+            ret = client.add_keywords([self._new_keywords[k]])
+            assert len(ret) == 1, "KeywordSet added incorrectly"
+            self.data.alias_keywords[k[0]][k[1]] = ret[0]
+            del self._new_keywords[k]
+        self._updated_state = False
+
+    def _pre_save_prep(self, client: "FractalClient") -> None:
+        self._canonical_pre_save(client)
+
+        # Preps any new molecules introduced to the Dataset before storing data.
+        mol_ret = self._add_molecules_by_dict(client, self._new_molecules)
+
+        # Update internal molecule UUID's to servers UUID's
+        for record in self._new_records:
+            molecule_hash = record.pop("molecule_hash")
+            new_record = MoleculeEntry(molecule_id=mol_ret[molecule_hash], **record)
+            self.data.records.append(new_record)
+
+        self._new_records = []
+        self._new_molecules = {}
+
+    def get_entries(self, subset: Optional[List[str]] = None, force: bool = False) -> pd.DataFrame:
+        """
+        Provides a list of entries for the dataset
+
+        Parameters
+        ----------
+        subset: Optional[List[str]], optional
+            The indices of the desired subset. Return all indices if subset is None.
+        force: bool, optional
+            skip cache
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe containing entry names and specifciations.
+            For Dataset, specifications are molecule ids.
+            For ReactionDataset, specifications describe reaction stoichiometry.
+        """
+        if self._use_view(force):
+            ret = self._view.get_entries(subset)
+        else:
+            ret = self._entry_index(subset)
+        return ret.copy()
+
+    def _molecule_indexer(
+        self, subset: Optional[Union[str, Set[str]]] = None, force: bool = False
+    ) -> Dict[str, ObjectId]:
+        """Provides a {index: molecule_id} mapping for a given subset.
+
+        Parameters
+        ----------
+        subset : Optional[Union[str, Set[str]]], optional
+            The indices of the desired subset. Return all indices if subset is None.
+
+        Returns
+        -------
+        Dict[str, 'ObjectId']
+            Molecule index to molecule ObjectId map
+        """
+        if subset:
+            if isinstance(subset, str):
+                subset = {subset}
+        index = self.get_entries(force=force, subset=subset)
+        # index = index[index.name.isin(subset)]
+
+        return {row["name"]: row["molecule_id"] for row in index.to_dict("records")}
+
+    def _add_history(self, **history: Optional[str]) -> None:
+        """
+        Adds compute history to the dataset
+        """
+        if history.keys() != set(self.data.history_keys):
+            raise KeyError("Internal error: Incorrect history keys passed in.")
+
+        new_history = []
+        for key in self.data.history_keys:
+
+            value = history[key]
+            if value is not None:
+                value = value.lower()
+
+            new_history.append(value)
+
+        self.data.history.add(tuple(new_history))
+
+    def list_values(
+        self,
+        method: Optional[Union[str, List[str]]] = None,
+        basis: Optional[Union[str, List[str]]] = None,
+        keywords: Optional[str] = None,
+        program: Optional[str] = None,
+        driver: Optional[str] = None,
+        name: Optional[Union[str, List[str]]] = None,
+        native: Optional[bool] = None,
+        force: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Lists available data that may be queried with get_values.
+        Results may be narrowed by providing search keys.
+        `None` is a wildcard selector. To search for `None`, use `"None"`.
+
+        Parameters
+        ----------
+        method : Optional[Union[str, List[str]]], optional
+            The computational method (B3LYP)
+        basis : Optional[Union[str, List[str]]], optional
+            The computational basis (6-31G)
+        keywords : Optional[str], optional
+            The keyword alias
+        program : Optional[str], optional
+            The underlying QC program
+        driver : Optional[str], optional
+            The type of calculation (e.g. energy, gradient, hessian, dipole...)
+        name : Optional[Union[str, List[str]]], optional
+            The canonical name of the data column
+        native: Optional[bool], optional
+            True: only include data computed with QCFractal
+            False: only include data contributed from outside sources
+            None: include both
+        force : bool, optional
+            Data is typically cached, forces a new query if True
+
+        Returns
+        -------
+        DataFrame
+            A DataFrame of the matching data specifications
+        """
+        spec: Dict[str, Optional[Union[str, bool, List[str]]]] = {
+            "method": method,
+            "basis": basis,
+            "keywords": keywords,
+            "program": program,
+            "name": name,
+            "driver": driver,
+        }
+
+        if self._use_view(force):
+            ret = self._view.list_values()
+            spec["native"] = native
+        else:
+            ret = []
+            if native in {True, None}:
+                df = self._list_records(dftd3=False)
+                df["native"] = True
+                ret.append(df)
+
+            if native in {False, None}:
+                df = self._list_contributed_values()
+                df["native"] = False
+                ret.append(df)
+
+            ret = pd.concat(ret)
+
+        # Filter
+        ret.fillna("None", inplace=True)
+        ret = self._filter_records(ret, **spec)
+
+        # Sort
+        sort_index = ["native"] + list(self.data.history_keys[:-1])
+        if "stoichiometry" in ret.columns:
+            sort_index += ["stoichiometry", "name"]
+        ret.set_index(sort_index, inplace=True)
+        ret.sort_index(inplace=True)
+        ret.reset_index(inplace=True)
+        ret.set_index(["native"] + list(self.data.history_keys[:-1]), inplace=True)
+
+        return ret
+
+    @staticmethod
+    def _filter_records(
+        df: pd.DataFrame, **spec: Optional[Union[str, bool, List[Union[str, bool]], Tuple]]
+    ) -> pd.DataFrame:
+        """
+        Helper for filtering records on a spec. Note that `None` is a wildcard while `"None"` matches `None` and NaN.
+        """
+        ret = df.copy()
+
+        if len(ret) == 0:  # workaround pandas empty dataframe sharp edges
+            return ret
+
+        for key, value in spec.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                ret = ret[ret[key] == value]
+            elif isinstance(value, str):
+                value = value.lower()
+                ret = ret[ret[key].fillna("None").str.lower() == value]
+            elif isinstance(value, (list, tuple)):
+                query = [x.lower() for x in value]
+                ret = ret[ret[key].fillna("None").str.lower().isin(query)]
+            else:
+                raise TypeError(f"Search type {type(value)} not understood.")
+        return ret
+
+    def list_records(
+        self, dftd3: bool = False, pretty: bool = True, **search: Optional[Union[str, List[str]]]
+    ) -> pd.DataFrame:
+        """
+        Lists specifications of available records, i.e. method, program, basis set, keyword set, driver combinations
+        `None` is a wildcard selector. To search for `None`, use `"None"`.
+
+        Parameters
+        ----------
+        pretty: bool
+            Replace NaN with "None" in returned DataFrame
+        **search : Dict[str, Optional[str]]
+            Allows searching to narrow down return.
+
+        Returns
+        -------
+        DataFrame
+            Record specifications matching **search.
+
+        """
+        ret = self._list_records(dftd3=dftd3)
+        ret = self._filter_records(ret, **search)
+        if pretty:
+            ret.fillna("None", inplace=True)
+        return ret
+
+    def _list_records(self, dftd3: bool = False) -> pd.DataFrame:
+        """
+        Lists specifications of available records, i.e. method, program, basis set, keyword set, driver combinations
+        `None` is a wildcard selector. To search for `None`, use `"None"`.
+
+        Parameters
+        ----------
+        dftd3: bool, optional
+            Include dftd3 program record specifications in addition to composite DFT-D3 record specifications
+
+        Returns
+        -------
+        DataFrame
+            Record specifications matching **search.
+
+        """
+        show_dftd3 = dftd3
+
+        history = pd.DataFrame(list(self.data.history), columns=self.data.history_keys)
+
+        # Short circuit because merge and apply below require data
+        if history.shape[0] == 0:
+            ret = history.copy()
+            ret["name"] = None
+            return ret
+
+        # Build out -D3 combos
+        dftd3 = history[history["program"] == "dftd3"].copy()
+        dftd3["base"] = [x.split("-d3")[0] for x in dftd3["method"]]
+
+        nondftd3 = history[history["program"] != "dftd3"]
+        dftd3combo = nondftd3.merge(dftd3[["method", "base"]], left_on="method", right_on="base")
+        dftd3combo["method"] = dftd3combo["method_y"]
+        dftd3combo.drop(["method_x", "method_y", "base"], axis=1, inplace=True)
+
+        history = pd.concat([history, dftd3combo], sort=False)
+        history = history.reset_index()
+        history.drop("index", axis=1, inplace=True)
+
+        # Drop duplicates due to stoich in some instances, this could be handled with multiple merges
+        # Simpler to do it this way.
+        history.drop_duplicates(inplace=True)
+
+        # Find the returned subset
+        ret = history.copy()
+
+        # Add name column
+        ret["name"] = ret.apply(
+            lambda row: self._canonical_name(
+                program=row["program"],
+                method=row["method"],
+                basis=row["basis"],
+                keywords=row["keywords"],
+                stoich=row.get("stoichiometry", None),
+                driver=row["driver"],
+            ),
+            axis=1,
+        )
+        if show_dftd3 is False:
+            ret = ret[ret["program"] != "dftd3"]
+
+        return ret
+
+    def get_values(
+        self,
+        method: Optional[Union[str, List[str]]] = None,
+        basis: Optional[Union[str, List[str]]] = None,
+        keywords: Optional[str] = None,
+        program: Optional[str] = None,
+        driver: Optional[str] = None,
+        name: Optional[Union[str, List[str]]] = None,
+        native: Optional[bool] = None,
+        subset: Optional[Union[str, List[str]]] = None,
+        force: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Obtains values matching the search parameters provided for the expected `return_result` values.
+        Defaults to the standard programs and keywords if not provided.
+
+        Note that unlike `get_records`, `get_values` will automatically expand searches and return multiple method
+        and basis combinations simultaneously.
+
+        `None` is a wildcard selector. To search for `None`, use `"None"`.
+
+        Parameters
+        ----------
+        method : Optional[Union[str, List[str]]], optional
+            The computational method (B3LYP)
+        basis : Optional[Union[str, List[str]]], optional
+            The computational basis (6-31G)
+        keywords : Optional[str], optional
+            The keyword alias
+        program : Optional[str], optional
+            The underlying QC program
+        driver : Optional[str], optional
+            The type of calculation (e.g. energy, gradient, hessian, dipole...)
+        name : Optional[Union[str, List[str]]], optional
+            Canonical name of the record. Overrides the above selectors.
+        native: Optional[bool], optional
+            True: only include data computed with QCFractal
+            False: only include data contributed from outside sources
+            None: include both
+        subset: Optional[List[str]], optional
+            The indices of the desired subset. Return all indices if subset is None.
+        force : bool, optional
+            Data is typically cached, forces a new query if True
+
+        Returns
+        -------
+        DataFrame
+            A DataFrame of values with columns corresponding to methods and rows corresponding to molecule entries.
+        """
+        return self._get_values(
+            method=method,
+            basis=basis,
+            keywords=keywords,
+            program=program,
+            driver=driver,
+            name=name,
+            native=native,
+            subset=subset,
+            force=force,
+        )
+
+    def _get_values(
+        self,
+        native: Optional[bool] = None,
+        force: bool = False,
+        subset: Optional[Union[str, List[str]]] = None,
+        **spec: Union[List[str], str, None],
+    ) -> pd.DataFrame:
+        ret = []
+
+        if subset is None:
+            subset_set = set(self.get_index(force=force))
+        elif isinstance(subset, str):
+            subset_set = {subset}
+        elif isinstance(subset, list):
+            subset_set = set(subset)
+        else:
+            raise ValueError(f"Subset must be str, List[str], or None. Got {type(subset)}")
+
+        if native in {True, None}:
+            spec_nodriver = spec.copy()
+            driver = spec_nodriver.pop("driver")
+            if driver is not None and driver != self.data.default_driver:
+                raise KeyError(
+                    f"For native values, driver ({driver}) must be the same as the dataset's default driver "
+                    f"({self.data.default_driver}). Consider using get_records instead."
+                )
+            df = self._get_native_values(subset=subset_set, force=force, **spec_nodriver)
+            ret.append(df)
+
+        if native in {False, None}:
+            df = self._get_contributed_values(subset=subset_set, force=force, **spec)
+            ret.append(df)
+        ret_df = pd.concat(ret, axis=1)
+        ret_df = ret_df.loc[subset if subset is not None else self.get_index()]
+
+        return ret_df
+
+    def _get_native_values(
+        self,
+        subset: Set[str],
+        method: Optional[Union[str, List[str]]] = None,
+        basis: Optional[Union[str, List[str]]] = None,
+        keywords: Optional[str] = None,
+        program: Optional[str] = None,
+        name: Optional[Union[str, List[str]]] = None,
+        force: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Obtains records matching the provided search criteria.
+        Defaults to the standard programs and keywords if not provided.
+
+        Parameters
+        ----------
+        subset: Set[str]
+            The indices of the desired subset.
+        method : Optional[Union[str, List[str]]], optional
+            The computational method to compute (B3LYP)
+        basis : Optional[Union[str, List[str]]], optional
+            The computational basis to compute (6-31G)
+        keywords : Optional[str], optional
+            The keyword alias for the requested compute
+        program : Optional[str], optional
+            The underlying QC program
+        name : Optional[Union[str, List[str]]], optional
+            Canonical name of the record. Overrides the above selectors.
+        force : bool, optional
+            Data is typically cached, forces a new query if True.
+
+        Returns
+        -------
+        DataFrame
+            A DataFrame of the queried parameters
+        """
+        au_units = {"energy": "hartree", "gradient": "hartree/bohr", "hessian": "hartree/bohr**2"}
+
+        # So that datasets with no records do not require a default program and default keywords
+        if len(self.list_records()) == 0:
+            return pd.DataFrame(index=self.get_index(subset))
+
+        queries = self._form_queries(method=method, basis=basis, keywords=keywords, program=program, name=name)
+        names = []
+        new_queries = []
+        for _, query in queries.iterrows():
+
+            query = query.replace({np.nan: None}).to_dict()
+            if "stoichiometry" in query:
+                query["stoich"] = query.pop("stoichiometry")
+
+            qname = query["name"]
+            names.append(qname)
+            if force or not self._subset_in_cache(qname, subset):
+                self._column_metadata[qname] = query
+                new_queries.append(query)
+
+        new_data = pd.DataFrame(index=subset)
+
+        if not self._use_view(force):
+            units: Dict[str, str] = {}
+            for query in new_queries:
+                driver = query.pop("driver")
+                qname = query.pop("name")
+                data = self.get_records(
+                    query.pop("method").upper(), include=["return_result"], merge=True, subset=subset, **query
+                )
+                new_data[qname] = data["return_result"]
+                units[qname] = au_units[driver]
+                query["name"] = qname
+        else:
+            for query in new_queries:
+                query["native"] = True
+            new_data, units = self._view.get_values(new_queries, subset)
+
+        for query in new_queries:
+            qname = query["name"]
+            new_data[qname] *= constants.conversion_factor(units[qname], self.units)
+            self._column_metadata[qname].update({"native": True, "units": self.units})
+
+        self._update_cache(new_data)
+        return self.df.loc[subset, names]
+
+    def _form_queries(
+        self,
+        method: Optional[Union[str, List[str]]] = None,
+        basis: Optional[Union[str, List[str]]] = None,
+        keywords: Optional[str] = None,
+        program: Optional[str] = None,
+        stoich: Optional[str] = None,
+        name: Optional[Union[str, List[str]]] = None,
+    ) -> pd.DataFrame:
+        if name is None:
+            _, _, history = self._default_parameters(program, "nan", "nan", keywords, stoich=stoich)
+            for k, v in [("method", method), ("basis", basis)]:
+
+                if v is not None:
+                    history[k] = v
+                else:
+                    history.pop(k, None)
+            queries = self.list_records(**history, dftd3=True, pretty=False)
+        else:
+            if any((field is not None for field in {program, method, basis, keywords})):
+                warnings.warn(
+                    "Name and additional field were provided. Only name will be used as a selector.", RuntimeWarning
+                )
+            queries = self.list_records(name=name, dftd3=True, pretty=False)
+
+        if queries.shape[0] > 10 and self._disable_query_limit is False:
+            raise TypeError("More than 10 queries formed, please narrow the search.")
+        return queries
+
+    def _visualize(
+        self,
+        metric,
+        bench,
+        query: Dict[str, Union[Optional[str], List[str]]],
+        groupby: Optional[str] = None,
+        return_figure=None,
+        digits=3,
+        kind="bar",
+        show_incomplete: bool = False,
+    ) -> "plotly.Figure":
+
+        # Validate query dimensions
+        list_queries = [k for k, v in query.items() if isinstance(v, (list, tuple))]
+        if len(list_queries) > 2:
+            raise TypeError("A maximum of two lists are allowed.")
+
+        # Check kind
+        kind = kind.lower()
+        if kind not in ["bar", "violin"]:
+            raise KeyError(f"Visualiztion kind must either be 'bar' or 'violin', found {kind}")
+
+        # Check metric
+        metric = metric.upper()
+        if metric == "UE":
+            ylabel = f"UE [{self.units}]"
+        elif metric == "URE":
+            ylabel = "URE [%]"
+        else:
+            raise KeyError('Metric {} not understood, available metrics: "UE", "URE"'.format(metric))
+
+        if kind == "bar":
+            ylabel = "M" + ylabel
+            metric = "M" + metric
+
+        # Are we a groupby?
+        _valid_groupby = {"method", "basis", "keywords", "program", "stoich", "d3"}
+        if groupby is not None:
+            groupby = groupby.lower()
+            if groupby not in _valid_groupby:
+                raise KeyError(f"Groupby option {groupby} not understood.")
+            if (groupby != "d3") and (groupby not in query):
+                raise KeyError(f"Groupby option {groupby} not found in query, must provide a search on this parameter.")
+
+            if (groupby != "d3") and (not isinstance(query[groupby], (tuple, list))):
+                raise KeyError(f"Groupby option {groupby} must be a list.")
+
+            query_names = []
+            queries = []
+            if groupby == "d3":
+                base = [method.upper().split("-D3")[0] for method in query["method"]]
+                d3types = [method.upper().replace(b, "").replace("-D", "D") for method, b in zip(query["method"], base)]
+
+                # Preserve order of first unique appearance
+                seen: Set[str] = set()
+                unique_d3types = [x for x in d3types if not (x in seen or seen.add(x))]
+
+                for d3type in unique_d3types:
+                    gb_query = query.copy()
+                    gb_query["method"] = []
+                    for i in range(len(base)):
+                        method = query["method"][i]
+                        if method.upper().replace(base[i], "").replace("-D", "D") == d3type:
+                            gb_query["method"].append(method)
+                    queries.append(gb_query)
+                    if d3type == "":
+                        query_names.append("No -D3")
+                    else:
+                        query_names.append(d3type.upper())
+            else:
+                for gb in query[groupby]:
+                    gb_query = query.copy()
+                    gb_query[groupby] = gb
+
+                    queries.append(gb_query)
+                    query_names.append(self._canonical_name(**{groupby: gb}))
+
+            if (kind == "violin") and (len(queries) != 2):
+                raise KeyError(f"Groupby option for violin plots must have two entries.")
+
+        else:
+            queries = [query]
+            query_names = ["Stats"]
+
+        title = f"{self.data.name} Dataset Statistics"
+
+        series = []
+        for q, name in zip(queries, query_names):
+
+            if len(q) == 0:
+                raise KeyError("No query matches, nothing to visualize!")
+
+            # Pull the values
+            if "stoichiometry" in q:
+                q["stoich"] = q.pop("stoichiometry")
+            values = self.get_values(**q)
+
+            if not show_incomplete:
+                values = values.dropna(axis=1, how="any")
+
+            # Create the statistics
+            stat = self.statistics(metric, values, bench=bench)
+            stat = stat.round(digits)
+            stat.sort_index(inplace=True)
+            stat.name = name
+
+            # Munge the column names based on the groupby parameter
+            col_names = {}
+            for k, v in stat.iteritems():
+                record = self._column_metadata[k].copy()
+                if groupby == "d3":
+                    record["method"] = record["method"].upper().split("-D3")[0]
+
+                elif groupby:
+                    record[groupby] = None
+
+                index_name = self._canonical_name(
+                    record["program"],
+                    record["method"],
+                    record["basis"],
+                    record["keywords"],
+                    stoich=record.get("stoich"),
+                )
+
+                col_names[k] = index_name
+
+            if kind == "bar":
+                stat.index = [col_names[x] for x in stat.index]
+            else:
+                stat.columns = [col_names[x] for x in stat.columns]
+
+            series.append(stat)
+
+        if kind == "bar":
+            return bar_plot(series, title=title, ylabel=ylabel, return_figure=return_figure)
+        else:
+            negative = None
+            if groupby:
+                negative = series[1]
+
+            return violin_plot(series[0], negative=negative, title=title, ylabel=ylabel, return_figure=return_figure)
+
+    def visualize(
+        self,
+        method: Optional[str] = None,
+        basis: Optional[str] = None,
+        keywords: Optional[str] = None,
+        program: Optional[str] = None,
+        groupby: Optional[str] = None,
+        metric: str = "UE",
+        bench: Optional[str] = None,
+        kind: str = "bar",
+        return_figure: Optional[bool] = None,
+        show_incomplete: bool = False,
+    ) -> "plotly.Figure":
+        """
+        Parameters
+        ----------
+        method : Optional[str], optional
+            Methods to query
+        basis : Optional[str], optional
+            Bases to query
+        keywords : Optional[str], optional
+            Keyword aliases to query
+        program : Optional[str], optional
+            Programs aliases to query
+        groupby : Optional[str], optional
+            Groups the plot by this index.
+        metric : str, optional
+            The metric to use either UE (unsigned error) or URE (unsigned relative error)
+        bench : Optional[str], optional
+            The benchmark level of theory to use
+        kind : str, optional
+            The kind of chart to produce, either 'bar' or 'violin'
+        return_figure : Optional[bool], optional
+            If True, return the raw plotly figure. If False, returns a hosted iPlot.
+            If None, return a iPlot display in Jupyter notebook and a raw plotly figure in all other circumstances.
+        show_incomplete: bool, optional
+            Display statistics method/basis set combinations where results are incomplete
+
+        Returns
+        -------
+        plotly.Figure
+            The requested figure.
+        """
+
+        query = {"method": method, "basis": basis, "keywords": keywords, "program": program}
+        query = {k: v for k, v in query.items() if v is not None}
+
+        return self._visualize(metric, bench, query=query, groupby=groupby, return_figure=return_figure, kind=kind)
+
+    def _canonical_name(
+        self,
+        program: Optional[str] = None,
+        method: Optional[str] = None,
+        basis: Optional[str] = None,
+        keywords: Optional[str] = None,
+        stoich: Optional[str] = None,
+        driver: Optional[str] = None,
+    ) -> str:
+        """
+        Attempts to build a canonical name for a DataFrame column
+        """
+
+        name = ""
+        if method:
+            name = method.upper()
+
+        if basis and name:
+            name = f"{name}/{basis.lower()}"
+        elif basis:
+            name = f"{basis.lower()}"
+
+        if keywords and (keywords != self.data.default_keywords.get(program, None)):
+            name = f"{name}-{keywords}"
+
+        if program and (program.lower() != self.data.default_program):
+            name = f"{name}-{program.title()}"
+
+        if stoich:
+            if name == "":
+                name = stoich.lower()
+            elif stoich.lower() != "default":
+                name = f"{stoich.lower()}-{name}"
+
+        return name
+
+    def _default_parameters(
+        self,
+        program: Optional[str],
+        method: str,
+        basis: Optional[str],
+        keywords: Optional[str],
+        stoich: Optional[str] = None,
+    ) -> Tuple[str, Dict[str, Union[str, "KeywordSet"]], Dict[str, str]]:
+        """
+        Takes raw input parsed parameters and applies defaults to them.
+        """
+
+        # Handle default program
+        if program is None:
+            if self.data.default_program is None:
+                raise KeyError("No default program was set and none was provided.")
+            program = self.data.default_program
+        else:
+            program = program.lower()
+
+        driver = self.data.default_driver
+
+        # Handle keywords
+        keywords_alias = keywords
+        if keywords is None:
+            if program in self.data.default_keywords:
+                keywords_alias = self.data.default_keywords[program]
+                keywords = self.data.alias_keywords[program][keywords_alias]
+        else:
+            if (program not in self.data.alias_keywords) or (keywords not in self.data.alias_keywords[program]):
+                raise KeyError("KeywordSet alias '{}' not found for program '{}'.".format(keywords, program))
+
+            keywords_alias = keywords
+            keywords = self.data.alias_keywords[program][keywords]
+
+        # Form database and history keys
+        dbkeys = {"driver": driver, "program": program, "method": method, "basis": basis, "keywords": keywords}
+        history = {**dbkeys, **{"keywords": keywords_alias}}
+        if stoich is not None:
+            history["stoichiometry"] = stoich
+
+        name = self._canonical_name(program, method, basis, keywords_alias, stoich)
+
+        return name, dbkeys, history
+
+    def _get_molecules(self, indexer: Dict[Any, ObjectId], force: bool = False) -> pd.DataFrame:
+        """Queries a list of molecules using a molecule indexer
+
+        Parameters
+        ----------
+        indexer : Dict[str, 'ObjectId']
+            A key/value index of molecules to query
+        force : bool, optional
+            Force pull of molecules from server
+
+        Returns
+        -------
+        pd.DataFrame
+            A table of Molecules, indexed by Entry names
+
+        Raises
+        ------
+        KeyError
+            If no records match the query
+        """
+
+        molecule_ids = list(set(indexer.values()))
+        if not self._use_view(force):
+            molecules: List["Molecule"] = []
+            for i in range(0, len(molecule_ids), self.client.query_limit):
+                molecules.extend(self.client.query_molecules(id=molecule_ids[i : i + self.client.query_limit]))
+            # XXX: molecules = pd.DataFrame({"molecule_id": molecule_ids, "molecule": molecules}) fails
+            #      test_gradient_dataset_get_molecules and I don't know why
+            molecules = pd.DataFrame({"molecule_id": molecule.id, "molecule": molecule} for molecule in molecules)
+        else:
+            molecules = self._view.get_molecules(molecule_ids)
+            molecules = pd.DataFrame({"molecule_id": molecule_ids, "molecule": molecules})
+
+        if len(molecules) == 0:
+            raise KeyError("Query matched 0 records.")
+
+        df = pd.DataFrame.from_dict(indexer, orient="index", columns=["molecule_id"])
+
+        df.reset_index(inplace=True)
+
+        # Outer join on left to merge duplicate molecules
+        df = df.merge(molecules, how="left", on="molecule_id")
+        df.set_index("index", inplace=True)
+        df.drop("molecule_id", axis=1, inplace=True)
+
+        return df
+
+    def _get_records(
+        self,
+        indexer: Dict[Any, ObjectId],
+        query: Dict[str, Any],
+        include: Optional[List[str]] = None,
+        merge: bool = False,
+        raise_on_plan: Union[str, bool] = False,
+    ) -> "pd.Series":
+        """
+        Runs a query based on an indexer which is index : molecule_id
+
+        Parameters
+        ----------
+        indexer : Dict[str, ObjectId]
+            A key/value index of molecules to query
+        query : Dict[str, Any]
+            A results query
+        include : Optional[List[str]], optional
+            The attributes to return. Otherwise returns ResultRecord objects.
+        merge : bool, optional
+            Sum compound queries together, useful for mixing results
+        raise_on_plan : Union[str, bool], optional
+            Raises a KeyError is True or string if a multi-stage plan is detected.
+
+        Returns
+        -------
+        pd.Series
+            A Series of the data results
+
+        """
+        self._check_client()
+        self._check_state()
+
+        ret = []
+        plan = composition_planner(**query)
+        if raise_on_plan and (len(plan) > 1):
+            if raise_on_plan is True:
+                raise KeyError("Recieved a multi-stage plan when this function does not support multi-staged plans.")
+            else:
+                raise KeyError(raise_on_plan)
+
+        for query_set in plan:
+
+            query_set["keywords"] = self.get_keywords(query_set["keywords"], query_set["program"], return_id=True)
+            # Set the index to remove duplicates
+            molecules = list(set(indexer.values()))
+            if include:
+                proj = [k.lower() for k in include]
+                if "molecule" not in proj:
+                    proj.append("molecule")
+                query_set["include"] = proj
+
+            # Chunk up the queries
+            records: List[ResultRecord] = []
+            for i in range(0, len(molecules), self.client.query_limit):
+                query_set["molecule"] = molecules[i : i + self.client.query_limit]
+                records.extend(self.client.query_results(**query_set))
+
+            if include is None:
+                records = [{"molecule": x.molecule, "record": x} for x in records]
+
+            records = pd.DataFrame.from_dict(records)
+
+            df = pd.DataFrame.from_dict(indexer, orient="index", columns=["molecule"])
+            df.reset_index(inplace=True)
+
+            if records.shape[0] > 0:
+                # Outer join on left to merge duplicate molecules
+                df = df.merge(records, how="left", on="molecule")
+            else:
+                # No results, fill NaN values
+                if include is None:
+                    df["record"] = None
+                else:
+                    for k in include:
+                        df[k] = np.nan
+
+            df.set_index("index", inplace=True)
+            df.drop("molecule", axis=1, inplace=True)
+
+            ret.append(df)
+
+        if len(molecules) == 0:
+            raise KeyError("Query matched 0 records.")
+
+        if merge:
+            retdf = ret[0]
+            for df in ret[1:]:
+                retdf += df
+            return retdf
+        else:
+            return ret
+
+    def _compute(
+        self,
+        compute_keys: Dict[str, Union[str, None]],
+        molecules: Union[List[str], pd.Series],
+        tag: Optional[str] = None,
+        priority: Optional[str] = None,
+        protocols: Optional[Dict[str, Any]] = None,
+    ) -> ComputeResponse:
+        """
+        Internal compute function
+        """
+
+        name, dbkeys, history = self._default_parameters(
+            compute_keys["program"],
+            compute_keys["method"],
+            compute_keys["basis"],
+            compute_keys["keywords"],
+            stoich=compute_keys.get("stoich", None),
+        )
+
+        self._check_client()
+        self._check_state()
+
+        umols = list(set(molecules))
+
+        ids: List[Optional[ObjectId]] = []
+        submitted: List[ObjectId] = []
+        existing: List[ObjectId] = []
+        for compute_set in composition_planner(**dbkeys):
+
+            for i in range(0, len(umols), self.client.query_limit):
+                chunk_mols = umols[i : i + self.client.query_limit]
+                ret = self.client.add_compute(
+                    **compute_set, molecule=chunk_mols, tag=tag, priority=priority, protocols=protocols
+                )
+
+                ids.extend(ret.ids)
+                submitted.extend(ret.submitted)
+                existing.extend(ret.existing)
+
+            qhistory = history.copy()
+            qhistory["program"] = compute_set["program"]
+            qhistory["method"] = compute_set["method"]
+            qhistory["basis"] = compute_set["basis"]
+            self._add_history(**qhistory)
+
+        return ComputeResponse(ids=ids, submitted=submitted, existing=existing)
+
+    @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, value):
+        for column in self.df.columns:
+            try:
+                self.df[column] *= constants.conversion_factor(self._column_metadata[column]["units"], value)
+
+                # Cast units to quantities so that `kcal / mol` == `kilocalorie / mole`
+                metadata_quantity = constants.Quantity(self._column_metadata[column]["units"])
+                self_quantity = constants.Quantity(self._units)
+                if metadata_quantity != self_quantity:
+                    warnings.warn(
+                        f"Data column '{column}' did not have the same units as the dataset. "
+                        f"This has been corrected."
+                    )
+                self._column_metadata[column]["units"] = value
+            except (ValueError, TypeError) as e:
+                # This is meant to catch pint.errors.DimensionalityError without importing pint, which is too slow.
+                # In pint <=0.9, DimensionalityError is a ValueError.
+                # In pint >=0.10, DimensionalityError is TypeError.
+                if e.__class__.__name__ == "DimensionalityError":
+                    pass
+                else:
+                    raise
+        self._units = value
+
+    def set_default_program(self, program: str) -> bool:
+        """
+        Sets the default program.
+
+        Parameters
+        ----------
+        program : str
+            The program to default to.
+        """
+
+        self.data.__dict__["default_program"] = program.lower()
+        return True
+
+    def set_default_benchmark(self, benchmark: str) -> bool:
+        """
+        Sets the default benchmark value.
+
+        Parameters
+        ----------
+        benchmark : str
+            The benchmark to default to.
+        """
+
+        self.data.__dict__["default_benchmark"] = benchmark
+        return True
+
+    def add_keywords(self, alias: str, program: str, keyword: "KeywordSet", default: bool = False) -> bool:
+        """
+        Adds an option alias to the dataset. Not that keywords are not present
+        until a save call has been completed.
+
+        Parameters
+        ----------
+        alias : str
+            The alias of the option
+        program : str
+            The compute program the alias is for
+        keyword : KeywordSet
+            The Keywords object to use.
+        default : bool, optional
+            Sets this option as the default for the program
+
+        """
+
+        alias = alias.lower()
+        program = program.lower()
+        if program not in self.data.alias_keywords:
+            self.data.alias_keywords[program] = {}
+
+        if alias in self.data.alias_keywords[program]:
+            raise KeyError("Alias '{}' already set for program {}.".format(alias, program))
+
+        self._new_keywords[(program, alias)] = keyword
+
+        if default:
+            self.data.default_keywords[program] = alias
+        return True
+
+    def list_keywords(self) -> pd.DataFrame:
+        """Lists keyword aliases for each program in the dataset.
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe containing programs, keyword aliases, KeywordSet ids, and whether those keywords are the
+            default for a program. Indexed on program.
+        """
+        data = []
+        for program, kwaliases in self.data.alias_keywords.items():
+            prog_default_kw = self.data.default_keywords.get(program, None)
+            for kwalias, kwid in kwaliases.items():
+                data.append(
+                    {
+                        "program": program,
+                        "keywords": kwalias,
+                        "id": kwid,
+                        "default": prog_default_kw == kwalias,
+                    }
+                )
+        return pd.DataFrame(data).set_index("program")
+
+    def get_keywords(self, alias: str, program: str, return_id: bool = False) -> Union["KeywordSet", str]:
+        """Pulls the keywords alias from the server for inspection.
+
+        Parameters
+        ----------
+        alias : str
+            The keywords alias.
+        program : str
+            The program the keywords correspond to.
+        return_id : bool, optional
+            If True, returns the ``id`` rather than the ``KeywordSet`` object.
+            Description
+
+        Returns
+        -------
+        Union['KeywordSet', str]
+            The requested ``KeywordSet`` or ``KeywordSet`` ``id``.
+
+        """
+        self._check_client()
+        if alias is None:
+            if return_id:
+                return None
+            else:
+                return {}
+
+        alias = alias.lower()
+        program = program.lower()
+        if (program not in self.data.alias_keywords) or (alias not in self.data.alias_keywords[program]):
+            raise KeyError("Keywords {}: {} not found.".format(program, alias))
+
+        kwid = self.data.alias_keywords[program][alias]
+        if return_id:
+            return kwid
+        else:
+            return self.client.query_keywords([kwid])[0]
+
+    def add_contributed_values(self, contrib: ContributedValues, overwrite: bool = False) -> None:
+        """
+        Adds a ContributedValues to the database. Be sure to call save() to commit changes to the server.
+
+        Parameters
+        ----------
+        contrib : ContributedValues
+            The ContributedValues to add.
+        overwrite : bool, optional
+            Overwrites pre-existing values
+        """
+        self.get_entries(force=True)
+        self._ensure_contributed_values()
+
+        # Convert and validate
+        if isinstance(contrib, ContributedValues):
+            contrib = contrib.copy()
+        else:
+            contrib = ContributedValues(**contrib)
+
+        if set(contrib.index) != set(self.get_index()):
+            raise ValueError("Contributed values indices do not match the entries in the dataset.")
+
+        # Check the key
+        key = contrib.name.lower()
+        if (key in self.data.contributed_values) and (overwrite is False):
+            raise KeyError(
+                "Key '{}' already found in contributed values. Use `overwrite=True` to force an update.".format(key)
+            )
+
+        self.data.contributed_values[key] = contrib
+        self._updated_state = True
+
+    def _ensure_contributed_values(self) -> None:
+        if self.data.contributed_values is None:
+            self._get_data_records_from_db()
+
+    def _list_contributed_values(self) -> pd.DataFrame:
+        """
+        Lists all specifications of contributed data, i.e. method, program, basis set, keyword set, driver combinations
+
+        Returns
+        -------
+        DataFrame
+            Contributed value specifications.
+        """
+        self._ensure_contributed_values()
+        ret = pd.DataFrame(columns=self.data.history_keys + tuple(["name"]))
+
+        cvs = (
+            (cv_data.name, cv_data.theory_level_details) for (cv_name, cv_data) in self.data.contributed_values.items()
+        )
+
+        for cv_name, theory_level_details in cvs:
+            spec = {"name": cv_name}
+            for k in self.data.history_keys:
+                spec[k] = "Unknown"
+            # ReactionDataset uses "default" as a default value for stoich,
+            # but many contributed datasets lack a stoich field
+            if "stoichiometry" in self.data.history_keys:
+                spec["stoichiometry"] = "default"
+            if isinstance(theory_level_details, dict):
+                spec.update(**theory_level_details)
+            ret = ret.append(spec, ignore_index=True)
+
+        return ret
+
+    def _subset_in_cache(self, column_name: str, subset: Set[str]) -> bool:
+        try:
+            return not self.df.loc[subset, column_name].isna().any()
+        except KeyError:
+            return False
+
+    def _update_cache(self, new_data: pd.DataFrame) -> None:
+        new_df = pd.DataFrame(
+            index=set(self.df.index) | set(new_data.index), columns=set(self.df.columns) | set(new_data.columns)
+        )
+        new_df.update(new_data)
+        new_df.update(self.df)
+        self.df = new_df
+
+    def _get_contributed_values(self, subset: Set[str], force: bool = False, **spec) -> pd.DataFrame:
+
+        cv_list = self.list_values(native=False, force=force).reset_index()
+        queries = self._filter_records(cv_list.rename(columns={"stoichiometry": "stoich"}), **spec)
+        column_names: List[str] = []
+        new_queries = []
+
+        for query in queries.to_dict("records"):
+            column_name = query["name"]
+            column_names.append(column_name)
+            if force or not self._subset_in_cache(column_name, subset):
+                self._column_metadata[column_name] = query
+                new_queries.append(query)
+
+        new_data = pd.DataFrame(index=subset)
+        if not self._use_view(force):
+            self._ensure_contributed_values()
+            units: Dict[str, str] = {}
+
+            for query in new_queries:
+                data = self.data.contributed_values[query["name"].lower()].copy()
+                column_name = data.name
+
+                # Annoying work around to prevent some pandas magic
+                if isinstance(data.values[0], (int, float, bool, np.number)):
+                    values = data.values
+                else:
+                    # TODO temporary patch until msgpack collections
+                    if isinstance(data.theory_level_details, dict) and "driver" in data.theory_level_details:
+                        cv_driver = data.theory_level_details["driver"]
+                    else:
+                        cv_driver = self.data.default_driver
+
+                    if cv_driver == "gradient":
+                        values = [np.array(v).reshape(-1, 3) for v in data.values]
+                    else:
+                        values = [np.array(v) for v in data.values]
+
+                new_data[column_name] = pd.Series(values, index=data.index)[subset]
+                units[column_name] = data.units
+        else:
+            for query in new_queries:
+                query["native"] = False
+            new_data, units = self._view.get_values(new_queries, subset)
+
+        # convert units
+        for query in new_queries:
+            column_name = query["name"]
+            metadata = {"native": False}
+            try:
+                new_data[column_name] *= constants.conversion_factor(units[column_name], self.units)
+                metadata["units"] = self.units
+            except (ValueError, TypeError) as e:
+                # This is meant to catch pint.errors.DimensionalityError without importing pint, which is too slow.
+                # In pint <=0.9, DimensionalityError is a ValueError.
+                # In pint >=0.10, DimensionalityError is TypeError.
+                if e.__class__.__name__ == "DimensionalityError":
+                    metadata["units"] = units[column_name]
+                else:
+                    raise
+            self._column_metadata[column_name].update(metadata)
+
+        self._update_cache(new_data)
+        return self.df.loc[subset, column_names]
+
+    def get_molecules(
+        self, subset: Optional[Union[str, Set[str]]] = None, force: bool = False
+    ) -> Union[pd.DataFrame, "Molecule"]:
+        """Queries full Molecules from the database.
+
+        Parameters
+        ----------
+        subset : Optional[Union[str, Set[str]]], optional
+            The index subset to query on
+        force : bool, optional
+            Force pull of molecules from server
+
+        Returns
+        -------
+        Union[pd.DataFrame, 'Molecule']
+            Either a DataFrame of indexed Molecules or a single Molecule if a single subset string was provided.
+        """
+        indexer = self._molecule_indexer(subset=subset, force=force)
+        df = self._get_molecules(indexer, force)
+
+        if isinstance(subset, str):
+            return df.iloc[0, 0]
+        else:
+            return df
+
+    def get_records(
+        self,
+        method: str,
+        basis: Optional[str] = None,
+        *,
+        keywords: Optional[str] = None,
+        program: Optional[str] = None,
+        include: Optional[List[str]] = None,
+        subset: Optional[Union[str, Set[str]]] = None,
+        merge: bool = False,
+    ) -> Union[pd.DataFrame, "ResultRecord"]:
+        """
+        Queries full ResultRecord objects from the database.
+
+        Parameters
+        ----------
+        method : str
+            The computational method to query on (B3LYP)
+        basis : Optional[str], optional
+            The computational basis query on (6-31G)
+        keywords : Optional[str], optional
+            The option token desired
+        program : Optional[str], optional
+            The program to query on
+        include : Optional[List[str]], optional
+            The attributes to return. Otherwise returns ResultRecord objects.
+        subset : Optional[Union[str, Set[str]]], optional
+            The index subset to query on
+        merge : bool
+            Merge multiple results into one (as in the case of DFT-D3).
+            This only works when include=['return_results'], as in get_values.
+
+        Returns
+        -------
+        Union[pd.DataFrame, 'ResultRecord']
+            Either a DataFrame of indexed ResultRecords or a single ResultRecord if a single subset string was provided.
+        """
+        name, _, history = self._default_parameters(program, method, basis, keywords)
+        if len(self.list_records(**history)) == 0:
+            raise KeyError(f"Requested query ({name}) did not match a known record.")
+
+        indexer = self._molecule_indexer(subset=subset, force=True)
+        df = self._get_records(indexer, history, include=include, merge=merge)
+
+        if not merge and len(df) == 1:
+            df = df[0]
+
+        if len(df) == 0:
+            raise KeyError("Query matched no records!")
+
+        if isinstance(subset, str):
+            return df.iloc[0, 0]
+        else:
+            return df
+
+    def add_entry(self, name: str, molecule: "Molecule", **kwargs: Dict[str, Any]) -> None:
+        """Adds a new entry to the Dataset
+
+        Parameters
+        ----------
+        name : str
+            The name of the record
+        molecule : Molecule
+            The Molecule associated with this record
+        **kwargs : Dict[str, Any]
+            Additional arguments to pass to the record
+        """
+        mhash = molecule.get_hash()
+        self._new_molecules[mhash] = molecule
+        self._new_records.append({"name": name, "molecule_hash": mhash, **kwargs})
+
+    def compute(
+        self,
+        method: str,
+        basis: Optional[str] = None,
+        *,
+        keywords: Optional[str] = None,
+        program: Optional[str] = None,
+        tag: Optional[str] = None,
+        priority: Optional[str] = None,
+        protocols: Optional[Dict[str, Any]] = None,
+    ) -> ComputeResponse:
+        """Executes a computational method for all reactions in the Dataset.
+        Previously completed computations are not repeated.
+
+        Parameters
+        ----------
+        method : str
+            The computational method to compute (B3LYP)
+        basis : Optional[str], optional
+            The computational basis to compute (6-31G)
+        keywords : Optional[str], optional
+            The keyword alias for the requested compute
+        program : Optional[str], optional
+            The underlying QC program
+        tag : Optional[str], optional
+            The queue tag to use when submitting compute requests.
+        priority : Optional[str], optional
+            The priority of the jobs low, medium, or high.
+        protocols: Optional[Dict[str, Any]], optional
+            Protocols for store more or less data per field. Current valid
+            protocols: {'wavefunction'}
+
+        Returns
+        -------
+        ComputeResponse
+            An object that contains the submitted ObjectIds of the new compute. This object has the following fields:
+              - ids: The ObjectId's of the task in the order of input molecules
+              - submitted: A list of ObjectId's that were submitted to the compute queue
+              - existing: A list of ObjectId's of tasks already in the database
+        """
+        self.get_entries(force=True)
+        compute_keys = {"program": program, "method": method, "basis": basis, "keywords": keywords}
+
+        molecule_idx = [e.molecule_id for e in self.data.records]
+
+        ret = self._compute(compute_keys, molecule_idx, tag, priority, protocols)
+        self.save()
+
+        return ret
+
+    def get_index(self, subset: Optional[List[str]] = None, force: bool = False) -> List[str]:
+        """
+        Returns the current index of the database.
+
+        Returns
+        -------
+        ret : List[str]
+            The names of all reactions in the database
+        """
+        return list(self.get_entries(subset=subset, force=force)["name"].unique())
+
+    # Statistical quantities
+    def statistics(
+        self, stype: str, value: str, bench: Optional[str] = None, **kwargs: Dict[str, Any]
+    ) -> Union[np.ndarray, pd.Series, np.float64]:
+        """Provides statistics for various columns in the underlying dataframe.
+
+        Parameters
+        ----------
+        stype : str
+            The type of statistic in question
+        value : str
+            The method string to compare
+        bench : str, optional
+            The benchmark method for the comparison, defaults to `default_benchmark`.
+        kwargs: Dict[str, Any]
+            Additional kwargs to pass to the statistics functions
+
+
+        Returns
+        -------
+        np.ndarray, pd.Series, float
+            Returns an ndarray, Series, or float with the requested statistics depending on input.
+        """
+
+        if bench is None:
+            bench = self.data.default_benchmark
+
+        if bench is None:
+            raise KeyError("No benchmark provided and default_benchmark is None!")
+
+        return wrap_statistics(stype.upper(), self, value, bench, **kwargs)
+
+    def _use_view(self, force: bool = False) -> bool:
+        """Helper function to decide whether to use a locally available HDF5 view"""
+        return (force is False) and (self._view is not None) and (self._disable_view is False)
+
+    def _clear_cache(self) -> None:
+        self.df = pd.DataFrame()
+        self.data.__dict__["records"] = None
+        self.data.__dict__["contributed_values"] = None
+
+    # Getters
+    def __getitem__(self, args: str) -> pd.Series:
+        """A wrapped to the underlying pd.DataFrame to access columnar data
+
+        Parameters
+        ----------
+        args : str
+            The column to access
+
+        Returns
+        -------
+        ret : pd.Series, pd.DataFrame
+            A view of the underlying dataframe data
+        """
+        return self.df[args]
+
+
+register_collection(Dataset)

--- a/qcfractal/portal/collections/optimization_dataset.py
+++ b/qcfractal/portal/collections/optimization_dataset.py
@@ -7,6 +7,7 @@ import pandas as pd
 import qcelemental as qcel
 
 from ...interface.models import ObjectId, OptimizationSpecification, ProtoModel, QCSpecification
+
 from .collection import BaseProcedureDataset
 from .collection_utils import register_collection
 

--- a/qcfractal/portal/collections/optimization_dataset.py
+++ b/qcfractal/portal/collections/optimization_dataset.py
@@ -1,5 +1,5 @@
-"""
-QCPortal Database ODM
+"""Optimization dataset collection.
+
 """
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
@@ -33,13 +33,13 @@ class OptEntrySpecification(ProtoModel):
 
 
 class OptimizationDataset(BaseProcedureDataset):
-    class _DataModel(BaseProcedureDataset.DataModel):
+    class _DataModel(BaseProcedureDataset._DataModel):
 
         records: Dict[str, OptEntry] = {}
         history: Set[str] = set()
         specs: Dict[str, OptEntrySpecification] = {}
 
-        class Config(BaseProcedureDataset.DataModel.Config):
+        class Config(BaseProcedureDataset._DataModel.Config):
             pass
 
     def _internal_compute_add(self, spec: Any, entry: Any, tag: str, priority: str) -> ObjectId:

--- a/qcfractal/portal/collections/optimization_dataset.py
+++ b/qcfractal/portal/collections/optimization_dataset.py
@@ -35,7 +35,7 @@ class OptEntrySpecification(ProtoModel):
 class OptimizationDataset(BaseProcedureDataset):
     class _DataModel(BaseProcedureDataset._DataModel):
 
-        records: Dict[str, OptEntry] = {}
+        records: Dict[str, OptEntry] = {} # TODO: can we rename this to `entries` without breaking everything?
         history: Set[str] = set()
         specs: Dict[str, OptEntrySpecification] = {}
 

--- a/qcfractal/portal/collections/optimization_dataset.py
+++ b/qcfractal/portal/collections/optimization_dataset.py
@@ -1,0 +1,205 @@
+"""
+QCPortal Database ODM
+"""
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
+
+import pandas as pd
+import qcelemental as qcel
+
+from ...interface.models import ObjectId, OptimizationSpecification, ProtoModel, QCSpecification
+from .collection import BaseProcedureDataset
+from .collection_utils import register_collection
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ...interface.models import Molecule
+
+
+class OptEntry(ProtoModel):
+    """Data model for the optimizations in a Dataset"""
+
+    name: str
+    initial_molecule: ObjectId
+    additional_keywords: Dict[str, Any] = {}
+    attributes: Dict[str, Any] = {}
+    object_map: Dict[str, ObjectId] = {}
+
+
+class OptEntrySpecification(ProtoModel):
+    name: str
+    description: Optional[str]
+    optimization_spec: OptimizationSpecification
+    qc_spec: QCSpecification
+    protocols: qcel.models.procedures.OptimizationProtocols = qcel.models.procedures.OptimizationProtocols()
+
+
+class OptimizationDataset(BaseProcedureDataset):
+    class _DataModel(BaseProcedureDataset.DataModel):
+
+        records: Dict[str, OptEntry] = {}
+        history: Set[str] = set()
+        specs: Dict[str, OptEntrySpecification] = {}
+
+        class Config(BaseProcedureDataset.DataModel.Config):
+            pass
+
+    def _internal_compute_add(self, spec: Any, entry: Any, tag: str, priority: str) -> ObjectId:
+
+        # Form per-procedure keywords dictionary
+        general_keywords = spec.optimization_spec.keywords
+        if general_keywords is None:
+            general_keywords = {}
+        keywords = {**general_keywords, **entry.additional_keywords}
+
+        procedure_parameters = {
+            "keywords": keywords,
+            "qc_spec": spec.qc_spec.dict(),
+            "protocols": spec.protocols.dict(),
+        }
+
+        return self.client.add_procedure(
+            "optimization",
+            spec.optimization_spec.program,
+            procedure_parameters,
+            [entry.initial_molecule],
+            tag=tag,
+            priority=priority,
+        ).ids[0]
+
+    def add_specification(
+        self,
+        name: str,
+        optimization_spec: OptimizationSpecification,
+        qc_spec: QCSpecification,
+        description: Optional[str] = None,
+        protocols: Optional[Dict[str, Any]] = None,
+        overwrite=False,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        name : str
+            The name of the specification
+        optimization_spec : OptimizationSpecification
+            A full optimization specification for Optimization
+        qc_spec : QCSpecification
+            A full quantum chemistry specification for Optimization
+        description : str, optional
+            A short text description of the specification
+        protocols : Optional[Dict[str, Any]], optional
+            Protocols for this specification.
+        overwrite : bool, optional
+            Overwrite existing specification names
+        """
+        if protocols is None:
+            protocols = {}
+
+        spec = OptEntrySpecification(
+            name=name,
+            optimization_spec=optimization_spec,
+            qc_spec=qc_spec,
+            description=description,
+            protocols=protocols,
+        )
+
+        return self._add_specification(name, spec, overwrite=overwrite)
+
+    def add_entry(
+        self,
+        name: str,
+        initial_molecule: "Molecule",
+        additional_keywords: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+        save: bool = True,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        name : str
+            The name of the entry, will be used for the index
+        initial_molecule : Molecule
+            The list of starting Molecules for the Optimization
+        additional_keywords : Dict[str, Any], optional
+            Additional keywords to add to the optimization run
+        attributes : Dict[str, Any], optional
+            Additional attributes and descriptions for the entry
+        save : bool, optional
+            If true, saves the collection after adding the entry. If this is False be careful
+            to call save after all entries are added, otherwise data pointers may be lost.
+        """
+
+        self._check_entry_exists(name)  # Fast skip
+
+        if additional_keywords is None:
+            additional_keywords = {}
+
+        if attributes is None:
+            attributes = {}
+
+        # Build new objects
+        molecule_id = self.client.add_molecules([initial_molecule])[0]
+        entry = OptEntry(
+            name=name, initial_molecule=molecule_id, additional_keywords=additional_keywords, attributes=attributes
+        )
+
+        self._add_entry(name, entry, save)
+
+    def counts(
+        self, entries: Optional[Union[str, List[str]]] = None, specs: Optional[Union[str, List[str]]] = None
+    ) -> pd.DataFrame:
+        """Counts the number of optimization or gradient evaluations associated with the
+        Optimizations.
+
+        Parameters
+        ----------
+        entries : Union[str, List[str]]
+            The entries to query for
+        specs : Optional[Union[str, List[str]]], optional
+            The specifications to query for
+        count_gradients : bool, optional
+            If True, counts the total number of gradient calls. Warning! This can be slow for large datasets.
+
+        Returns
+        -------
+        DataFrame
+            The queried counts.
+        """
+
+        if isinstance(specs, str):
+            specs = [specs]
+
+        if isinstance(entries, str):
+            entries = [entries]
+
+        # Query all of the specs and make sure they are valid
+        if specs is None:
+            specs = list(self.df.columns)
+        else:
+            new_specs = []
+            for spec in specs:
+                new_specs.append(self.query(spec))
+
+            # Remap names
+            specs = new_specs
+
+        def count_gradients(opt):
+            if (not hasattr(opt, "status")) or opt.status != "COMPLETE":
+                return None
+            return len(opt.energies)
+
+        # Loop over the data and apply the count function
+        ret = []
+        for col in specs:
+            data = self.df[col]
+            if entries:
+                data = data[entries]
+
+            cnts = data.apply(lambda td: count_gradients(td))
+            ret.append(cnts)
+
+        ret = pd.DataFrame(ret).transpose()
+        ret.dropna(inplace=True, how="all")
+        # ret = pd.DataFrame([ret[x].astype(int) for x in ret.columns]).transpose()
+        return ret
+
+
+register_collection(OptimizationDataset)

--- a/qcfractal/portal/collections/optimization_dataset.py
+++ b/qcfractal/portal/collections/optimization_dataset.py
@@ -35,7 +35,7 @@ class OptEntrySpecification(ProtoModel):
 class OptimizationDataset(BaseProcedureDataset):
     class _DataModel(BaseProcedureDataset._DataModel):
 
-        records: Dict[str, OptEntry] = {} # TODO: can we rename this to `entries` without breaking everything?
+        records: Dict[str, OptEntry] = {}  # TODO: can we rename this to `entries` without breaking everything?
         history: Set[str] = set()
         specs: Dict[str, OptEntrySpecification] = {}
 

--- a/qcfractal/portal/records/__init__.py
+++ b/qcfractal/portal/records/__init__.py
@@ -1,0 +1,2 @@
+from .record_utils import record_factory, record_name_map, register_record
+from .optimization_record import OptimizationRecord

--- a/qcfractal/portal/records/optimization_record.py
+++ b/qcfractal/portal/records/optimization_record.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from ...interface.models import OptimizationRecord as _OptimizationRecord
+
+
+class OptimizationRecord:
+    """
+    User-facing API for accessing data for a single optimization.
+
+    """
+    _DataModel = _OptimizationRecord
+
+    def __init__(self, **kwargs: Any):
+        """
+
+        Parameters
+        ----------
+        **kwargs : Dict[str, Any]
+            Additional keywords passed to the OptimizationRecord and the initial data constructor.
+        """
+        # Create the data model
+        self._data = self._DataModel(**kwargs)
+
+
+register_record(OptimizationRecord)

--- a/qcfractal/portal/records/optimization_record.py
+++ b/qcfractal/portal/records/optimization_record.py
@@ -1,15 +1,17 @@
 from typing import Any
 
 from ...interface.models import OptimizationRecord as _OptimizationRecord
+from .record import Record
 from .record_utils import register_record
 
 
-class OptimizationRecord:
+class OptimizationRecord(Record):
     """
     User-facing API for accessing data for a single optimization.
 
     """
     _DataModel = _OptimizationRecord
+    _type = "optimization"
 
     def __init__(self, **kwargs: Any):
         """
@@ -19,8 +21,13 @@ class OptimizationRecord:
         **kwargs : Dict[str, Any]
             Additional keywords passed to the OptimizationRecord and the initial data constructor.
         """
-        # Create the data model
         self._data = self._DataModel(**kwargs)
+
+    @property
+    def status(self):
+        return self._data.status
+
+    # TODO: add in optimization-specific methods
 
 
 register_record(OptimizationRecord)

--- a/qcfractal/portal/records/optimization_record.py
+++ b/qcfractal/portal/records/optimization_record.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from ...interface.models import OptimizationRecord as _OptimizationRecord
+from .record_utils import register_record
 
 
 class OptimizationRecord:

--- a/qcfractal/portal/records/record.py
+++ b/qcfractal/portal/records/record.py
@@ -1,0 +1,144 @@
+import abc
+import copy
+import json
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
+
+from ...interface.models import ProtoModel
+
+
+class Record(abc.ABC):
+
+    class _DataModel(ProtoModel):
+        # TODO: populate me with structural fields of a basic record
+        pass
+
+    def __init__(self, **kwargs: Any):
+        """
+
+        Parameters
+        ----------
+        **kwargs : Dict[str, Any]
+            Additional keywords passed to the Record and the initial data constructor.
+        """
+        # Create the data model
+        self._data = self._DataModel(**kwargs)
+
+    def __repr__(self):
+        fields = [f"{key}={value}" for key, value in self.__repr_args__()]
+        return f"{self.__class__.__name__}({', '.join(fields)})"
+
+    def __repr_args__(self):
+
+        return [("id", f"{self.id}"), ("status", f"{self.status}")]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Record":
+        """Creates a new Record instance from a dict representation.
+
+        Allows roundtrips from `Collection.to_dict`.
+
+        Parameters
+        ----------
+        data : Dict[str, Any]
+            A dict to create a new Record instance from.
+
+        Returns
+        -------
+        Record
+            A Record instance.
+        """
+        class_name = cls.__name__.lower()
+
+        # Check we are building the correct object
+        record_type = cls._type
+        if "procedure" not in data:
+            raise KeyError("Attempted to create Record from data, but no `procedure` field found.")
+
+        if data["procedure"].lower() != record_type:
+            raise KeyError(
+                "Attempted to create Record from data with class {}, but found record type of {}.".format(
+                    class_name, data["procedure"].lower()
+                )
+            )
+
+        # Allow PyDantic to handle type validation
+        ret = cls(**data)
+        return ret
+
+    @classmethod
+    def from_json(cls, jsondata: Optional[str] = None, filename: Optional[str] = None) -> "Record":
+        """Creates a new Record instance from a JSON string.
+
+        Allows roundtrips from `Record.to_json`.
+        One of `jsondata` or `filename` must be provided.
+
+        Parameters
+        ----------
+        jsondata : str, Optional, Default: None
+            The JSON string to create a new Record instance from.
+        filename : str, Optional, Default: None
+            The filename to read JSON data from.
+
+        Returns
+        -------
+        Record
+            A Record instance.
+        """
+        if (jsondata is not None) and (filename is not None):
+            raise ValueError("One of `jsondata` or `filename` must be specified, not both")
+
+        if jsondata is not None:
+            data = json.loads(jsondata)
+        elif filename is not None:
+            with open(filename, 'r') as jsonfile:
+                data = json.load(jsonfile)
+        else:
+            raise ValueError("One of `jsondata` or `filename` must be specified")
+
+        return cls.from_dict(data)
+
+    def to_dict(self) -> dict:
+        """Returns a copy of the current Record data as a Python dict.
+
+        Returns
+        -------
+        ret : dict
+            A Python dict representation of the Record data.
+        """
+        datadict = self._data.dict()
+        return copy.deepcopy(datadict)
+
+    def to_json(self, filename: Optional[str] = None) -> str:
+        """Returns the current Record data as JSON.
+
+        If a filename is provided, dumps JSON to file.
+        Otherwise returns data as a JSON string.
+
+        Parameters
+        ----------
+        filename : str, Optional, Default: None
+            The filename to write JSON data to.
+
+        Returns
+        -------
+        ret : dict
+            If `filename=None`, a JSON representation of the Record.
+            Otherwise `None`.
+        """
+        jsondata = self._data.json()
+        if filename is not None:
+            with open(filename, "w") as open_file:
+                open_file.write(jsondata)
+        else:
+            return jsondata
+
+    @property
+    def status(self):
+        """Status of the calculation corresponding to this record.
+
+        """
+        pass
+
+    @property
+    def id(self):
+        return self._data.id

--- a/qcfractal/portal/records/record_utils.py
+++ b/qcfractal/portal/records/record_utils.py
@@ -14,19 +14,17 @@ def register_record(record: "RecordBase") -> None:
 
     """
 
-    class_name = record.__name__.lower()
-    __registered_records[class_name] = record
+    record_type = record._type
+    __registered_records[record_type] = record
 
 
-def record_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "RecordBase":
+def record_factory(data: Dict[str, Any]) -> "RecordBase":
     """Returns a Record object from data deserialized from JSON.
 
     Parameters
     ----------
     data : Dict[str, Any]
         The JSON-serializable dict to create a new class from.
-    client : PortalClient, optional
-        A PortalClient connected to a server.
 
     Returns
     -------
@@ -41,7 +39,7 @@ def record_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "Reco
         raise KeyError("Attempted to create Record of unknown type '{}'.".format(data["procedure"]))
 
     # TODO: return here after fixing `from_json`, `to_json` to be less ambiguous
-    return __registered_records[data["procedure"].lower()].from_json(data, client=client)
+    return __registered_records[data["procedure"].lower()].from_dict(data)
 
 
 def record_name_map() -> Dict[str, str]:
@@ -54,56 +52,3 @@ def record_name_map() -> Dict[str, str]:
         Map of {'internal': 'user fiendly name'}
     """
     return {k: v.__name__ for k, v in __registered_records.items()}
-
-
-#def build_procedure(
-#    data: Dict[str, Any], procedure: Optional[str] = None, client: Optional["FractalClient"] = None
-#) -> "BaseRecord":
-#    """
-#    Constructs a Service ORM from incoming JSON data.
-#
-#    Parameters
-#    ----------
-#    data : Dict[str, Any]
-#        A JSON representation of the procedure.
-#    procedure : Optional[str], optional
-#        The name of the procedure. If blank the procedure name is pulled from the `data["procedure"]` field.
-#    client : Optional['FractalClient'], optional
-#        A FractalClient connected to a server.
-#
-#    Returns
-#    -------
-#    ret : BaseRecord
-#        Returns an interface object of the appropriate procedure.
-#
-#    Examples
-#    --------
-#
-#    # A partial example of torsiondrive metadata
-#    >>> data = {
-#        "procedure": "torsiondrive",
-#        "initial_molecule": "5b7f1fd57b87872d2c5d0a6c",
-#        "state": "RUNNING",
-#        "id": "5b7f1fd57b87872d2c5d0a6d",
-#        ....
-#    }
-#
-#    >>> build_orm(data)
-#    TorsionDriveRecord(id='5b7f1fd57b87872d2c5d0a6c', state='RUNNING', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
-#    """
-#
-#    if ("procedure" not in data) and (procedure is None):
-#        raise KeyError("There is not a procedure tag and procedure is none. Unable to determine procedure type")
-#
-#    # import json
-#    # print(json.dumps(data, indent=2))
-#    if data["procedure"].lower() == "single":
-#        return ResultRecord(**data, client=client)
-#    elif data["procedure"].lower() == "torsiondrive":
-#        return TorsionDriveRecord(**data, client=client)
-#    elif data["procedure"].lower() == "gridoptimization":
-#        return GridOptimizationRecord(**data, client=client)
-#    elif data["procedure"].lower() == "optimization":
-#        return OptimizationRecord(**data, client=client)
-#    else:
-#        raise KeyError("Service names {} not recognized.".format(data["procedure"]))

--- a/qcfractal/portal/records/record_utils.py
+++ b/qcfractal/portal/records/record_utils.py
@@ -1,9 +1,5 @@
 from typing import Any, Dict, Optional
 
-from .gridoptimization import GridOptimizationRecord
-from .records import OptimizationRecord, ResultRecord
-from .torsiondrive import TorsionDriveRecord
-
 
 __registered_records = {}
 
@@ -19,96 +15,95 @@ def register_record(record: "RecordBase") -> None:
     """
 
     class_name = record.__name__.lower()
-    # if class_name in __registered_collections:
-    #     raise KeyError("Collection type '{}' already registered".format(class_name))
     __registered_records[class_name] = record
 
 
-def record_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "Collection":
+def record_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "RecordBase":
     """Returns a Record object from data deserialized from JSON.
 
     Parameters
     ----------
     data : Dict[str, Any]
-        The JSON blob to create a new class from.
+        The JSON-serializable dict to create a new class from.
     client : PortalClient, optional
-        A PortalClient connected to a server
+        A PortalClient connected to a server.
 
     Returns
     -------
-    Collection
-        A ODM of the data.
+    Record
+        An object representation of the data.
 
     """
-    if "collection" not in data:
-        raise KeyError("Attempted to create Collection from JSON, but no `collection` field found.")
+    if "procedure" not in data:
+        raise KeyError("Attempted to create Record from data, but no `procedure` field found.")
 
-    if data["collection"].lower() not in __registered_records:
-        raise KeyError("Attempted to create Collection of unknown type '{}'.".format(data["collection"]))
+    if data["procedure"].lower() not in __registered_records:
+        raise KeyError("Attempted to create Record of unknown type '{}'.".format(data["procedure"]))
 
     # TODO: return here after fixing `from_json`, `to_json` to be less ambiguous
-    return __registered_records[data["collection"].lower()].from_json(data, client=client)
+    return __registered_records[data["procedure"].lower()].from_json(data, client=client)
 
 
-def collections_name_map() -> Dict[str, str]:
+def record_name_map() -> Dict[str, str]:
     """
-    Returns a map of internal name to external Collection name.
+    Returns a map of internal name to external Record name.
 
     Returns
     -------
     Dict[str, str]
         Map of {'internal': 'user fiendly name'}
     """
-    return {k: v.__name__ for k, v in __registered_collections.items()}
+    return {k: v.__name__ for k, v in __registered_records.items()}
 
-def build_procedure(
-    data: Dict[str, Any], procedure: Optional[str] = None, client: Optional["FractalClient"] = None
-) -> "BaseRecord":
-    """
-    Constructs a Service ORM from incoming JSON data.
 
-    Parameters
-    ----------
-    data : Dict[str, Any]
-        A JSON representation of the procedure.
-    procedure : Optional[str], optional
-        The name of the procedure. If blank the procedure name is pulled from the `data["procedure"]` field.
-    client : Optional['FractalClient'], optional
-        A FractalClient connected to a server.
-
-    Returns
-    -------
-    ret : BaseRecord
-        Returns an interface object of the appropriate procedure.
-
-    Examples
-    --------
-
-    # A partial example of torsiondrive metadata
-    >>> data = {
-        "procedure": "torsiondrive",
-        "initial_molecule": "5b7f1fd57b87872d2c5d0a6c",
-        "state": "RUNNING",
-        "id": "5b7f1fd57b87872d2c5d0a6d",
-        ....
-    }
-
-    >>> build_orm(data)
-    TorsionDriveRecord(id='5b7f1fd57b87872d2c5d0a6c', state='RUNNING', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
-    """
-
-    if ("procedure" not in data) and (procedure is None):
-        raise KeyError("There is not a procedure tag and procedure is none. Unable to determine procedure type")
-
-    # import json
-    # print(json.dumps(data, indent=2))
-    if data["procedure"].lower() == "single":
-        return ResultRecord(**data, client=client)
-    elif data["procedure"].lower() == "torsiondrive":
-        return TorsionDriveRecord(**data, client=client)
-    elif data["procedure"].lower() == "gridoptimization":
-        return GridOptimizationRecord(**data, client=client)
-    elif data["procedure"].lower() == "optimization":
-        return OptimizationRecord(**data, client=client)
-    else:
-        raise KeyError("Service names {} not recognized.".format(data["procedure"]))
+#def build_procedure(
+#    data: Dict[str, Any], procedure: Optional[str] = None, client: Optional["FractalClient"] = None
+#) -> "BaseRecord":
+#    """
+#    Constructs a Service ORM from incoming JSON data.
+#
+#    Parameters
+#    ----------
+#    data : Dict[str, Any]
+#        A JSON representation of the procedure.
+#    procedure : Optional[str], optional
+#        The name of the procedure. If blank the procedure name is pulled from the `data["procedure"]` field.
+#    client : Optional['FractalClient'], optional
+#        A FractalClient connected to a server.
+#
+#    Returns
+#    -------
+#    ret : BaseRecord
+#        Returns an interface object of the appropriate procedure.
+#
+#    Examples
+#    --------
+#
+#    # A partial example of torsiondrive metadata
+#    >>> data = {
+#        "procedure": "torsiondrive",
+#        "initial_molecule": "5b7f1fd57b87872d2c5d0a6c",
+#        "state": "RUNNING",
+#        "id": "5b7f1fd57b87872d2c5d0a6d",
+#        ....
+#    }
+#
+#    >>> build_orm(data)
+#    TorsionDriveRecord(id='5b7f1fd57b87872d2c5d0a6c', state='RUNNING', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
+#    """
+#
+#    if ("procedure" not in data) and (procedure is None):
+#        raise KeyError("There is not a procedure tag and procedure is none. Unable to determine procedure type")
+#
+#    # import json
+#    # print(json.dumps(data, indent=2))
+#    if data["procedure"].lower() == "single":
+#        return ResultRecord(**data, client=client)
+#    elif data["procedure"].lower() == "torsiondrive":
+#        return TorsionDriveRecord(**data, client=client)
+#    elif data["procedure"].lower() == "gridoptimization":
+#        return GridOptimizationRecord(**data, client=client)
+#    elif data["procedure"].lower() == "optimization":
+#        return OptimizationRecord(**data, client=client)
+#    else:
+#        raise KeyError("Service names {} not recognized.".format(data["procedure"]))

--- a/qcfractal/portal/records/record_utils.py
+++ b/qcfractal/portal/records/record_utils.py
@@ -1,0 +1,114 @@
+from typing import Any, Dict, Optional
+
+from .gridoptimization import GridOptimizationRecord
+from .records import OptimizationRecord, ResultRecord
+from .torsiondrive import TorsionDriveRecord
+
+
+__registered_records = {}
+
+
+def register_record(record: "RecordBase") -> None:
+    """Registers a record class for use by the factory.
+
+    Parameters
+    ----------
+    record : Record
+        The Record class to be registered
+
+    """
+
+    class_name = record.__name__.lower()
+    # if class_name in __registered_collections:
+    #     raise KeyError("Collection type '{}' already registered".format(class_name))
+    __registered_records[class_name] = record
+
+
+def record_factory(data: Dict[str, Any], client: "PortalClient" = None) -> "Collection":
+    """Returns a Record object from data deserialized from JSON.
+
+    Parameters
+    ----------
+    data : Dict[str, Any]
+        The JSON blob to create a new class from.
+    client : PortalClient, optional
+        A PortalClient connected to a server
+
+    Returns
+    -------
+    Collection
+        A ODM of the data.
+
+    """
+    if "collection" not in data:
+        raise KeyError("Attempted to create Collection from JSON, but no `collection` field found.")
+
+    if data["collection"].lower() not in __registered_records:
+        raise KeyError("Attempted to create Collection of unknown type '{}'.".format(data["collection"]))
+
+    # TODO: return here after fixing `from_json`, `to_json` to be less ambiguous
+    return __registered_records[data["collection"].lower()].from_json(data, client=client)
+
+
+def collections_name_map() -> Dict[str, str]:
+    """
+    Returns a map of internal name to external Collection name.
+
+    Returns
+    -------
+    Dict[str, str]
+        Map of {'internal': 'user fiendly name'}
+    """
+    return {k: v.__name__ for k, v in __registered_collections.items()}
+
+def build_procedure(
+    data: Dict[str, Any], procedure: Optional[str] = None, client: Optional["FractalClient"] = None
+) -> "BaseRecord":
+    """
+    Constructs a Service ORM from incoming JSON data.
+
+    Parameters
+    ----------
+    data : Dict[str, Any]
+        A JSON representation of the procedure.
+    procedure : Optional[str], optional
+        The name of the procedure. If blank the procedure name is pulled from the `data["procedure"]` field.
+    client : Optional['FractalClient'], optional
+        A FractalClient connected to a server.
+
+    Returns
+    -------
+    ret : BaseRecord
+        Returns an interface object of the appropriate procedure.
+
+    Examples
+    --------
+
+    # A partial example of torsiondrive metadata
+    >>> data = {
+        "procedure": "torsiondrive",
+        "initial_molecule": "5b7f1fd57b87872d2c5d0a6c",
+        "state": "RUNNING",
+        "id": "5b7f1fd57b87872d2c5d0a6d",
+        ....
+    }
+
+    >>> build_orm(data)
+    TorsionDriveRecord(id='5b7f1fd57b87872d2c5d0a6c', state='RUNNING', molecule_id='5b7f1fd57b87872d2c5d0a6c', molecule_name='HOOH')
+    """
+
+    if ("procedure" not in data) and (procedure is None):
+        raise KeyError("There is not a procedure tag and procedure is none. Unable to determine procedure type")
+
+    # import json
+    # print(json.dumps(data, indent=2))
+    if data["procedure"].lower() == "single":
+        return ResultRecord(**data, client=client)
+    elif data["procedure"].lower() == "torsiondrive":
+        return TorsionDriveRecord(**data, client=client)
+    elif data["procedure"].lower() == "gridoptimization":
+        return GridOptimizationRecord(**data, client=client)
+    elif data["procedure"].lower() == "optimization":
+        return OptimizationRecord(**data, client=client)
+    else:
+        raise KeyError("Service names {} not recognized.".format(data["procedure"]))

--- a/qcfractal/procedures/optimization.py
+++ b/qcfractal/procedures/optimization.py
@@ -8,7 +8,7 @@ import qcelemental as qcel
 import qcengine as qcng
 
 from .base import BaseTasks
-from ..interface.models import Molecule, OptimizationRecord, QCSpecification, ResultRecord, TaskRecord, KeywordSet
+from ..interface.models import Molecule, OptimizationRecord, QCSpecification, SingleResultRecord, TaskRecord, KeywordSet
 from ..interface.models.task_models import PriorityEnum
 from .procedures_util import parse_single_tasks, form_qcinputspec_schema
 
@@ -262,7 +262,7 @@ class OptimizationTasks(BaseTasks):
 
             results = parse_single_tasks(self.storage, traj_dict, rec.qc_spec)
             for k, v in results.items():
-                results[k] = ResultRecord(**v)
+                results[k] = SingleResultRecord(**v)
 
             ret = self.storage.add_results(list(results.values()))
             update_dict["trajectory"] = ret["data"]

--- a/qcfractal/procedures/single.py
+++ b/qcfractal/procedures/single.py
@@ -8,7 +8,7 @@ import qcelemental as qcel
 import qcengine as qcng
 
 from .base import BaseTasks
-from ..interface.models import Molecule, ResultRecord, TaskRecord, KeywordSet
+from ..interface.models import Molecule, SingleResultRecord, TaskRecord, KeywordSet
 from ..interface.models.task_models import PriorityEnum
 
 _wfn_return_names = set(qcel.models.results.WavefunctionProperties._return_results_names)
@@ -62,7 +62,7 @@ class SingleResultTasks(BaseTasks):
         assert procedure.lower() == "single"
 
         # Grab the tag and priority if available
-        # These are not used in the ResultRecord, so we can pop them
+        # These are not used in the SingleResultRecord, so we can pop them
         tag = qc_spec_dict.pop("tag")
         priority = qc_spec_dict.pop("priority")
 
@@ -93,10 +93,10 @@ class SingleResultTasks(BaseTasks):
         valid_molecule_idx = [idx for idx, mol in enumerate(molecule_list) if mol is not None]
         valid_molecules = [x for x in molecule_list if x is not None]
 
-        # Create ResultRecords for everything
+        # Create SingleResultRecords for everything
         all_result_records = []
         for mol in valid_molecules:
-            record = ResultRecord(**qc_spec_dict.copy(), molecule=mol.id)
+            record = SingleResultRecord(**qc_spec_dict.copy(), molecule=mol.id)
             all_result_records.append(record)
 
         # Add all results in a single function call
@@ -132,7 +132,7 @@ class SingleResultTasks(BaseTasks):
 
     def create_tasks(
         self,
-        records: List[ResultRecord],
+        records: List[SingleResultRecord],
         molecules: Optional[List[Molecule]] = None,
         keywords: Optional[List[KeywordSet]] = None,
         tag: Optional[str] = None,
@@ -146,7 +146,7 @@ class SingleResultTasks(BaseTasks):
 
         Parameters
         ----------
-        records: List[ResultRecord]
+        records: List[SingleResultRecord]
             Records for which to create the TaskRecord object
         molecules: Optional[List[Molecule]]
             Molecules to be applied to the records. If given, must be the same length as records, and
@@ -260,7 +260,7 @@ class SingleResultTasks(BaseTasks):
                 wfn_data_id = self.storage.add_wavefunction_store([wavefunction_save])["data"][0]
                 rdata["wavefunction_data_id"] = wfn_data_id
 
-            # Create an updated ResultRecord based on the existing record and the new results
+            # Create an updated SingleResultRecord based on the existing record and the new results
             # Double check to make sure everything is consistent
             assert existing_result["method"] == rdata["model"]["method"]
             assert existing_result["basis"] == rdata["model"]["basis"]
@@ -283,7 +283,7 @@ class SingleResultTasks(BaseTasks):
             existing_result["stderr"] = rdata["stderr"]
             existing_result["status"] = "COMPLETE"
 
-            result = ResultRecord(**existing_result)
+            result = SingleResultRecord(**existing_result)
 
             # Add to the list to be updated
             updates.append(result)
@@ -296,14 +296,14 @@ class SingleResultTasks(BaseTasks):
 
     @staticmethod
     def _build_schema_input(
-        record: ResultRecord, molecule: "Molecule", keywords: Optional["KeywordSet"] = None
+        record: SingleResultRecord, molecule: "Molecule", keywords: Optional["KeywordSet"] = None
     ) -> "ResultInput":
         """
         Creates an input schema for a single calculation
         """
 
         # Check for programmer sanity. Since we are building this input
-        # right after creating the ResultRecord, these should never fail.
+        # right after creating the SingleResultRecord, these should never fail.
         # But would be very hard to debug
         assert record.molecule == molecule.id
         if record.keywords:

--- a/qcfractal/storage_sockets/db_queries.py
+++ b/qcfractal/storage_sockets/db_queries.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Set, Union
 from sqlalchemy import Integer, inspect
 from sqlalchemy.sql import bindparam, text
 
-from qcfractal.interface.models import Molecule, ResultRecord
+from qcfractal.interface.models import Molecule, SingleResultRecord
 from qcfractal.storage_sockets.models import MoleculeORM, ResultORM
 
 QUERY_CLASSES = set()
@@ -330,7 +330,7 @@ class OptimizationQueries(QueryBase):
             if key not in ret:
                 ret[key] = []
 
-            ret[key].append(ResultRecord(**rec))
+            ret[key].append(SingleResultRecord(**rec))
 
         return ret
 
@@ -372,7 +372,7 @@ class OptimizationQueries(QueryBase):
         for rec in query_result:
             self._remove_excluded_keys(rec)
             key = rec.pop("opt_id")
-            ret[key] = ResultRecord(**rec)
+            ret[key] = SingleResultRecord(**rec)
 
         return ret
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
             "tqdm",
             "plotly >=4.0.0",
             "pandas",
+            "tabulate"
             "h5py",
             "pyarrow >=0.13.0",
             #            'double-conversion >=3.0.0',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR features a new `PortalClient` client interface, functioning as a MVP demonstrator for the following design features:
- local client caching of COMPLETE procedure dataset records, with in-memory (transient) caching and filesystem (persistent) caching; designed around datasets being accessed far more frequently than they are added, and COMPLETE records not changing
- use of `__getitem__` for `BaseProcedureDataset` subclasses, such as `OptimizationDataset` as the access pattern of choice for getting records from compute specs
- moving `.data` to `._data` from top-level interface in `Collection` subclasses, treating it as an implementation detail and guiding users away from parsing it directly
- movement of other low-level methods from visible interface to `_` methods
- use of progress bars via `tqdm` to clearly indicate server communication from an action, feedback to users on wait times
- minimal use of `pandas`, in particular as a container for complex objects such as `OptimizationRecord`s, where a dict or list will do; `pandas` is a great tool, but can make the client cumbersome to use with low value-add in many cases

The approach taken here is informed by user feedback collected in late 2020 on the difficulty of using the current `FractalClient`.
We hope to make the use of the client more obvious for users by virtue of its exposed methods, interaction patterns, and responsiveness, while also improving performance for repeated access of the same dataset(s).

This approach is meant to inspire discussion, and we are early enough in the process to alter course.
Please do offer feedback!


## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
