### PR TITLE
Fix pandas/byte array conversion in views (and other CI issues)

### DIFF
--- a/devtools/conda-envs/adapter_dask.yaml
+++ b/devtools/conda-envs/adapter_dask.yaml
@@ -39,8 +39,8 @@ dependencies:
 
 #   Environment specific includes
   - rdkit
-  - dask
-  - distributed
+  - dask==2021.5.0
+  - distributed==2021.5.0
   - dask-jobqueue >=0.5.0
 
 #   QCArchive includes


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Fixes two issues that have been plaguing CI for a while

- HDF5 stores fields as byte arrays. We need to convert these back to strings when used as indices in pandas dataframes
- Conda's weird dependency resolution will install different versions of `dask` and `distributed`. So pin them for now and move on with life.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

- Fix byte array/string conversion between HDF5/pandas in view code
- Pin version of dask to prevent conda from installing incompatible versions

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
