### PR TITLE
Enable Pydantic v2 using v1 API

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -36,5 +36,6 @@ jobs:
 
       - name: Deploy Documentation
         uses: JamesIves/github-pages-deploy-action@v4
+        if: github.event_name == 'push' && github.repository == 'MolSSI/QCFractal' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/next' )
         with:
           folder: docs/build/html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx_design
 pydata_sphinx_theme
 sphinx
-autodoc-pydantic
+autodoc-pydantic=1
 -e ../qcportal
 -e ../qcfractalcompute
 -e ../qcfractal

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx_design
 pydata_sphinx_theme
 sphinx
-autodoc-pydantic=1
+autodoc-pydantic==1
 -e ../qcportal
 -e ../qcfractalcompute
 -e ../qcfractal

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,8 @@
 sphinx_design
 pydata_sphinx_theme
 sphinx
-autodoc-pydantic==1
+autodoc-pydantic==1.9.0
+pydantic==1.10.11
 -e ../qcportal
 -e ../qcfractalcompute
 -e ../qcfractal

--- a/qcfractal/qcfractal/api_v1/helpers.py
+++ b/qcfractal/qcfractal/api_v1/helpers.py
@@ -1,7 +1,10 @@
 from functools import wraps
 from typing import Callable
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from flask import request, Response
 from werkzeug.exceptions import BadRequest
 

--- a/qcfractal/qcfractal/components/gridoptimization/record_socket.py
+++ b/qcfractal/qcfractal/components/gridoptimization/record_socket.py
@@ -7,7 +7,10 @@ from typing import List, Dict, Tuple, Optional, Sequence, Any, Union, Set, TYPE_
 
 import numpy as np
 import sqlalchemy.orm.attributes
-from pydantic import BaseModel, Extra, parse_obj_as
+try:
+    from pydantic.v1 import BaseModel, Extra, parse_obj_as
+except ImportError:
+    from pydantic import BaseModel, Extra, parse_obj_as
 from sqlalchemy import select, func
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import lazyload, joinedload, undefer, defer

--- a/qcfractal/qcfractal/components/gridoptimization/testing_helpers.py
+++ b/qcfractal/qcfractal/components/gridoptimization/testing_helpers.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Tuple, Optional, Dict, Union, Any
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, OptimizationResult
 from qcelemental.models.procedures import OptimizationProtocols
 

--- a/qcfractal/qcfractal/components/managers/test_manager_client.py
+++ b/qcfractal/qcfractal/components/managers/test_manager_client.py
@@ -4,7 +4,10 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import pytest
-from pydantic import ValidationError
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from qcfractal.components.singlepoint.testing_helpers import submit_test_data
 from qcportal import PortalRequestError

--- a/qcfractal/qcfractal/components/manybody/testing_helpers.py
+++ b/qcfractal/qcfractal/components/manybody/testing_helpers.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple, Optional, Dict, Union, Any
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, AtomicResult
 
 from qcarchivetesting.helpers import read_record_data

--- a/qcfractal/qcfractal/components/neb/record_socket.py
+++ b/qcfractal/qcfractal/components/neb/record_socket.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING
 import numpy as np
 import sqlalchemy.orm.attributes
 import tabulate
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
+
 from sqlalchemy import select, func
 from sqlalchemy.dialects.postgresql import insert, array_agg, aggregate_order_by, DOUBLE_PRECISION, TEXT
 from sqlalchemy.orm import lazyload, joinedload, defer, undefer

--- a/qcfractal/qcfractal/components/neb/testing_helpers.py
+++ b/qcfractal/qcfractal/components/neb/testing_helpers.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple, Optional, Dict, List, Union, Any
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, AtomicResult, OptimizationResult
 
 from qcarchivetesting.helpers import read_record_data

--- a/qcfractal/qcfractal/components/optimization/testing_helpers.py
+++ b/qcfractal/qcfractal/components/optimization/testing_helpers.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Tuple, Optional, Union, Dict, Any
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, OptimizationResult
 
 from qcarchivetesting.helpers import read_record_data

--- a/qcfractal/qcfractal/components/reaction/testing_helpers.py
+++ b/qcfractal/qcfractal/components/reaction/testing_helpers.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple, Optional, Dict, List, Union, Any
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, AtomicResult, OptimizationResult
 
 from qcarchivetesting.helpers import read_record_data

--- a/qcfractal/qcfractal/components/singlepoint/testing_helpers.py
+++ b/qcfractal/qcfractal/components/singlepoint/testing_helpers.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Tuple, Optional, Union, Dict, Any
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, AtomicResult
 
 from qcarchivetesting.helpers import read_record_data

--- a/qcfractal/qcfractal/components/tasks/socket.py
+++ b/qcfractal/qcfractal/components/tasks/socket.py
@@ -5,7 +5,10 @@ import traceback
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from qcelemental.models import FailedOperation
 from sqlalchemy import select, func
 from sqlalchemy.dialects.postgresql import array

--- a/qcfractal/qcfractal/components/torsiondrive/record_socket.py
+++ b/qcfractal/qcfractal/components/torsiondrive/record_socket.py
@@ -9,7 +9,10 @@ import logging
 from typing import TYPE_CHECKING
 
 import sqlalchemy.orm.attributes
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
 from sqlalchemy import select, func
 from sqlalchemy.dialects.postgresql import insert, array_agg, aggregate_order_by, DOUBLE_PRECISION, TEXT
 from sqlalchemy.orm import lazyload, joinedload, defer, undefer

--- a/qcfractal/qcfractal/components/torsiondrive/testing_helpers.py
+++ b/qcfractal/qcfractal/components/torsiondrive/testing_helpers.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Tuple, Optional, Dict, List, Union, Any
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, OptimizationResult
 from qcelemental.models.procedures import OptimizationProtocols
 

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -11,8 +11,12 @@ from typing import Optional, Dict, Union, Any
 
 import yaml
 from psycopg2.extensions import make_dsn, parse_dsn
-from pydantic import BaseSettings, Field, validator, root_validator, ValidationError
-from pydantic.env_settings import SettingsSourceCallable
+try:
+    from pydantic.v1 import BaseSettings, Field, validator, root_validator, ValidationError
+    from pydantic.v1.env_settings import SettingsSourceCallable
+except ImportError:
+    from pydantic import BaseSettings, Field, validator, root_validator, ValidationError
+    from pydantic.env_settings import SettingsSourceCallable
 from sqlalchemy.engine.url import URL, make_url
 
 from qcfractal.port_util import find_open_port

--- a/qcfractal/qcfractal/db_socket/base_orm.py
+++ b/qcfractal/qcfractal/db_socket/base_orm.py
@@ -10,7 +10,10 @@ from sqlalchemy.orm import as_declarative
 
 if TYPE_CHECKING:
     from typing import Any, TypeVar, Type, Dict, Optional, Iterable, Union, List
-    from pydantic import BaseModel
+    try:
+        from pydantic.v1 import BaseModel
+    except ImportError:
+        from pydantic import BaseModel
 
     _T = TypeVar("_T")
 

--- a/qcfractal/qcfractal/old_config.py
+++ b/qcfractal/qcfractal/old_config.py
@@ -9,7 +9,10 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from pydantic import Field, validator
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 from .config import ConfigBase, ConfigCommon
 

--- a/qcfractalcompute/qcfractalcompute/apps/models.py
+++ b/qcfractalcompute/qcfractalcompute/apps/models.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 
 from qcportal.compression import decompress, CompressionEnum
 

--- a/qcfractalcompute/qcfractalcompute/compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/compute_manager.py
@@ -16,7 +16,10 @@ from parsl.dataflow.dflow import DataFlowKernel
 from parsl.dataflow.futures import Future as ParslFuture
 from parsl.executors import HighThroughputExecutor, ThreadPoolExecutor
 from pkg_resources import parse_version
-from pydantic import BaseModel, Extra, Field
+try:
+    from pydantic.v1 import BaseModel, Extra, Field
+except ImportError:
+    from pydantic import BaseModel, Extra, Field
 from requests.exceptions import Timeout
 
 from qcfractalcompute.apps.app_manager import AppManager

--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -3,7 +3,10 @@ import os
 from typing import List, Optional, Union, Dict, Any
 
 import yaml
-from pydantic import BaseModel, Field, validator
+try:
+    from pydantic.v1 import BaseModel, Field, validator
+except ImportError:
+    from pydantic import BaseModel, Field, validator
 from typing_extensions import Literal
 
 from qcportal.utils import seconds_to_hms

--- a/qcfractalcompute/qcfractalcompute/managers.py
+++ b/qcfractalcompute/qcfractalcompute/managers.py
@@ -12,7 +12,10 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Union
 
 import qcengine as qcng
-from pydantic import BaseModel, validator, Extra
+try:
+    from pydantic.v1 import BaseModel, validator, Extra
+except ImportError:
+    from pydantic import BaseModel, validator, Extra
 from qcelemental.models import Molecule, FailedOperation
 
 from . import __version__

--- a/qcfractalcompute/qcfractalcompute/qcfractal_manager_cli.py
+++ b/qcfractalcompute/qcfractalcompute/qcfractal_manager_cli.py
@@ -13,7 +13,10 @@ from typing import List, Optional, Union
 
 import qcengine as qcng
 import yaml
-from pydantic import BaseSettings, Field, validator
+try:
+    from pydantic.v1 import BaseSettings, Field, validator
+except ImportError:
+    from pydantic import BaseSettings, Field, validator
 
 from . import __version__, cli_utils
 from .managers import ComputeManager

--- a/qcportal/pyproject.toml
+++ b/qcportal/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "msgpack",
     "requests",
     "pyyaml",
-    "pydantic<2.0",
+    "pydantic",
     "zstandard",
     "qcelemental",
     "tabulate",

--- a/qcportal/qcportal/auth/models.py
+++ b/qcportal/qcportal/auth/models.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional, Union, List
 
-from pydantic import BaseModel, Field, validator, constr, Extra
+try:
+    from pydantic.v1 import BaseModel, Field, validator, constr, Extra
+except ImportError:
+    from pydantic import BaseModel, Field, validator, constr, Extra
 
 from ..exceptions import InvalidPasswordError, InvalidUsernameError, InvalidRolenameError, InvalidGroupnameError
 

--- a/qcportal/qcportal/base_models.py
+++ b/qcportal/qcportal/base_models.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Optional, List, Iterator, Generic, TypeVar
 
-from pydantic import BaseModel, validator, Extra
+try:
+    from pydantic.v1 import BaseModel, validator, Extra
+except ImportError:
+    from pydantic import BaseModel, validator, Extra
 
 T = TypeVar("T")
 

--- a/qcportal/qcportal/client_base.py
+++ b/qcportal/qcportal/client_base.py
@@ -12,7 +12,10 @@ from typing import (
 )
 
 import jwt
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 import requests
 import yaml
 from pkg_resources import parse_version

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -5,8 +5,12 @@ from datetime import datetime
 from typing import Optional, Dict, Any, List, Iterable, Type, Tuple, Union, Callable, ClassVar
 
 import pandas as pd
-import pydantic
-from pydantic import BaseModel, Extra, validator, PrivateAttr, Field
+try:
+    import pydantic.v1 as pydantic
+    from pydantic.v1 import BaseModel, Extra, validator, PrivateAttr, Field
+except ImportError:
+    import pydantic
+    from pydantic import BaseModel, Extra, validator, PrivateAttr, Field
 from qcelemental.models.types import Array
 from tabulate import tabulate
 

--- a/qcportal/qcportal/dataset_view.py
+++ b/qcportal/qcportal/dataset_view.py
@@ -5,7 +5,10 @@ import sqlite3
 from typing import Optional, Dict, Any, List, Iterable
 
 import zstandard
-from pydantic import BaseModel, validator, PrivateAttr, parse_obj_as, Extra
+try:
+    from pydantic.v1 import BaseModel, validator, PrivateAttr, parse_obj_as, Extra
+except ImportError:
+    from pydantic import BaseModel, validator, PrivateAttr, parse_obj_as, Extra
 
 from qcportal.serialization import deserialize
 

--- a/qcportal/qcportal/gridoptimization/dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/dataset_models.py
@@ -1,6 +1,9 @@
 from typing import Dict, Any, Union, Optional, Iterable, Tuple
 
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
 from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset

--- a/qcportal/qcportal/gridoptimization/record_models.py
+++ b/qcportal/qcportal/gridoptimization/record_models.py
@@ -2,7 +2,10 @@ import json
 from enum import Enum
 from typing import List, Union, Optional, Dict, Iterable, Tuple, Sequence, Any
 
-from pydantic import BaseModel, Extra, Field, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Extra, Field, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Extra, Field, constr, validator
 from typing_extensions import Literal
 
 from qcportal.molecules import Molecule

--- a/qcportal/qcportal/internal_jobs/models.py
+++ b/qcportal/qcportal/internal_jobs/models.py
@@ -3,7 +3,10 @@ from enum import Enum
 from typing import Optional, Dict, Any, List, Union
 
 from dateutil.parser import parse as date_parser
-from pydantic import BaseModel, Extra, validator
+try:
+    from pydantic.v1 import BaseModel, Extra, validator
+except ImportError:
+    from pydantic import BaseModel, Extra, validator
 
 from qcportal.base_models import QueryProjModelBase
 from ..base_models import QueryIteratorBase

--- a/qcportal/qcportal/managers/models.py
+++ b/qcportal/qcportal/managers/models.py
@@ -5,7 +5,10 @@ from enum import Enum
 from typing import Optional, Dict, Any, List
 
 from dateutil.parser import parse as date_parser
-from pydantic import BaseModel, Field, constr, validator, Extra, PrivateAttr
+try:
+    from pydantic.v1 import BaseModel, Field, constr, validator, Extra, PrivateAttr
+except ImportError:
+    from pydantic import BaseModel, Field, constr, validator, Extra, PrivateAttr
 
 from qcportal.base_models import RestModelBase, QueryProjModelBase
 from ..base_models import QueryIteratorBase

--- a/qcportal/qcportal/manybody/dataset_models.py
+++ b/qcportal/qcportal/manybody/dataset_models.py
@@ -1,6 +1,9 @@
 from typing import Dict, Any, Union, Optional, List, Iterable, Tuple
 
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
 from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset

--- a/qcportal/qcportal/manybody/record_models.py
+++ b/qcportal/qcportal/manybody/record_models.py
@@ -1,7 +1,10 @@
 from enum import Enum
 from typing import List, Union, Optional, Dict, Any, Iterable
 
-from pydantic import BaseModel, Extra, validator, constr
+try:
+    from pydantic.v1 import BaseModel, Extra, validator, constr
+except ImportError:
+    from pydantic import BaseModel, Extra, validator, constr
 from typing_extensions import Literal
 
 from qcportal.molecules import Molecule

--- a/qcportal/qcportal/metadata_models.py
+++ b/qcportal/qcportal/metadata_models.py
@@ -1,8 +1,12 @@
 import dataclasses
 from typing import List, Optional, Tuple, Dict, Any
 
-from pydantic import validator, root_validator
-from pydantic.dataclasses import dataclass
+try:
+    from pydantic.v1 import validator, root_validator
+    from pydantic.v1.dataclasses import dataclass
+except ImportError:
+    from pydantic import validator, root_validator
+    from pydantic.dataclasses import dataclass
 
 
 @dataclass

--- a/qcportal/qcportal/neb/dataset_models.py
+++ b/qcportal/qcportal/neb/dataset_models.py
@@ -1,6 +1,9 @@
 from typing import Dict, Any, Union, Optional, List, Iterable, Tuple
 
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
 from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset

--- a/qcportal/qcportal/neb/record_models.py
+++ b/qcportal/qcportal/neb/record_models.py
@@ -1,6 +1,9 @@
 from typing import List, Optional, Union, Dict, Iterable
 
-from pydantic import BaseModel, Field, Extra, root_validator, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, Extra, root_validator, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, Extra, root_validator, constr, validator
 from typing_extensions import Literal
 
 from qcportal.molecules import Molecule

--- a/qcportal/qcportal/optimization/dataset_models.py
+++ b/qcportal/qcportal/optimization/dataset_models.py
@@ -1,6 +1,9 @@
 from typing import Dict, Any, Union, Optional, List, Iterable, Tuple
 
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
 from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset

--- a/qcportal/qcportal/optimization/record_models.py
+++ b/qcportal/qcportal/optimization/record_models.py
@@ -1,7 +1,10 @@
 from copy import deepcopy
 from typing import Optional, Union, Any, List, Dict, Iterable
 
-from pydantic import BaseModel, Field, constr, validator, Extra
+try:
+    from pydantic.v1 import BaseModel, Field, constr, validator, Extra
+except ImportError:
+    from pydantic import BaseModel, Field, constr, validator, Extra
 from qcelemental.models import Molecule
 from qcelemental.models.procedures import (
     OptimizationResult,

--- a/qcportal/qcportal/reaction/dataset_models.py
+++ b/qcportal/qcportal/reaction/dataset_models.py
@@ -1,6 +1,9 @@
 from typing import Dict, Any, Union, Optional, List, Iterable, Tuple
 
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
 from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset

--- a/qcportal/qcportal/reaction/record_models.py
+++ b/qcportal/qcportal/reaction/record_models.py
@@ -1,6 +1,9 @@
 from typing import List, Union, Optional, Tuple, Iterable
 
-from pydantic import BaseModel, Extra, root_validator, constr
+try:
+    from pydantic.v1 import BaseModel, Extra, root_validator, constr
+except ImportError:
+    from pydantic import BaseModel, Extra, root_validator, constr
 from typing_extensions import Literal
 
 from qcportal.molecules import Molecule

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -6,7 +6,10 @@ from enum import Enum
 from typing import Optional, Dict, Any, List, Union, Iterable, Tuple, Type, Sequence, ClassVar, TypeVar
 
 from dateutil.parser import parse as date_parser
-from pydantic import BaseModel, Extra, constr, validator, PrivateAttr, Field
+try:
+    from pydantic.v1 import BaseModel, Extra, constr, validator, PrivateAttr, Field
+except ImportError:
+    from pydantic import BaseModel, Extra, constr, validator, PrivateAttr, Field
 from qcelemental.models.results import Provenance
 
 from qcportal.base_models import (

--- a/qcportal/qcportal/serialization.py
+++ b/qcportal/qcportal/serialization.py
@@ -4,7 +4,10 @@ from typing import Union, Any
 
 import msgpack
 import numpy as np
-from pydantic.json import pydantic_encoder
+try:
+    from pydantic.v1.json import pydantic_encoder
+except ImportError:
+    from pydantic.json import pydantic_encoder
 
 
 def _msgpack_encode(obj: Any) -> Any:

--- a/qcportal/qcportal/serverinfo/models.py
+++ b/qcportal/qcportal/serverinfo/models.py
@@ -3,7 +3,10 @@ from enum import Enum
 from typing import Optional, List, Dict, Any, Union
 
 from dateutil.parser import parse as date_parser
-from pydantic import BaseModel, Extra, validator, IPvAnyAddress, constr
+try:
+    from pydantic.v1 import BaseModel, Extra, validator, IPvAnyAddress, constr
+except ImportError:
+    from pydantic import BaseModel, Extra, validator, IPvAnyAddress, constr
 
 from qcportal.base_models import (
     RestModelBase,

--- a/qcportal/qcportal/singlepoint/dataset_models.py
+++ b/qcportal/qcportal/singlepoint/dataset_models.py
@@ -1,6 +1,9 @@
 from typing import Dict, Any, Union, Optional, Iterable, Tuple
 
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
 from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset

--- a/qcportal/qcportal/singlepoint/record_models.py
+++ b/qcportal/qcportal/singlepoint/record_models.py
@@ -2,7 +2,10 @@ from copy import deepcopy
 from enum import Enum
 from typing import Optional, Union, Any, List, Dict, Iterable, Tuple
 
-from pydantic import BaseModel, Field, constr, validator, Extra, PrivateAttr
+try:
+    from pydantic.v1 import BaseModel, Field, constr, validator, Extra, PrivateAttr
+except ImportError:
+    from pydantic import BaseModel, Field, constr, validator, Extra, PrivateAttr
 from qcelemental.models import Molecule
 from qcelemental.models.results import (
     AtomicResult,

--- a/qcportal/qcportal/tasks/models.py
+++ b/qcportal/qcportal/tasks/models.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 from typing import Dict, List, Any, Optional
 
-from pydantic import Field, BaseModel, constr, Extra
+try:
+    from pydantic.v1 import Field, BaseModel, constr, Extra
+except ImportError:
+    from pydantic import Field, BaseModel, constr, Extra
 
 from qcportal.base_models import RestModelBase
 from qcportal.compression import decompress, CompressionEnum

--- a/qcportal/qcportal/torsiondrive/dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/dataset_models.py
@@ -1,6 +1,9 @@
 from typing import Dict, Any, Union, Optional, List, Iterable, Tuple
 
-from pydantic import BaseModel, Extra
+try:
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:
+    from pydantic import BaseModel, Extra
 from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset

--- a/qcportal/qcportal/torsiondrive/record_models.py
+++ b/qcportal/qcportal/torsiondrive/record_models.py
@@ -1,7 +1,10 @@
 import json
 from typing import List, Optional, Tuple, Union, Dict, Iterable, Sequence, Any
 
-from pydantic import BaseModel, Field, Extra, root_validator, constr, validator
+try:
+    from pydantic.v1 import BaseModel, Field, Extra, root_validator, constr, validator
+except ImportError:
+    from pydantic import BaseModel, Field, Extra, root_validator, constr, validator
 from typing_extensions import Literal
 
 from qcportal.molecules import Molecule


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## Description
As it says. This is a stopgap until we can properly implement Pydantic v2

Focuses mostly on QCPortal

Part of the larger QCA Upgrade to Pydantic v2

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
