### PR TITLE
Make saving optional when calling `Dataset.compute`

### DIFF
--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1643,7 +1643,7 @@ class Dataset(Collection):
         tag: Optional[str] = None,
         priority: Optional[str] = None,
         protocols: Optional[Dict[str, Any]] = None,
-        save: Optional[bool] = True
+        save: Optional[bool] = True,
     ) -> ComputeResponse:
         """Executes a computational method for all reactions in the Dataset.
         Previously completed computations are not repeated.

--- a/qcfractal/interface/collections/dataset.py
+++ b/qcfractal/interface/collections/dataset.py
@@ -1643,6 +1643,7 @@ class Dataset(Collection):
         tag: Optional[str] = None,
         priority: Optional[str] = None,
         protocols: Optional[Dict[str, Any]] = None,
+        save: Optional[bool] = True
     ) -> ComputeResponse:
         """Executes a computational method for all reactions in the Dataset.
         Previously completed computations are not repeated.
@@ -1666,6 +1667,8 @@ class Dataset(Collection):
             protocols: {'wavefunction'}
         subset : Set[str], optional
             Computes only a subset of the dataset.
+        save : bool, optional
+            If `True`, save the whole collection after calling compute
 
         Returns
         -------
@@ -1684,7 +1687,9 @@ class Dataset(Collection):
             molecule_idx = [e.molecule_id for e in self.data.records]
 
         ret = self._compute(compute_keys, molecule_idx, tag, priority, protocols)
-        self.save()
+
+        if save:
+            self.save()
 
         return ret
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Saving collection optional when calling `Dataset.compute`; this is valuable when doing subsets of compute calls and it isn't necessary to save on every call.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Saving collection optional when calling `Dataset.compute`

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
