### PR TITLE
Make fields of provenance not null, and fix other validation issues

### DIFF
--- a/qcfractal/alembic/versions/469ece903d76_migrate_provenance_to_not_null.py
+++ b/qcfractal/alembic/versions/469ece903d76_migrate_provenance_to_not_null.py
@@ -1,0 +1,61 @@
+"""migrate provenance to not null
+
+Revision ID: 469ece903d76
+Revises: 6b07e9a3589d
+Create Date: 2021-05-02 09:48:57.061825
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm.session import Session
+
+
+# revision identifiers, used by Alembic.
+revision = "469ece903d76"
+down_revision = "6b07e9a3589d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE base_result SET provenance = provenance::jsonb || '{\"creator\":\"\"}' where (provenance->'creator')::text = 'null'"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE base_result SET provenance = provenance::jsonb || '{\"routine\":\"\"}' where (provenance->'routine')::text = 'null'"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE base_result SET provenance = provenance::jsonb || '{\"version\":\"\"}' where (provenance->'version')::text = 'null'"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE molecule SET provenance = provenance::jsonb || '{\"creator\":\"\"}' where (provenance->'creator')::text = 'null'"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE molecule SET provenance = provenance::jsonb || '{\"routine\":\"\"}' where (provenance->'routine')::text = 'null'"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE molecule SET provenance = provenance::jsonb || '{\"version\":\"\"}' where (provenance->'version')::text = 'null'"
+        )
+    )
+    conn.execute(sa.text("UPDATE molecule SET connectivity = null where connectivity::text = '[]'"))
+    conn.execute(
+        sa.text(
+            "UPDATE result SET properties = properties::jsonb - 'mp2_total_correlation_energy' || jsonb_build_object('mp2_correlation_energy', properties->'mp2_total_correlation_energy') WHERE properties::jsonb ? 'mp2_total_correlation_energy'"
+        )
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR migrates some old data in the database. This old data was causing validation errors.

Errors fixed:

- Molecule where connectivity is an empty list (should either be None or a list with length > 1) (See https://github.com/MolSSI/QCArchiveExamples/issues/16)
- Provenance fields that were None/null (should be empty string)
- Result properties with `mp2_total_correlation_energy` (should be `mp2_correlation_energy`)

This has been thoroughly tested against a copy of the production database to ensure integrity (ie, it doesn't change data unless it needs to be changed)

## Changelog description
Provide data migration for old data that no longer passes validation

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
