### PR TITLE
Hack fix for d3 calculations which shouldn't be split in the planner

### DIFF
--- a/qcfractal/interface/collections/collection_utils.py
+++ b/qcfractal/interface/collections/collection_utils.py
@@ -99,6 +99,10 @@ def composition_planner(program=None, method=None, basis=None, driver=None, keyw
 
     base = {"program": program, "method": method, "basis": basis, "driver": driver, "keywords": keywords}
 
+    # HACK: shortcut these. See issue #688
+    if method.lower() in ["b97-d3bj", "b97m-d3bj", "wb97m-d3bj"]:
+        return [base]
+
     if ("-d3" in method.lower()) and ("dftd3" != program.lower()) and ("hessian" != driver.lower()):
         dftd3keys = {"program": "dftd3", "method": method, "basis": None, "driver": driver, "keywords": None}
         base["method"] = method.lower().split("-d3")[0]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fixes issue #688

These functionals shouldn't be split in the composition planner, as the first part isn't available in psi4 as a plain functional.

This is a temporary fix. The next major version will probably do away with the composition planner altogether.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Skip composition planner for certain functionals

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [x] Ready to go
