### PR TITLE
Small shim in `FractalClient.query_results` for old Result models

### DIFF
--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -720,7 +720,10 @@ class FractalClient(object):
         # Add references back to the client
         if not include:
             for result in response.data:
-                result.__dict__["client"] = self
+                if isinstance(result, dict):
+                    result['client'] = self
+                else:
+                    result.__dict__["client"] = self
 
         if full_return:
             return response

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -699,7 +699,8 @@ class FractalClient(object):
         -------
         Union[List[RecordResult], Dict[str, Any]]
             Returns a List of found RecordResult's without include, or a
-            dictionary of results with include.
+            dictionary of results with include. A dictionary will be returned
+            of a result is defined with an outdated model (temporary workaround).
         """
         payload = {
             "meta": {"limit": limit, "skip": skip, "include": include},

--- a/qcfractal/interface/client.py
+++ b/qcfractal/interface/client.py
@@ -722,7 +722,7 @@ class FractalClient(object):
         if not include:
             for result in response.data:
                 if isinstance(result, dict):
-                    result['client'] = self
+                    result["client"] = self
                 else:
                     result.__dict__["client"] = self
 


### PR DESCRIPTION
Addresses #674.

There are some datasets in the database with old QCElemental result models that fail validation when queries. These are retruned by `FractalClient._automodel_request` as dictionaries, even without `include` specified. This shim handles these cases as gracefully as we can at this time until the old results are migrated to the new result model.

<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
