### PR TITLE
remove old manager from pyproject

### DIFF
--- a/qcfractalcompute/pyproject.toml
+++ b/qcfractalcompute/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
 
 
 [project.scripts]
-qcfractal-manager = "qcfractalcompute.qcfractal_manager_cli:main"
 qcfractal-compute-manager = "qcfractalcompute.compute_manager_cli:main"
 
 


### PR DESCRIPTION
As it says on the tin. This is needed for the conda recipe.
