### PR TITLE
Added ability to add compute specs to only a subset of entries in Dataset

### DIFF
--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1635,6 +1635,7 @@ class Dataset(Collection):
         tag: Optional[str] = None,
         priority: Optional[str] = None,
         protocols: Optional[Dict[str, Any]] = None,
+        subset: Optional[Set[str]] = None
     ) -> ComputeResponse:
         """Executes a computational method for all reactions in the Dataset.
         Previously completed computations are not repeated.
@@ -1656,6 +1657,8 @@ class Dataset(Collection):
         protocols: Optional[Dict[str, Any]], optional
             Protocols for store more or less data per field. Current valid
             protocols: {'wavefunction'}
+        subset : Set[str], optional
+            Computes only a subset of the dataset.
 
         Returns
         -------
@@ -1668,7 +1671,10 @@ class Dataset(Collection):
         self.get_entries(force=True)
         compute_keys = {"program": program, "method": method, "basis": basis, "keywords": keywords}
 
-        molecule_idx = [e.molecule_id for e in self.data.records]
+        if subset:
+            molecule_idx = set(subset)
+        else:
+            molecule_idx = [e.molecule_id for e in self.data.records]
 
         ret = self._compute(compute_keys, molecule_idx, tag, priority, protocols)
         self.save()

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1632,10 +1632,10 @@ class Dataset(Collection):
         *,
         keywords: Optional[str] = None,
         program: Optional[str] = None,
+        subset: Optional[Set[str]] = None,
         tag: Optional[str] = None,
         priority: Optional[str] = None,
         protocols: Optional[Dict[str, Any]] = None,
-        subset: Optional[Set[str]] = None
     ) -> ComputeResponse:
         """Executes a computational method for all reactions in the Dataset.
         Previously completed computations are not repeated.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

The `Dataset.compute` method now has a `subset` keyword, allowing for a subset of entries to be assigned a new compute spec. This functionality gives better parity with the `ProcedureDataset`s, such as `OptimizationDataset`, `TorsionDriveDataset`.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

`Dataset.compute` method now has a `subset` keyword for feature parity with `OptimizationDataset.compute`, `TorsionDriveDataset.compute`.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
