### PR TITLE
QCElemental 0.23.0 update

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,12 +39,21 @@ jobs:
           ulimit -a
 
       - name: Configure conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: qcarchive
           environment-file: devtools/conda-envs/${{ matrix.environ }}.yaml
+
+          channels: conda-forge,psi4,defaults
+
           auto-activate-base: false
+          auto-update-conda: true
+          show-channel-urls: true
+          mamba-version: "*"
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
 
       - name: Environment Information
         shell: bash -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,9 +44,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: qcarchive
           environment-file: devtools/conda-envs/${{ matrix.environ }}.yaml
-
-          channels: conda-forge,psi4,defaults
-
           auto-activate-base: false
           auto-update-conda: true
           show-channel-urls: true

--- a/devtools/conda-envs/adapter_dask.yaml
+++ b/devtools/conda-envs/adapter_dask.yaml
@@ -44,5 +44,5 @@ dependencies:
   - dask-jobqueue >=0.5.0
 
 #   QCArchive includes
-  - qcengine >=0.17.0,<0.20
-  - qcelemental >=0.17.0,<0.23
+  - qcengine >=0.20
+  - qcelemental >=0.23

--- a/devtools/conda-envs/adapter_dask.yaml
+++ b/devtools/conda-envs/adapter_dask.yaml
@@ -18,7 +18,7 @@ dependencies:
   - cryptography
 
   # Storage dependencies
-  - alembic
+  - conda-forge::alembic
   - psycopg2 >=2.7
   - postgresql
   - sqlalchemy >=1.3,<1.4
@@ -44,5 +44,5 @@ dependencies:
   - dask-jobqueue >=0.5.0
 
 #   QCArchive includes
-  - qcengine >=0.20
-  - qcelemental >=0.23
+  - qcengine >=0.20,<0.21
+  - qcelemental >=0.23,<0.24

--- a/devtools/conda-envs/adapter_fireworks.yaml
+++ b/devtools/conda-envs/adapter_fireworks.yaml
@@ -18,7 +18,7 @@ dependencies:
   - cryptography
 
   # Storage dependencies
-  - alembic
+  - conda-forge::alembic
   - psycopg2 >=2.7
   - postgresql
   - sqlalchemy >=1.3,<1.4
@@ -38,8 +38,8 @@ dependencies:
   - requests-mock
 
 #   QCArchive includes
-  - qcengine >=0.20
-  - qcelemental >=0.23
+  - qcengine >=0.20,<0.21
+  - qcelemental >=0.23,<0.24
 
 #   Pip includes
   - pip:

--- a/devtools/conda-envs/adapter_fireworks.yaml
+++ b/devtools/conda-envs/adapter_fireworks.yaml
@@ -38,8 +38,8 @@ dependencies:
   - requests-mock
 
 #   QCArchive includes
-  - qcengine >=0.17.0,<0.20
-  - qcelemental >=0.17.0,<0.23
+  - qcengine >=0.20
+  - qcelemental >=0.23
 
 #   Pip includes
   - pip:

--- a/devtools/conda-envs/adapter_parsl.yaml
+++ b/devtools/conda-envs/adapter_parsl.yaml
@@ -18,7 +18,7 @@ dependencies:
   - cryptography
 
   # Storage dependencies
-  - alembic
+  - conda-forge::alembic
   - psycopg2 >=2.7
   - postgresql
   - sqlalchemy >=1.3,<1.4
@@ -44,5 +44,5 @@ dependencies:
   - parsl ==1.0.0
 
 #   QCArchive includes
-  - qcengine >=0.20
-  - qcelemental >=0.23
+  - qcengine >=0.20,<0.21
+  - qcelemental >=0.23,<0.24

--- a/devtools/conda-envs/adapter_parsl.yaml
+++ b/devtools/conda-envs/adapter_parsl.yaml
@@ -44,5 +44,5 @@ dependencies:
   - parsl ==1.0.0
 
 #   QCArchive includes
-  - qcengine >=0.17.0,<0.20
-  - qcelemental >=0.17.0,<0.23
+  - qcengine >=0.20
+  - qcelemental >=0.23

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -38,5 +38,5 @@ dependencies:
   - requests-mock
 
 #   QCArchive includes
-  - qcengine >=0.17.0,<0.20
-  - qcelemental >=0.17.0,<0.23
+  - qcengine >=0.20
+  - qcelemental >=0.23

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -18,7 +18,7 @@ dependencies:
   - cryptography
 
   # Storage dependencies
-  - alembic
+  - conda-forge::alembic
   - psycopg2 >=2.7
   - postgresql
   - sqlalchemy >=1.3,<1.4
@@ -38,5 +38,5 @@ dependencies:
   - requests-mock
 
 #   QCArchive includes
-  - qcengine >=0.20
-  - qcelemental >=0.23
+  - qcengine >=0.20,<0.21
+  - qcelemental >=0.23,<0.24

--- a/devtools/conda-envs/dev_head.yaml
+++ b/devtools/conda-envs/dev_head.yaml
@@ -18,7 +18,7 @@ dependencies:
   - cryptography
 
   # Storage dependencies
-  - alembic
+  - conda-forge::alembic
   - psycopg2 >=2.7
   - postgresql
   - sqlalchemy >=1.3,<1.4

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -1,7 +1,7 @@
 name: qcarchive
 channels:
   - defaults
-  - psi4
+  - psi4/label/dev
   - conda-forge
 dependencies:
   - pip
@@ -39,7 +39,7 @@ dependencies:
   - requests-mock
 
 #   Environment specific includes
-  - psi4 >=1.4.1
+  - psi4
   - gau2grid
   - rdkit
   - geometric >=0.9.3

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -19,7 +19,7 @@ dependencies:
   - cryptography
 
   # Storage dependencies
-  - alembic
+  - conda-forge::alembic
   - psycopg2 >=2.7
   - postgresql
   - sqlalchemy >=1.3,<1.4
@@ -51,5 +51,5 @@ dependencies:
   - openmmforcefields >=0.8.0
 
 #   QCArchive includes
-  - qcengine >=0.20
-  - qcelemental >=0.23
+  - qcengine >=0.20,<0.21
+  - qcelemental >=0.23,<0.24

--- a/devtools/conda-envs/openff.yaml
+++ b/devtools/conda-envs/openff.yaml
@@ -1,8 +1,7 @@
 name: qcarchive
 channels:
   - defaults
-  - omnia
-  - psi4/label/dev
+  - psi4
   - conda-forge
 dependencies:
   - pip
@@ -40,17 +39,17 @@ dependencies:
   - requests-mock
 
 #   Environment specific includes
-  - psi4>1.4a2.dev700,<1.4a2
-  - gau2grid=2.0.3
+  - psi4 >=1.4.1
+  - gau2grid
   - rdkit
   - geometric >=0.9.3
   - torsiondrive
   - dftd3
-  - openforcefield >=0.7.1
-  - openforcefields >=1.2.0
-  - openmm >=7.4.2
+  - openff-toolkit >=0.10.0
+  - openff-forcefields >=2.0.0
+  - openmm >=7.6.0
   - openmmforcefields >=0.8.0
 
 #   QCArchive includes
-  - qcengine >=0.17.0,<0.20
-  - qcelemental >=0.17.0,<0.23
+  - qcengine >=0.20
+  - qcelemental >=0.23

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1221,7 +1221,10 @@ class SQLAlchemySocket:
 
                 if idx not in existing_results:
                     # Does not exist in the database. Construct a new ResultORM
-                    doc = ResultORM(**result.dict(exclude={"id"}, encoding="json"))
+                    doc = ResultORM(**result.dict(exclude={"id", "properties"}))
+
+                    # Keep properties as JSON (PR #694)
+                    doc.properties = result.properties.dict(encoding="json")
 
                     # Store in existing_results in case later records are duplicates
                     existing_results[idx] = doc
@@ -1312,8 +1315,11 @@ class SQLAlchemySocket:
                 if result.id is None:
                     self.logger.error("Attempted update without ID, skipping")
                     continue
-                # must use json encoding to remove numpy arrays
-                data = result.dict(exclude={"id"}, encoding="json")
+
+                # must use json encoding to remove numpy arrays of properties
+                data = result.dict(exclude={"id", "properties"})
+                data["properties"] = result.properties.dict(encoding="json")
+
                 # retrieve the found item
                 found_db = found_dict[result.id]
 

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1224,7 +1224,8 @@ class SQLAlchemySocket:
                     doc = ResultORM(**result.dict(exclude={"id", "properties"}))
 
                     # Keep properties as JSON (PR #694)
-                    doc.properties = result.properties.dict(encoding="json")
+                    if result.properties is not None:
+                        doc.properties = result.properties.dict(encoding="json")
 
                     # Store in existing_results in case later records are duplicates
                     existing_results[idx] = doc
@@ -1318,7 +1319,9 @@ class SQLAlchemySocket:
 
                 # must use json encoding to remove numpy arrays of properties
                 data = result.dict(exclude={"id", "properties"})
-                data["properties"] = result.properties.dict(encoding="json")
+
+                if result.properties is not None:
+                    data["properties"] = result.properties.dict(encoding="json")
 
                 # retrieve the found item
                 found_db = found_dict[result.id]

--- a/qcfractal/storage_sockets/sqlalchemy_socket.py
+++ b/qcfractal/storage_sockets/sqlalchemy_socket.py
@@ -1221,7 +1221,7 @@ class SQLAlchemySocket:
 
                 if idx not in existing_results:
                     # Does not exist in the database. Construct a new ResultORM
-                    doc = ResultORM(**result.dict(exclude={"id"}))
+                    doc = ResultORM(**result.dict(exclude={"id"}, encoding="json"))
 
                     # Store in existing_results in case later records are duplicates
                     existing_results[idx] = doc
@@ -1312,8 +1312,8 @@ class SQLAlchemySocket:
                 if result.id is None:
                     self.logger.error("Attempted update without ID, skipping")
                     continue
-
-                data = result.dict(exclude={"id"})
+                # must use json encoding to remove numpy arrays
+                data = result.dict(exclude={"id"}, encoding="json")
                 # retrieve the found item
                 found_db = found_dict[result.id]
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ if __name__ == "__main__":
             "pyarrow >=0.15.0",
             #            'double-conversion >=3.0.0',
             # QCArchive depends
-            "qcengine>=0.11.0,<0.20",
-            "qcelemental>=0.13.1,<0.23",
+            "qcengine>=0.20",
+            "qcelemental>=0.23",
         ],
         entry_points={
             "console_scripts": [


### PR DESCRIPTION
## Description
This PR should make QCFractal compatible with qcelemental=0.23.0, we now use the json encoding on dicts when adding or updating results which should remove all non-json serializable objects. 

## Changelog description
Update QCFractal to work with QCElemental=0.23.0

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
