### PR TITLE
Allow selecting by status in ds.get_records

### DIFF
--- a/devtools/conda-envs/adapter_parsl.yaml
+++ b/devtools/conda-envs/adapter_parsl.yaml
@@ -41,7 +41,7 @@ dependencies:
   - rdkit
   - ipyparallel
   - ipykernel
-  - parsl >=0.9.0
+  - parsl ==1.0.0
 
 #   QCArchive includes
   - qcengine >=0.17.0

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1102,6 +1102,7 @@ class Dataset(Collection):
         include: Optional[List[str]] = None,
         merge: bool = False,
         raise_on_plan: Union[str, bool] = False,
+        status: Optional[List[str]] = None,
     ) -> "pd.Series":
         """
         Runs a query based on an indexer which is index : molecule_id
@@ -1118,6 +1119,8 @@ class Dataset(Collection):
             Sum compound queries together, useful for mixing results
         raise_on_plan : Union[str, bool], optional
             Raises a KeyError is True or string if a multi-stage plan is detected.
+        status : List[str]
+            Include only records with these statuses. By default, obtain all records
 
         Returns
         -------
@@ -1151,7 +1154,7 @@ class Dataset(Collection):
             records: List[ResultRecord] = []
             for i in range(0, len(molecules), self.client.query_limit):
                 query_set["molecule"] = molecules[i : i + self.client.query_limit]
-                records.extend(self.client.query_results(**query_set))
+                records.extend(self.client.query_results(**query_set, status=status))
 
             if include is None:
                 records = [{"molecule": x.molecule, "record": x} for x in records]
@@ -1564,6 +1567,7 @@ class Dataset(Collection):
         include: Optional[List[str]] = None,
         subset: Optional[Union[str, Set[str]]] = None,
         merge: bool = False,
+        status: Optional[List[str]] = None,
     ) -> Union[pd.DataFrame, "ResultRecord"]:
         """
         Queries full ResultRecord objects from the database.
@@ -1585,6 +1589,8 @@ class Dataset(Collection):
         merge : bool
             Merge multiple results into one (as in the case of DFT-D3).
             This only works when include=['return_results'], as in get_values.
+        status : List[str]
+            Include only records with these statuses. By default, obtain all records
 
         Returns
         -------
@@ -1596,7 +1602,7 @@ class Dataset(Collection):
             raise KeyError(f"Requested query ({name}) did not match a known record.")
 
         indexer = self._molecule_indexer(subset=subset, force=True)
-        df = self._get_records(indexer, history, include=include, merge=merge)
+        df = self._get_records(indexer, history, include=include, merge=merge, status=status)
 
         if not merge and len(df) == 1:
             df = df[0]

--- a/qcfractal/interface/collections/dataset_view.py
+++ b/qcfractal/interface/collections/dataset_view.py
@@ -424,7 +424,7 @@ class HDF5View(DatasetView):
         self._entries = None
 
     def hash(self) -> str:
-        """ Returns the Blake2b hash of the view """
+        """Returns the Blake2b hash of the view"""
         b2b = hashlib.blake2b()
         with open(self._path, "rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):
@@ -433,7 +433,7 @@ class HDF5View(DatasetView):
 
     @staticmethod
     def _normalize_hdf5_name(name: str) -> str:
-        """ Handles names with / in them, which is disallowed in HDF5 """
+        """Handles names with / in them, which is disallowed in HDF5"""
         if ":" in name:
             raise ValueError("':' not allowed in names")
         return name.replace("/", ":")

--- a/qcfractal/interface/models/common_models.py
+++ b/qcfractal/interface/models/common_models.py
@@ -350,7 +350,7 @@ class KeywordSet(ProtoModel):
 
 
 class Citation(ProtoModel):
-    """ A literature citation.  """
+    """A literature citation."""
 
     acs_citation: Optional[
         str
@@ -360,5 +360,5 @@ class Citation(ProtoModel):
     url: Optional[str] = None
 
     def to_acs(self) -> str:
-        """ Returns an ACS-formatted citation """
+        """Returns an ACS-formatted citation"""
         return self.acs_citation

--- a/qcfractal/interface/tests/test_visualization.py
+++ b/qcfractal/interface/tests/test_visualization.py
@@ -78,7 +78,7 @@ def test_plot_dataset_groupby(S22Fixture, kind, groupby):
 
 @using_plotly
 def test_plot_qca_examples(S22Fixture):
-    """ Tests plotting examples from QCArchiveExamples/basic_examples/reaction_dataset.ipynb"""
+    """Tests plotting examples from QCArchiveExamples/basic_examples/reaction_dataset.ipynb"""
     client, S22 = S22Fixture
     fig = S22.visualize(method=["B3LYP", "B3LYP-D3", "B3LYP-D3M"], basis=["def2-tzvp"], groupby="D3").to_dict()
     assert "S22" in fig["layout"]["title"]["text"]

--- a/qcfractal/storage_sockets/models/sql_models.py
+++ b/qcfractal/storage_sockets/models/sql_models.py
@@ -93,7 +93,7 @@ class VersionsORM(Base):
 
 
 class KVStoreORM(Base):
-    """TODO: rename to """
+    """TODO: rename to"""
 
     __tablename__ = "kv_store"
 
@@ -300,7 +300,7 @@ class QueueManagerLogORM(Base):
 
 
 class QueueManagerORM(Base):
-    """"""
+    """ """
 
     __tablename__ = "queue_manager"
 

--- a/qcfractal/testing.py
+++ b/qcfractal/testing.py
@@ -558,7 +558,7 @@ def live_fractal_or_skip():
 
 
 def df_compare(df1, df2, sort=False):
-    """ checks equality even when columns contain numpy arrays, which .equals and == struggle with """
+    """checks equality even when columns contain numpy arrays, which .equals and == struggle with"""
     if sort:
         if isinstance(df1, pd.DataFrame):
             df1 = df1.reindex(sorted(df1.columns), axis=1)

--- a/qcfractal/tests/test_client.py
+++ b/qcfractal/tests/test_client.py
@@ -150,7 +150,7 @@ def test_collection_portal(test_server, encoding):
 
 @pytest.mark.parametrize("encoding", valid_encodings)
 def test_custom_queries(test_server, encoding):
-    """ Test the round trip between client and server in custom queries"""
+    """Test the round trip between client and server in custom queries"""
 
     client = ptl.FractalClient(test_server)
     client._set_encoding(encoding)

--- a/qcfractal/tests/test_collections.py
+++ b/qcfractal/tests/test_collections.py
@@ -337,7 +337,7 @@ def test_gradient_dataset_records_args(gradient_dataset_fixture):
 
 @pytest.fixture(scope="module", params=["download_view", "no_view", "remote_view"])
 def contributed_dataset_fixture(fractal_compute_server, tmp_path_factory, request):
-    """ Fixture for testing rich contributed datasets with many properties and molecules of different sizes"""
+    """Fixture for testing rich contributed datasets with many properties and molecules of different sizes"""
     client = ptl.FractalClient(fractal_compute_server)
     try:
         ds = client.get_collection("Dataset", "ds_contributed")
@@ -475,7 +475,7 @@ def test_dataset_contributed_mixed_values(contributed_dataset_fixture):
 
 
 def test_dataset_compute_response(fractal_compute_server):
-    """ Tests that the full compute response is returned when calling Dataset.compute """
+    """Tests that the full compute response is returned when calling Dataset.compute"""
     client = ptl.FractalClient(fractal_compute_server)
 
     # Build a dataset
@@ -498,7 +498,7 @@ def test_dataset_compute_response(fractal_compute_server):
 
 @testing.using_psi4
 def test_dataset_protocols(fractal_compute_server):
-    """ Tests using protocols with dataset compute."""
+    """Tests using protocols with dataset compute."""
     client = ptl.FractalClient(fractal_compute_server)
 
     # Build basis dataset
@@ -964,7 +964,7 @@ def s22_fixture(request, tmp_path_factory):
 
 @pytest.mark.slow
 def test_qm3_list_select(qm3_fixture):
-    """ tests list_values and get_values with multiple selections on the method and basis field """
+    """tests list_values and get_values with multiple selections on the method and basis field"""
     client, ds = qm3_fixture
 
     methods = {"b3lyp", "pbe"}
@@ -986,7 +986,7 @@ def test_qm3_list_select(qm3_fixture):
 
 @pytest.mark.slow
 def test_s22_list_select(s22_fixture):
-    """ tests list_values and get_values with multiple selections on the method and basis field """
+    """tests list_values and get_values with multiple selections on the method and basis field"""
     client, ds = s22_fixture
 
     methods = {"b3lyp", "pbe"}
@@ -1023,7 +1023,7 @@ def test_rds_rxn(fractal_compute_server):
 
 
 def assert_list_get_values(ds):
-    """ Tests that the output of list_values can be used as input to get_values"""
+    """Tests that the output of list_values can be used as input to get_values"""
     columns = ds.list_values().reset_index()
     all_specs_unique = len(columns.drop("name", axis=1).drop_duplicates()) == len(columns.drop("name", axis=1))
     for row in columns.to_dict("records"):
@@ -1068,7 +1068,7 @@ def test_s22_list_get_values(s22_fixture):
 
 
 def assert_view_identical(ds):
-    """ Tests if get_values, list_values, get_entries, and get_molecules return the same result with/out a view"""
+    """Tests if get_values, list_values, get_entries, and get_molecules return the same result with/out a view"""
 
     ds._disable_view = True
     list_ds = ds.list_values(force=True)

--- a/qcfractal/tests/test_server.py
+++ b/qcfractal/tests/test_server.py
@@ -122,7 +122,7 @@ def test_bad_collection_post(test_server):
 
 
 def test_bad_view_endpoints(test_server):
-    """ Tests that certain misspellings of the view endpoints result in 404s """
+    """Tests that certain misspellings of the view endpoints result in 404s"""
     addr = test_server.get_address()
 
     assert requests.get(addr + "collection//value").status_code == 404

--- a/qcfractal/tests/test_services.py
+++ b/qcfractal/tests/test_services.py
@@ -131,7 +131,7 @@ def test_service_manipulation(torsiondrive_fixture):
 
 
 def test_service_torsiondrive_single(torsiondrive_fixture):
-    """"Tests torsiondrive pathway and checks the result """
+    """ "Tests torsiondrive pathway and checks the result"""
 
     spin_up_test, client = torsiondrive_fixture
 
@@ -190,7 +190,7 @@ def test_service_torsiondrive_duplicates(torsiondrive_fixture):
 
 @pytest.mark.slow
 def test_service_torsiondrive_option_dihedral_ranges(torsiondrive_fixture):
-    """"Tests torsiondrive with dihedral_ranges optional keyword """
+    """ "Tests torsiondrive with dihedral_ranges optional keyword"""
 
     spin_up_test, client = torsiondrive_fixture
     ret = spin_up_test(keywords={"grid_spacing": [30], "dihedral_ranges": [[-150, -60]]})
@@ -214,7 +214,7 @@ def test_service_torsiondrive_option_dihedral_ranges(torsiondrive_fixture):
 
 @pytest.mark.slow
 def test_service_torsiondrive_option_energy_decrease_thresh(torsiondrive_fixture):
-    """"Tests torsiondrive with energy_decrease_thresh optional keyword"""
+    """ "Tests torsiondrive with energy_decrease_thresh optional keyword"""
 
     spin_up_test, client = torsiondrive_fixture
     ret = spin_up_test(keywords={"grid_spacing": [90], "energy_decrease_thresh": 3e-5})
@@ -233,7 +233,7 @@ def test_service_torsiondrive_option_energy_decrease_thresh(torsiondrive_fixture
 
 @pytest.mark.slow
 def test_service_torsiondrive_option_energy_upper_limit(torsiondrive_fixture):
-    """"Tests torsiondrive with energy_upper_limit optional keyword"""
+    """ "Tests torsiondrive with energy_upper_limit optional keyword"""
 
     spin_up_test, client = torsiondrive_fixture
     ret = spin_up_test(keywords={"grid_spacing": [30], "energy_upper_limit": 1e-4})
@@ -252,7 +252,7 @@ def test_service_torsiondrive_option_energy_upper_limit(torsiondrive_fixture):
 
 @pytest.mark.slow
 def test_service_torsiondrive_option_extra_constraints(torsiondrive_fixture):
-    """"Tests torsiondrive with extra_constraints in optimization_spec """
+    """ "Tests torsiondrive with extra_constraints in optimization_spec"""
 
     spin_up_test, client = torsiondrive_fixture
     ret = spin_up_test(

--- a/qcfractal/tests/test_storage_queries.py
+++ b/qcfractal/tests/test_storage_queries.py
@@ -87,7 +87,7 @@ def test_molecule_count_queries(torsiondrive_fixture, fractal_compute_server):
 
 
 def test_torsiondrive_initial_final_molecule(torsiondrive_fixture, fractal_compute_server):
-    """ With single initial molecule in torsion proc"""
+    """With single initial molecule in torsion proc"""
 
     torsion, client = torsiondrive_fixture
 
@@ -122,7 +122,7 @@ def test_torsiondrive_initial_final_molecule(torsiondrive_fixture, fractal_compu
 
 
 def test_torsiondrive_return_results(torsiondrive_fixture, fractal_compute_server):
-    """ With single initial molecule in torsion proc"""
+    """With single initial molecule in torsion proc"""
 
     torsion, client = torsiondrive_fixture
 
@@ -133,7 +133,7 @@ def test_torsiondrive_return_results(torsiondrive_fixture, fractal_compute_serve
 
 
 def test_optimization_best_results(torsiondrive_fixture, fractal_compute_server):
-    """ Test return best optimization proc results in one query"""
+    """Test return best optimization proc results in one query"""
 
     torsion, client = torsiondrive_fixture
 
@@ -148,7 +148,7 @@ def test_optimization_best_results(torsiondrive_fixture, fractal_compute_server)
 
 
 def test_optimization_all_results(torsiondrive_fixture, fractal_compute_server):
-    """ Test return best optimization proc results in one query"""
+    """Test return best optimization proc results in one query"""
 
     torsion, client = torsiondrive_fixture
 
@@ -165,7 +165,7 @@ def test_optimization_all_results(torsiondrive_fixture, fractal_compute_server):
 
 
 def test_optimization_initial_molecules(torsiondrive_fixture, fractal_compute_server):
-    """ Test return best optimization proc results in one query"""
+    """Test return best optimization proc results in one query"""
 
     torsion, client = torsiondrive_fixture
 
@@ -180,7 +180,7 @@ def test_optimization_initial_molecules(torsiondrive_fixture, fractal_compute_se
 
 
 def test_optimization_final_molecules(torsiondrive_fixture, fractal_compute_server):
-    """ Test return best optimization proc results in one query"""
+    """Test return best optimization proc results in one query"""
 
     torsion, client = torsiondrive_fixture
 

--- a/qcfractal/web_handlers.py
+++ b/qcfractal/web_handlers.py
@@ -141,7 +141,7 @@ class InformationHandler(APIHandler):
     _required_auth = "read"
 
     def get(self):
-        """"""
+        """ """
 
         self.logger.info("GET: Information")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
By default, dataset `get_records` will only retrieve records with status = COMPLETE. This allows for selecting records by status,
with the default being to obtain all records.

This also has a small fix, constraining the version of parsl in the test environments

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Allow retrieving dataset records by status

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
