### PR TITLE
export version in tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+qcfractal/_version.py export-subst


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. --> You'll want this to avoid https://github.com/MolSSI/QCEngine/issues/337 . It's supposed to happen at versioneer installation time and was fine with qcel, but it's missing in qcng and qcf. Perhaps a local gitignore

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [x] Ready to go
