### PR TITLE
Fix incorrect reporting in collection status

### DIFF
--- a/qcfractal/interface/collections/collection.py
+++ b/qcfractal/interface/collections/collection.py
@@ -597,7 +597,7 @@ class BaseProcedureDataset(Collection):
             df = self.df[specs].apply(lambda col: col.apply(get_status))
 
             if status:
-                df = df[(df == status.upper()).all(axis=1)]
+                df = df[(df == status.upper())]
 
             if collapse:
                 return df.apply(lambda x: x.value_counts())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

Fix incorrect reporting in some collections. If a status is specified to the `status()` function, the number of records corresponding to that status was incorrectly calculated. It was calculated in such a way that only if all specifications were that status for a record would it be counted. This led to a mismatch between `get_status()` and `get_status(status='COMPLETE')`

Before:
![before](https://user-images.githubusercontent.com/4708439/120893428-4f14aa80-c5e1-11eb-9e37-2a3fd1e180a1.png)

After:
![after](https://user-images.githubusercontent.com/4708439/120893430-520f9b00-c5e1-11eb-8f6c-345c485e9604.png)


## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fixes incorrect status reporting in collections

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
