### PR TITLE
Restrict sqlalchemy versions to < 1.4

### DIFF
--- a/devtools/conda-envs/adapter_dask.yaml
+++ b/devtools/conda-envs/adapter_dask.yaml
@@ -21,7 +21,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy >=1.3
+  - sqlalchemy >=1.3,<1.4
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/devtools/conda-envs/adapter_fireworks.yaml
+++ b/devtools/conda-envs/adapter_fireworks.yaml
@@ -21,7 +21,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy >=1.3
+  - sqlalchemy >=1.3,<1.4
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/devtools/conda-envs/adapter_parsl.yaml
+++ b/devtools/conda-envs/adapter_parsl.yaml
@@ -21,7 +21,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy >=1.3
+  - sqlalchemy >=1.3,<1.4
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -21,7 +21,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy >=1.3
+  - sqlalchemy >=1.3,<1.4
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/devtools/conda-envs/dev_head.yaml
+++ b/devtools/conda-envs/dev_head.yaml
@@ -21,7 +21,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy >=1.3
+  - sqlalchemy >=1.3,<1.4
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -23,7 +23,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy >=1.3
+  - sqlalchemy >=1.3,<1.4
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
             "bcrypt",
             "cryptography",
             # Storage dependencies
-            "sqlalchemy >=1.3",
+            "sqlalchemy >=1.3,<1.4",
             "alembic",
             "psycopg2 >=2.7",
             # QCPortal dependencies


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Sqlalchemy 1.4 breaks some stuff. This pins the version of Sqlalchemy to be below 1.4

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
