### PR TITLE
pydantic model docs, objects.inv, aftermath removing qcel autodoc

### DIFF
--- a/docs/qcfractal/source/conf.py
+++ b/docs/qcfractal/source/conf.py
@@ -58,12 +58,18 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.automodsumm',
-    'nbsphinx'
+    'nbsphinx',
+    "sphinxcontrib.autodoc_pydantic",
 ]
 
 napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
+
+autodoc_typehints = "description"
+autodoc_pydantic_model_hide_paramlist = True
+autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_field_swap_name_and_alias = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -220,13 +226,13 @@ extlinks = {
 # -- Keywords for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {
-                       # 'python': ('https://docs.python.org/3.7', None),
-                       # 'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-                       # 'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-                       # 'matplotlib': ('https://matplotlib.org/', None),
-                       'qcelemental': ('https://qcelemental.readthedocs.io/en/latest/', None),
-                       'qcengine': ('https://qcengine.readthedocs.io/en/latest/', None),
+intersphinx_mapping = {'python': ('https://docs.python.org/3.10', None),
+                       "numpy": ("https://numpy.org/doc/stable/", None),
+                       'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+                       'matplotlib': ('https://matplotlib.org/stable/', None),
+                       "qcelemental": ("http://docs.qcarchive.molssi.org/projects/QCElemental/en/latest/", None),
+                       "qcengine": ("http://docs.qcarchive.molssi.org/projects/QCEngine/en/latest/", None),
+                       "qcportal": ("http://docs.qcarchive.molssi.org/projects/QCPortal/en/latest/", None),
                       }
 
 # -- Keywords for todo extension ----------------------------------------------

--- a/docs/qcfractal/source/managers_config_api.rst
+++ b/docs/qcfractal/source/managers_config_api.rst
@@ -21,13 +21,13 @@ Each section below here is summarized the same way, showing all the options for 
 `pydantic <https://pydantic-docs.helpmanual.io/>`_ API which the YAML is fed into in a one-to-one match of options.
 
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.ManagerSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.ManagerSettings
 
 
 common
 ------
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.CommonManagerSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.CommonManagerSettings
 
 
 .. _managers_server:
@@ -35,40 +35,40 @@ common
 server
 ------
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.FractalServerSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.FractalServerSettings
 
 
 manager
 -------
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.QueueManagerSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.QueueManagerSettings
 
 
 cluster
 -------
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.ClusterSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.ClusterSettings
 
 
 dask
 ----
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.DaskQueueSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.DaskQueueSettings
 
 
 parsl
 -----
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.ParslQueueSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.ParslQueueSettings
 
 
 executor
 ++++++++
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.ParslExecutorSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.ParslExecutorSettings
 
 
 provider
 ++++++++
 
-.. autoclass:: qcfractal.cli.qcfractal_manager.ParslProviderSettings
+.. autopydantic_model:: qcfractal.cli.qcfractal_manager.ParslProviderSettings

--- a/docs/qcfractal/source/server_config.rst
+++ b/docs/qcfractal/source/server_config.rst
@@ -38,23 +38,23 @@ Config File Complete Options
 
 The valid top-level YAML headers are the parameters of the ``FractalConfig`` class.
 
-.. autoclass:: qcfractal.config.FractalConfig
+.. autopydantic_model:: qcfractal.config.FractalConfig
    :members:
 
 ``database``
 ************
 
-.. autoclass:: qcfractal.config.DatabaseSettings
+.. autopydantic_model:: qcfractal.config.DatabaseSettings
    :members:
 
 ``fractal``
 ***********
 
-.. autoclass:: qcfractal.config.FractalServerSettings
+.. autopydantic_model:: qcfractal.config.FractalServerSettings
    :members:
 
 ``view``
 ********
 
-.. autoclass:: qcfractal.config.ViewSettings
+.. autopydantic_model:: qcfractal.config.ViewSettings
    :members:

--- a/docs/qcportal/source/client-api.rst
+++ b/docs/qcportal/source/client-api.rst
@@ -79,3 +79,9 @@ Function Definitions
 .. autofunction:: add_service
 
 .. autofunction:: query_services
+
+API
+---
+
+.. autoclass:: qcportal.FractalClient
+

--- a/docs/qcportal/source/conf.py
+++ b/docs/qcportal/source/conf.py
@@ -63,11 +63,17 @@ extensions = [
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.automodsumm',
     'nbsphinx',
+    "sphinxcontrib.autodoc_pydantic",
 ]
 
 napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
+
+autodoc_typehints = "description"
+autodoc_pydantic_model_hide_paramlist = True
+autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_field_swap_name_and_alias = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -213,13 +219,14 @@ extlinks = {
 # -- Keywords for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-#intersphinx_mapping = {'python': ('https://docs.python.org/3.7', None),
-#                       'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-#                       'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-#                       'matplotlib': ('https://matplotlib.org/', None),
-#                       'qcelemental': ('https://qcelemental.readthedocs.io/en/latest/', None),
-#                       'qcengine': ('https://qcengine.readthedocs.io/en/latest/', None),
-#                      }
+intersphinx_mapping = {'python': ('https://docs.python.org/3.10', None),
+                       "numpy": ("https://numpy.org/doc/stable/", None),
+                       'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+                       'matplotlib': ('https://matplotlib.org/stable/', None),
+                       "qcelemental": ("http://docs.qcarchive.molssi.org/projects/QCElemental/en/latest/", None),
+                       "qcengine": ("http://docs.qcarchive.molssi.org/projects/QCEngine/en/latest/", None),
+                       "qcfractal": ("http://docs.qcarchive.molssi.org/projects/QCFractal/en/latest/", None),
+                      }
 
 # -- Keywords for todo extension ----------------------------------------------
 

--- a/docs/qcportal/source/record-api.rst
+++ b/docs/qcportal/source/record-api.rst
@@ -5,29 +5,35 @@ API
 The complete set of object models and relations implemented by QCPortal. Every class shown here is its own model
 and the attributes shown are valid kwargs and values which can be fed into the construction.
 
+from other projects
 
-.. autoclass:: qcportal.models.KeywordSet
+* :py:class:`qcelemental.models.Molecule`
 
-.. autoclass:: qcportal.models.Molecule
+.. autopydantic_model:: qcportal.models.KeywordSet
 
-.. autoclass:: qcportal.models.OptimizationRecord
+.. already in qcel .. autopydantic_model:: qcportal.models.Molecule
+
+.. autopydantic_model:: qcportal.models.OptimizationRecord
+   :members:
+   :noindex:
+
+.. autopydantic_model:: qcportal.models.QCSpecification
+
+.. autopydantic_model:: qcportal.models.GridOptimizationInput
+
+.. autopydantic_model:: qcportal.models.GridOptimizationRecord
    :members:
 
-.. autoclass:: qcportal.models.QCSpecification
+.. autopydantic_model:: qcportal.models.OptimizationSpecification
 
-.. autoclass:: qcportal.models.GridOptimizationInput
+.. already in qcel but not exported
+.. autopydantic_model:: qcportal.models.OptimizationProtocols
 
-.. autoclass:: qcportal.models.GridOptimizationRecord
-   :members:
+.. already in qcel but not exported
+.. autopydantic_model:: qcportal.models.ResultProtocols
 
-.. autoclass:: qcportal.models.OptimizationSpecification
+.. autopydantic_model:: qcportal.models.TorsionDriveInput
 
-.. autoclass:: qcportal.models.OptimizationProtocols
+.. autopydantic_model:: qcportal.models.TorsionDriveRecord
 
-.. autoclass:: qcportal.models.ResultProtocols
-
-.. autoclass:: qcportal.models.TorsionDriveInput
-
-.. autoclass:: qcportal.models.TorsionDriveRecord
-
-.. autoclass:: qcportal.models.WavefunctionProtocols
+.. does not exist in qcel .. autoclass:: qcportal.models.WavefunctionProtocols

--- a/docs/qcportal/source/record-optimization.rst
+++ b/docs/qcportal/source/record-optimization.rst
@@ -14,5 +14,5 @@ The ``Record`` of a geometry optimization.
 Attributes
 ----------
 
-.. autoclass:: qcportal.models.OptimizationRecord
+.. autopydantic_model:: qcportal.models.OptimizationRecord
     :members:

--- a/docs/qcportal/source/record-result.rst
+++ b/docs/qcportal/source/record-result.rst
@@ -15,6 +15,6 @@ which can correspond to an energy, gradient, Hessian, or property computation.
 Attributes
 ----------
 
-.. autoclass:: qcportal.models.ResultRecord
+.. autopydantic_model:: qcportal.models.ResultRecord
 
 

--- a/docs/qcportal/source/rest-api.rst
+++ b/docs/qcportal/source/rest-api.rst
@@ -14,33 +14,33 @@ Responses (like Metadata), but occur many times in the normal calls.
 KV Store
 --------
 
-.. autoclass:: qcportal.models.rest_models.KVStoreGETBody
+.. autopydantic_model:: qcportal.models.rest_models.KVStoreGETBody
 
-.. autoclass:: qcportal.models.rest_models.KVStoreGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.KVStoreGETResponse
 
 --------
 Molecule
 --------
 
-.. autoclass:: qcportal.models.rest_models.MoleculeGETBody
+.. autopydantic_model:: qcportal.models.rest_models.MoleculeGETBody
 
-.. autoclass:: qcportal.models.rest_models.MoleculeGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.MoleculeGETResponse
 
-.. autoclass:: qcportal.models.rest_models.MoleculePOSTBody
+.. autopydantic_model:: qcportal.models.rest_models.MoleculePOSTBody
 
-.. autoclass:: qcportal.models.rest_models.MoleculePOSTResponse
+.. autopydantic_model:: qcportal.models.rest_models.MoleculePOSTResponse
 
 --------
 Keywords
 --------
 
-.. autoclass:: qcportal.models.rest_models.KeywordGETBody
+.. autopydantic_model:: qcportal.models.rest_models.KeywordGETBody
 
-.. autoclass:: qcportal.models.rest_models.KeywordGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.KeywordGETResponse
 
-.. autoclass:: qcportal.models.rest_models.KeywordPOSTBody
+.. autopydantic_model:: qcportal.models.rest_models.KeywordPOSTBody
 
-.. autoclass:: qcportal.models.rest_models.KeywordPOSTResponse
+.. autopydantic_model:: qcportal.models.rest_models.KeywordPOSTResponse
 
 -----------
 Collections
@@ -48,11 +48,11 @@ Collections
 
 .. autoclass:: qcportal.models.rest_models.CollectionGETBody
 
-.. autoclass:: qcportal.models.rest_models.CollectionGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.CollectionGETResponse
 
 .. autoclass:: qcportal.models.rest_models.CollectionPOSTBody
 
-.. autoclass:: qcportal.models.rest_models.CollectionPOSTResponse
+.. autopydantic_model:: qcportal.models.rest_models.CollectionPOSTResponse
 
 ------
 Result
@@ -60,7 +60,7 @@ Result
 
 .. autoclass:: qcportal.models.rest_models.ResultGETBody
 
-.. autoclass:: qcportal.models.rest_models.ResultGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.ResultGETResponse
 
 ----------
 Procedures
@@ -68,7 +68,7 @@ Procedures
 
 .. autoclass:: qcportal.models.rest_models.ProcedureGETBody
 
-.. autoclass:: qcportal.models.rest_models.ProcedureGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.ProcedureGETResponse
 
 ----------
 Task Queue
@@ -76,15 +76,15 @@ Task Queue
 
 .. autoclass:: qcportal.models.rest_models.TaskQueueGETBody
 
-.. autoclass:: qcportal.models.rest_models.TaskQueueGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.TaskQueueGETResponse
 
 .. autoclass:: qcportal.models.rest_models.TaskQueuePOSTBody
 
-.. autoclass:: qcportal.models.rest_models.TaskQueuePOSTResponse
+.. autopydantic_model:: qcportal.models.rest_models.TaskQueuePOSTResponse
 
 .. autoclass:: qcportal.models.rest_models.TaskQueuePUTBody
 
-.. autoclass:: qcportal.models.rest_models.TaskQueuePUTResponse
+.. autopydantic_model:: qcportal.models.rest_models.TaskQueuePUTResponse
 
 -------------
 Service Queue
@@ -92,31 +92,31 @@ Service Queue
 
 .. autoclass:: qcportal.models.rest_models.ServiceQueueGETBody
 
-.. autoclass:: qcportal.models.rest_models.ServiceQueueGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.ServiceQueueGETResponse
 
 .. autoclass:: qcportal.models.rest_models.ServiceQueuePOSTBody
 
-.. autoclass:: qcportal.models.rest_models.ServiceQueuePOSTResponse
+.. autopydantic_model:: qcportal.models.rest_models.ServiceQueuePOSTResponse
 
 .. autoclass:: qcportal.models.rest_models.ServiceQueuePUTBody
 
-.. autoclass:: qcportal.models.rest_models.ServiceQueuePUTResponse
+.. autopydantic_model:: qcportal.models.rest_models.ServiceQueuePUTResponse
 
 -------------
 Queue Manager
 -------------
 
-.. autoclass:: qcportal.models.rest_models.QueueManagerGETBody
+.. autopydantic_model:: qcportal.models.rest_models.QueueManagerGETBody
 
-.. autoclass:: qcportal.models.rest_models.QueueManagerGETResponse
+.. autopydantic_model:: qcportal.models.rest_models.QueueManagerGETResponse
 
-.. autoclass:: qcportal.models.rest_models.QueueManagerPOSTBody
+.. autopydantic_model:: qcportal.models.rest_models.QueueManagerPOSTBody
 
-.. autoclass:: qcportal.models.rest_models.QueueManagerPOSTResponse
+.. autopydantic_model:: qcportal.models.rest_models.QueueManagerPOSTResponse
 
-.. autoclass:: qcportal.models.rest_models.QueueManagerPUTBody
+.. autopydantic_model:: qcportal.models.rest_models.QueueManagerPUTBody
 
-.. autoclass:: qcportal.models.rest_models.QueueManagerPUTResponse
+.. autopydantic_model:: qcportal.models.rest_models.QueueManagerPUTResponse
 
 ----------------------
 Common REST Components
@@ -125,16 +125,16 @@ Common REST Components
 These are NOT complete Body or Responses to the REST API, but common fragments which
 make up things like the Metadata or the Data fields.
 
-.. autoclass:: qcportal.models.rest_models.EmptyMeta
+.. autopydantic_model:: qcportal.models.rest_models.EmptyMeta
 
-.. autoclass:: qcportal.models.rest_models.ResponseMeta
+.. autopydantic_model:: qcportal.models.rest_models.ResponseMeta
 
-.. autoclass:: qcportal.models.rest_models.ResponseGETMeta
+.. autopydantic_model:: qcportal.models.rest_models.ResponseGETMeta
 
-.. autoclass:: qcportal.models.rest_models.ResponsePOSTMeta
+.. autopydantic_model:: qcportal.models.rest_models.ResponsePOSTMeta
 
-.. autoclass:: qcportal.models.rest_models.QueryMeta
+.. autopydantic_model:: qcportal.models.rest_models.QueryMeta
 
-.. autoclass:: qcportal.models.rest_models.QueryMetaProjection
+.. does not exist in qcf .. autoclass:: qcportal.models.rest_models.QueryMetaProjection
 
-.. autoclass:: qcportal.models.rest_models.QueueManagerMeta
+.. autopydantic_model:: qcportal.models.rest_models.QueueManagerMeta

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -10,6 +10,7 @@ dependencies:
     - nbsphinx
     - ipython
     - qcfractal-core
+    - autodoc-pydantic
 
-    - pip:
-      - git+git://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme
+    #- pip:
+    #  - git+git://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme

--- a/qcfractal/cli/qcfractal_manager.py
+++ b/qcfractal/cli/qcfractal_manager.py
@@ -13,12 +13,12 @@ from typing import List, Optional, Union
 
 import tornado.log
 import yaml
-from pydantic import Field, validator
+from pydantic import BaseSettings, Field, validator
 
 import qcengine as qcng
 import qcfractal
 
-from ..interface.models import AutodocBaseSettings, ProtoModel
+from ..interface.models import ProtoModel
 from . import cli_utils
 
 __all__ = ["main"]
@@ -51,7 +51,7 @@ class AdapterEnum(str, Enum):
     parsl = "parsl"
 
 
-class CommonManagerSettings(AutodocBaseSettings):
+class CommonManagerSettings(BaseSettings):
     """
     The Common settings are the settings most users will need to adjust regularly to control the nature of
     task execution and the hardware under which tasks are executed on. This block is often unique to each deployment,
@@ -130,7 +130,7 @@ class CommonManagerSettings(AutodocBaseSettings):
         pass
 
 
-class FractalServerSettings(AutodocBaseSettings):
+class FractalServerSettings(BaseSettings):
     """
     Settings pertaining to the Fractal Server you wish to pull tasks from and push completed tasks to. Each manager
     supports exactly 1 Fractal Server to be in communication with, and exactly 1 user on that Fractal Server. These
@@ -156,7 +156,7 @@ class FractalServerSettings(AutodocBaseSettings):
         pass
 
 
-class QueueManagerSettings(AutodocBaseSettings):
+class QueueManagerSettings(BaseSettings):
     """
     Fractal Queue Manger settings. These are options which control the setup and execution of the Fractal Manager
     itself.
@@ -233,7 +233,7 @@ class AdaptiveCluster(str, Enum):
     adaptive = "adaptive"
 
 
-class ClusterSettings(AutodocBaseSettings):
+class ClusterSettings(BaseSettings):
     """
     Settings tied to the cluster you are running on. These settings are mostly tied to the nature of the cluster
     jobs you are submitting, separate from the nature of the compute tasks you will be running within them. As such,
@@ -297,7 +297,7 @@ class ClusterSettings(AutodocBaseSettings):
         return v
 
 
-class SettingsBlocker(AutodocBaseSettings):
+class SettingsBlocker(BaseSettings):
     """Helper class to auto block certain entries, overwrite hidden methods to access"""
 
     _forbidden_set = set()
@@ -390,7 +390,7 @@ class ParslExecutorSettings(SettingsBlocker):
     _forbidden_name = "the parsl executor"
 
 
-class ParslLauncherSettings(AutodocBaseSettings):
+class ParslLauncherSettings(BaseSettings):
     """
     Set the Launcher in a Parsl Provider, and its options, if not set, the defaults are used.
 
@@ -492,7 +492,7 @@ class ParslProviderSettings(SettingsBlocker):
     _forbidden_name = "parsl's provider"
 
 
-class ParslQueueSettings(AutodocBaseSettings):
+class ParslQueueSettings(BaseSettings):
     """
     The Parsl-specific configurations used with the `common.adapter = parsl` setting. The parsl config is broken up into
     a top level `Config` class, an `Executor` sub-class, and a `Provider` sub-class of the `Executor`.

--- a/qcfractal/config.py
+++ b/qcfractal/config.py
@@ -8,9 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from pydantic import Field, validator
-
-from .interface.models import AutodocBaseSettings
+from pydantic import BaseSettings, Field, validator
 
 
 def _str2bool(v):
@@ -30,7 +28,7 @@ class SettingsCommonConfig:
     extra = "forbid"
 
 
-class ConfigSettings(AutodocBaseSettings):
+class ConfigSettings(BaseSettings):
 
     _type_map = {"string": str, "integer": int, "float": float, "boolean": _str2bool}
 

--- a/qcfractal/interface/models/__init__.py
+++ b/qcfractal/interface/models/__init__.py
@@ -4,7 +4,6 @@ Either pull in QCEl models or local models
 
 from . import rest_models
 from .common_models import (
-    AutodocBaseSettings,
     Citation,
     KeywordSet,
     CompressionEnum,

--- a/qcfractal/interface/models/common_models.py
+++ b/qcfractal/interface/models/common_models.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import Any, Dict, Optional, Union
 
 from pydantic import Field, validator
-from qcelemental.models import AutodocBaseSettings, Molecule, ProtoModel, Provenance
+from qcelemental.models import Molecule, ProtoModel, Provenance
 from qcelemental.models.procedures import OptimizationProtocols
 from qcelemental.models.results import ResultProtocols
 
@@ -227,7 +227,7 @@ class QCSpecification(ProtoModel):
         description="The Id of the :class:`KeywordSet` registered in the database to run this calculation with. This "
         "Id must exist in the database.",
     )
-    protocols: Optional[ResultProtocols] = Field(ResultProtocols(), description=str(ResultProtocols.__base_doc__))
+    protocols: Optional[ResultProtocols] = Field(ResultProtocols(), description=str(ResultProtocols.__doc__))
     program: str = Field(
         ...,
         description="The quantum chemistry program to evaluate the computation with. Not all quantum chemistry programs"
@@ -269,7 +269,7 @@ class OptimizationSpecification(ProtoModel):
         ":class:`KeywordSet`. ",
     )
     protocols: Optional[OptimizationProtocols] = Field(
-        OptimizationProtocols(), description=str(OptimizationProtocols.__base_doc__)
+        OptimizationProtocols(), description=str(OptimizationProtocols.__doc__)
     )
 
     def dict(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,11 @@ if __name__ == "__main__":
         extras_require={
             "api_logging": ["geoip2"],
             "docs": [
-                "sphinx==1.2.3",  # autodoc was broken in 1.3.1
+                "sphinx",  # autodoc was broken in 1.3.1
                 "sphinxcontrib-napoleon",
                 "sphinx_rtd_theme",
                 "numpydoc",
+                "autodoc-pydantic",
             ],
             "lint": ["black", "isort"],
             "tests": ["pytest", "pytest-cov", "requests-mock"],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Changelog description
- [x] remove use of qcel autodoc and `__base_doc__` in qcf code that were removed in MolSSI/QCElemental#289
- [x] add use of https://github.com/mansenfranzen/autodoc_pydantic by replacing `.. autoclass::` with `.. autopydantic_model::` . hopefully I didn't miss any.
- [x] for qcportal docs, I added `FractalClient` so the class would appear in `objects.inv`. I removed Mol so that `qcelemental.models.Molecule` _didn't_ appear in `objects.inv`. there's still a couple qcel refs in there, but they're to Protocols that aren't acutally exported by qcel, and I didn't want to change code.
- [x] updated sphinx autodoc options, updated intersphinx, effectively switched main build to rtd.
- [ ] I can't see how the docs build is going to go, but both qcportal and qcfractal docs builds work fine for me locally. here's a GHA docs build snippet (https://github.com/MolSSI/QCElemental/blob/master/.github/workflows/CI.yml#L81) but I don't want to be radically switching from rtd to gha on `master`, and I see your gha's in `next` are much different.
- [ ] CI errors 
  *  `ConnectionRefusedError` to the molssi api server?
  *  `KeyError: "Collection 'Dataset:ds_gradient' not found."`

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
