### PR TITLE
Detect geoip test data and skip if not there

### DIFF
--- a/qcarchivetesting/qcarchivetesting/__init__.py
+++ b/qcarchivetesting/qcarchivetesting/__init__.py
@@ -5,6 +5,8 @@ __version__ = version("qcarchivetesting")
 from .helpers import (
     geoip_path,
     geoip_filename,
+    ip_testdata_path,
+    ip_tests_enabled,
     testconfig_path,
     migrationdata_path,
     test_users,

--- a/qcarchivetesting/qcarchivetesting/helpers.py
+++ b/qcarchivetesting/qcarchivetesting/helpers.py
@@ -24,6 +24,9 @@ _my_path = os.path.dirname(os.path.abspath(__file__))
 
 geoip_path = os.path.join(_my_path, "MaxMind-DB", "test-data")
 geoip_filename = "GeoLite2-City-Test.mmdb"
+ip_testdata_path = os.path.join(_my_path, "MaxMind-DB", "source-data", "GeoIP2-City-Test.json")
+
+ip_tests_enabled = os.path.exists(geoip_path) and os.path.exists(ip_testdata_path)
 
 testconfig_path = os.path.join(_my_path, "config_files")
 migrationdata_path = os.path.join(_my_path, "migration_data")
@@ -148,9 +151,7 @@ def load_ip_test_data():
     Loads data for testing IP logging
     """
 
-    file_path = os.path.join(_my_path, "MaxMind-DB", "source-data", "GeoIP2-City-Test.json")
-
-    with open(file_path, "r") as f:
+    with open(ip_testdata_path, "r") as f:
         d = json.load(f)
 
     # Stored as a list containing a dictionary with one key. Convert to a regular dict

--- a/qcarchivetesting/qcarchivetesting/testing_classes.py
+++ b/qcarchivetesting/qcarchivetesting/testing_classes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 
-from qcarchivetesting import geoip_path, geoip_filename
+from qcarchivetesting import geoip_path, geoip_filename, ip_tests_enabled
 from qcfractal.config import DatabaseConfig, update_nested_dict
 from qcfractal.db_socket import SQLAlchemySocket
 from qcfractal.postgres_harness import PostgresHarness, create_snowflake_postgres
@@ -150,8 +150,11 @@ class QCATestingSnowflake(FractalSnowflake):
 
         qcf_config["database"] = {"pool_size": 0}
         qcf_config["log_access"] = log_access
-        qcf_config["geoip2_dir"] = geoip_path
-        qcf_config["geoip2_filename"] = geoip_filename
+
+        if ip_tests_enabled:
+            qcf_config["geoip2_dir"] = geoip_path
+            qcf_config["geoip2_filename"] = geoip_filename
+
         qcf_config["auto_reset"] = {"enabled": False}
 
         # Merge in any other specified config

--- a/qcarchivetesting/qcarchivetesting/testing_fixtures.py
+++ b/qcarchivetesting/qcarchivetesting/testing_fixtures.py
@@ -12,7 +12,7 @@ from qcfractal.config import FractalConfig
 from qcfractal.db_socket.socket import SQLAlchemySocket
 from qcportal import PortalClient
 from qcportal.managers import ManagerName
-from .helpers import geoip_path, geoip_filename, test_users
+from .helpers import geoip_path, geoip_filename, ip_tests_enabled, test_users
 from .testing_classes import QCATestingPostgresServer, QCATestingSnowflake, _activated_manager_programs
 
 
@@ -51,8 +51,11 @@ def session_storage_socket(postgres_server):
     cfg_dict["database"] = pg_harness.config.dict()
     cfg_dict["database"]["pool_size"] = 0
     cfg_dict["log_access"] = True
-    cfg_dict["geoip2_dir"] = geoip_path
-    cfg_dict["geoip2_filename"] = geoip_filename
+
+    if ip_tests_enabled:
+        cfg_dict["geoip2_dir"] = geoip_path
+        cfg_dict["geoip2_filename"] = geoip_filename
+
     cfg_dict["api"] = {"secret_key": secrets.token_urlsafe(32), "jwt_secret_key": secrets.token_urlsafe(32)}
     qcf_config = FractalConfig(**cfg_dict)
 

--- a/qcfractal/qcfractal/components/serverinfo/test_access_socket.py
+++ b/qcfractal/qcfractal/components/serverinfo/test_access_socket.py
@@ -4,7 +4,9 @@ import ipaddress
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from qcarchivetesting import load_ip_test_data
+import pytest
+
+from qcarchivetesting import load_ip_test_data, ip_tests_enabled
 from qcarchivetesting.testing_classes import QCATestingSnowflake
 from qcfractal.testing_helpers import DummyJobProgress
 from qcportal.serverinfo.models import AccessLogQueryFilters
@@ -24,6 +26,7 @@ test_ips = [
 ]
 
 
+@pytest.mark.skipif(not ip_tests_enabled, reason="Test GeoIP data not found")
 def test_serverinfo_socket_save_access(secure_snowflake: QCATestingSnowflake):
 
     storage_socket = secure_snowflake.get_storage_socket()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Skip tests that require geoip data if the test data is not cloned into `qcarchivetesting`

Fixes #718 

## Changelog description
Tests requiring geoip test data are now automatically skipped if not available

## Status
- [X] Code base linted
- [X] Ready to go
