### PR TITLE
modifed line to eliminate duplicate entries in the return dataframe of a ReactionDataset

### DIFF
--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1185,7 +1185,7 @@ class Dataset(Collection):
             raise KeyError("Query matched 0 records.")
 
         if merge:
-            retdf = ret[0]
+            retdf = ret[0][~ret[0].index.duplicated(keep='first')]
             for df in ret[1:]:
                 retdf += df
             return retdf


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description

When doing query results and in the database there are  two molecules that are identical except for the keywords, then both molecules are pulled even though` keyword=None` is explicitly used. This has as a consequence that the result record of both are stored in the dataframe of the ReactionDataset, which breaks the stoichiometry and gives wrong values when using  `ds.get_values(method='XXXX') `. For example if the same molecule was computed with the _keyword uks_  and _None_,  for an open shell molecule the result is the same (since uks is the default), such that both result records appear in the dataframe as en entry because both are pulled from the database when building the stoichiometry in databse.py. 

## Changelog description
modifed line 1188 to remove duplicate entries in the dataframe

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
