### PR TITLE
add quickstart files

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ pydata_sphinx_theme
 sphinx
 autodoc-pydantic
 sphinx-copybutton
+myst-nb
 -e ../qcportal
 -e ../qcfractalcompute
 -e ../qcfractal

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ sphinx
 autodoc-pydantic
 sphinx-copybutton
 myst-nb
+nglview
 -e ../qcportal
 -e ../qcfractalcompute
 -e ../qcfractal

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -14,8 +14,10 @@ html[data-theme="dark"] {
 	--pst-color-warning: #ed1c24;
 	--pst-color-primary-highlight: #288ec5;
 	--pst-color-background: #1A1A1A;
+	--pst-color-on-background: #222222;
+	--pst-color-surface: #222222;
 	--pst-color-secondary: #513D92;
-	--pst-color-secondary-highlight: #5f48a9;
+	--pst-color-secondary-highlight: #stats5f48a9;
 }
 
 html[data-theme="light"] a:hover {
@@ -28,12 +30,6 @@ html[data-theme="dark"] h1, html[data-theme="dark"] h2, html[data-theme="dark"] 
 
 a.headerlink {
     color: var(--pst-color-primary-highlight);
-}
-
-nav.bd-links li>a {
-    color: var(--pst-color-primary);
-    display: block;
-    padding: 0.25rem 0;
 }
 
 

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -4,8 +4,8 @@ html[data-theme="light"] {
     --pst-color-primary: #0080C7;
 	--pst-color-warning: #ed1c24;
 	--pst-color-primary-highlight: #288ec5;
-	--pst-color-secondary: #ed1c24;
-	--pst-color-secondary-highlight: #bc151b;
+	--pst-color-secondary: #513D92;
+	--pst-color-secondary-highlight: #5f48a9;
 }
 
 
@@ -14,10 +14,8 @@ html[data-theme="dark"] {
 	--pst-color-warning: #ed1c24;
 	--pst-color-primary-highlight: #288ec5;
 	--pst-color-background: #1A1A1A;
-	--pst-color-secondary: #ed1c24;
-	--pst-color-secondary-highlight: #bc151b;
-
-	
+	--pst-color-secondary: #513D92;
+	--pst-color-secondary-highlight: #5f48a9;
 }
 
 html[data-theme="light"] a:hover {
@@ -26,6 +24,16 @@ html[data-theme="light"] a:hover {
 
 html[data-theme="dark"] h1, html[data-theme="dark"] h2, html[data-theme="dark"] h3, html[data-theme="dark"] h4, html[data-theme="dark"] h5, html[data-theme="dark"] h6 {
 	color: #ffffff;
+}
+
+a.headerlink {
+    color: var(--pst-color-primary-highlight);
+}
+
+nav.bd-links li>a {
+    color: var(--pst-color-primary);
+    display: block;
+    padding: 0.25rem 0;
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,8 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_design',
     'sphinxcontrib.autodoc_pydantic',
-    'sphinx_copybutton'
+    'sphinx_copybutton',
+    'myst_nb',
 ]
 
 # Some options

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,15 +2,33 @@ The MolSSI QCArchive Project
 ==============================================
 
 
-QCArchive is a platform for running large numbers of quantum chemistry calculations in a robust and scalable manner.
+QCArchive is a specialized platform designed to support computational chemists in the management and execution of large-scale quantum chemistry calculations. 
+Capable of handling data ranging from thousands to millions of computations, 
+it offers an organized database for storing, sharing, retrieving, and analyzing results. 
+QCArchive addresses the challenges of unique requirements from different QM codes and the intricacies of coordinating distributed computational resources. 
 
+QCArchive's comprehensive architecture, from the central server software (QCFractal) to its client interface (QCPortal) and computational workers (QCFractalCompute), 
+ensures a streamlined experience with quantum computations.
+
+.. grid:: 1 1 1 1
+
+    .. grid-item-card:: Getting Started
+      :margin: 0 3 0 0
+
+      Get up and running with QCArchive.
+
+      .. button-link:: ./quickstart/index.html
+         :color: primary
+         :expand:
+
+         To the Quickstart
 
 .. grid:: 1 1 2 2
 
     .. grid-item-card:: Overview
       :margin: 0 3 0 0
 
-      Overview and basic concepts of the QCArchive project
+      Overview and basic concepts of the QCArchive project.
 
       .. button-link:: ./overview/index.html
          :color: primary
@@ -21,7 +39,7 @@ QCArchive is a platform for running large numbers of quantum chemistry calculati
     .. grid-item-card::  User Guide
       :margin: 0 3 0 0
       
-      An in-depth guide for users
+      An in-depth guide for users.
 
       .. button-link:: ./user_guide/index.html
          :color: primary
@@ -32,7 +50,7 @@ QCArchive is a platform for running large numbers of quantum chemistry calculati
     .. grid-item-card::  Server Administrator Guide
       :margin: 0 3 0 0
       
-      Details of how to run and administer a server
+      Details of how to run and administer a server.
 
       .. button-link:: ./admin_guide/index.html
          :color: primary
@@ -43,13 +61,13 @@ QCArchive is a platform for running large numbers of quantum chemistry calculati
     .. grid-item-card::  Developer Guide
       :margin: 0 3 0 0
       
-      How to contribute to QCArchive
+      How to contribute to QCArchive.
 
       .. button-link:: ./developer_guide/index.html
          :color: primary
          :expand:
 
-         To the Developer Guide
+         To the Developer Guide.
 
 
 .. toctree::
@@ -57,6 +75,7 @@ QCArchive is a platform for running large numbers of quantum chemistry calculati
    :hidden:
    :titlesonly:
 
+   Quickstart <quickstart/index.rst>
    Overview <overview/index>
    User Guide <user_guide/index>
    Admin Guide <admin_guide/index>

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -28,6 +28,7 @@ We recommend starting with our 15 minutes to QCArchive tutorial.
 
 .. toctree::
    :maxdepth: 1
+   :caption: Overview:
    
    qca_15min.ipynb
 
@@ -37,7 +38,7 @@ Tutorials
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents:
+   :caption: Quickstart Guides:
 
    record_retrieval.ipynb
    record_query.ipynb

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -19,7 +19,7 @@ It is recommended to install QCArchive in its own environment.
 
 .. code-block:: bash
 
-   conda create -n qcportal qcportal -c qcarchive/label/next
+   conda create -n qcportal -c conda-forge qcportal
    conda activate qcportal
 
 Overview Tutorials
@@ -30,8 +30,6 @@ We recommend starting with our 15 minutes to QCArchive tutorial.
    :maxdepth: 1
    
    qca_15min.ipynb
-
-
 
 
 Tutorials

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -1,0 +1,46 @@
+QCArchive Quickstart
+=====================================
+
+QCArchive is a data generation and retrieval platform specialized for quantum chemistry calculation.
+These quickstart tutorials demonstrate the basics of retrieving results
+and submitting computations using the QCArchive Python API.
+
+Depending on your use case for QCArchive, there are many things you might try to do.
+For example, you might retrieve specific computations (records) by ID, query the database for particular computations,
+submit a computation, or submit and  work with a dataset.
+
+These Quickstart tutorials are intended to cover the basics of all of these use cases.
+
+Installation
+------------
+
+QCArchive can be installed using the `conda` package manager.
+It is recommended to install QCArchive in its own environment.
+
+.. code-block:: bash
+
+   conda create -n qcportal qcportal -c qcarchive/label/next
+   conda activate qcportal
+
+Overview Tutorials
+------------------
+We recommend starting with our 15 minutes to QCArchive tutorial.
+
+.. toctree::
+   :maxdepth: 1
+   
+   qca_15min.ipynb
+
+
+
+
+Tutorials
+---------
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   record_retrieval.ipynb
+   record_query.ipynb
+   

--- a/docs/source/quickstart/qca_15min.ipynb
+++ b/docs/source/quickstart/qca_15min.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(first_record.properties[\"scf total energy\"])"
+    "print(first_record.properties[\"scf_total_energy\"])"
    ]
   },
   {
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Molecule: {first_record.molecule.name}, Energy: {first_record.properties['scf total energy']}\")"
+    "print(f\"Molecule: {first_record.molecule.name}, Energy: {first_record.properties['scf_total_energy']}\")"
    ]
   },
   {
@@ -121,7 +121,7 @@
     "multiple_records = client.get_records([1, 2, 3]) \n",
     "\n",
     "for record in multiple_records:\n",
-    "    print(f\"Molecule: {record.molecule.name}, Energy: {record.properties['scf total energy']}\")"
+    "    print(f\"Molecule: {record.molecule.name}, Energy: {record.properties['scf_total_energy']}\")"
    ]
   },
   {
@@ -215,7 +215,7 @@
    "outputs": [],
    "source": [
     "# use compile_values to make a dataframe\n",
-    "df = ds.compile_values(lambda record: record.properties['scf total energy'], \"scf total energy\")\n",
+    "df = ds.compile_values(lambda record: record.properties['scf_total_energy'], \"scf_total_energy\")\n",
     "\n",
     "# view the first 10 rows.\n",
     "df.head(10)"
@@ -301,8 +301,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The molecule objects in QCArchive can be visualized using NGLView by putting\n",
-    "the variable representing the molecule as the last thing in a cell."
+    "If NGLView is installed in your environment, the molecule objects in QCArchive can be visualized using NGLView by putting the variable representing the molecule as the last thing in a notebook cell."
    ]
   },
   {

--- a/docs/source/quickstart/qca_15min.ipynb
+++ b/docs/source/quickstart/qca_15min.ipynb
@@ -1,0 +1,431 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(overview-tutorial)=\n",
+    "# QCArchive in 15 minutes\n",
+    "\n",
+    "This tutorial will give you an overview of possible actions in QCArchive.\n",
+    "Using QCArchive, you can:\n",
+    "\n",
+    "1. Submit a single or set of computations to a server, following a variety of workflows. \n",
+    "2. Retrieve the results of previous computations.\n",
+    "3. Query the database for particular computations.\n",
+    "4. Create datasets holding related quantum chemistry computations.\n",
+    "5. Retrieve results from datasets.\n",
+    "\n",
+    "This notebook will briefly walk you through each capability. \n",
+    "For more details, we recommend you follow our other starter tutorials."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connecting to a server\n",
+    "\n",
+    "To work with QCArchive, you will need to connect to a QCArchive server.\n",
+    "For the QuickStart tutorials, we will connect to the QCArchive Demo Server.\n",
+    "To interact with a server, you will create a QCPortal client using `PortalClient`.\n",
+    "The argument to `PortalClient` is the server address. \n",
+    "To work with the QCArchive demo server, enter `https://qcademo.molssi.org`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qcportal as ptl\n",
+    "\n",
+    "client = ptl.PortalClient(\"https://qcademo.molssi.org\")\n",
+    "print(client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have a QCPortal client that we can use to read from and query the QCArchive demo server.\n",
+    "\n",
+    "## Retrieving Data and Querying the Database\n",
+    "\n",
+    "### How do I retrieve computation results by ID?\n",
+    "\n",
+    "We can retrieve computations by ID using the `client.get_records` function.\n",
+    "Each computation in the database is given an integer ID number.\n",
+    "The cell below shows retrieval of the calculation result with ID 1. \n",
+    "We see that this computation was a single point computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_record = client.get_records(1)\n",
+    "print(first_record)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Typically, properties from a calculation can be viewed using the `.properties` attribute for a result.\n",
+    "The calculated properties are in a dictionary. \n",
+    "In the cell below, we print the SCF total energy from our calcuation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(first_record.properties[\"scf total energy\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can print information about the computation like the molecule name and properties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Molecule: {first_record.molecule.name}, Energy: {first_record.properties['scf total energy']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you pass in several IDs, you will receive a list of results that can be iterated through."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multiple_records = client.get_records([1, 2, 3]) \n",
+    "\n",
+    "for record in multiple_records:\n",
+    "    print(f\"Molecule: {record.molecule.name}, Energy: {record.properties['scf total energy']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How do I search for particular types of computations?\n",
+    "\n",
+    "You can search the database for particular computations using `query_records`.\n",
+    "For example, to see all results from a particular time period, we can use\n",
+    "`query_records` with arguments `created_before` and `created_after`.\n",
+    "\n",
+    "There are many fields you can query the database on and this can differ by the type of computation you'd like to retrieve.\n",
+    "The query method returns a Python iterator.\n",
+    "For more detailed information, see [the quickstart tutorial on querying](query-quickstart)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records = client.query_records(created_after=\"2023/01/10\", created_before=\"2023/01/14\")\n",
+    "\n",
+    "# Print the first record.\n",
+    "print(next(records))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How do I retrieve results from a dataset?\n",
+    "\n",
+    "QCArchive also supports data to be stored in datasets.\n",
+    "A dataset is a set of related computations. \n",
+    "Datasets can be created when computations are submitted, or after computations have completed, and\n",
+    "computations can belong to multiple datasets.\n",
+    "Datasets are the primary use case for QCArchive, and are usually created with large-scale workflows.\n",
+    "Datasets will contain only one type of calculation.\n",
+    "\n",
+    "We can list all of the datasets on the server we've connected to using `list_datasets`.\n",
+    "Below, we print the names of the data sets on the QCArchive demo server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasets = client.list_datasets()\n",
+    "\n",
+    "for dataset in datasets:\n",
+    "    print(f\"Name: {dataset['dataset_name']}, Type: {dataset['dataset_type']}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can retrieve records from a particular dataset using the `get_dataset` method and passing in the dataset name and type. The following cell retrieves the \"Element Benchmark\" dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = client.get_dataset(dataset_type=\"singlepoint\", dataset_name=\"Element Benchmark\")\n",
+    "print(ds.description)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Datasets have a lot of properties that are beyond the scope of this overview. \n",
+    "Datasets are made up of many records of the same type of computation that can differ in molecule identity or other specification parameters.\n",
+    "You can pull out iterate over records, see specifications, and compile values from records.\n",
+    "\n",
+    "The cell below shows using the `compile_values` method to create a pandas dataframe containing the SCF total energy from each record."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use compile_values to make a dataframe\n",
+    "df = ds.compile_values(lambda record: record.properties['scf total energy'], \"scf total energy\")\n",
+    "\n",
+    "# view the first 10 rows.\n",
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Submitting Computations\n",
+    "\n",
+    "Beyond retrieving results and querying the database, QCArchive provides a robust system for submitting computations. \n",
+    "You may submit single computations, multiple computations, or computations to create a dataset.\n",
+    "\n",
+    "Our QCArchive demo server is publicly readable.\n",
+    "This means you do not need a username or password to access the data.\n",
+    "However, to submit computations, a username and password is required.\n",
+    "\n",
+    "```{admonition} Protecting usernames and passwords\n",
+    ":class: warning\n",
+    "\n",
+    "When connecting to QCArchive using a username and password, be careful to never commit this information to publicly accessible repositories.\n",
+    "You can store credentials in environment variables, as shown in the cell below,\n",
+    "or you can [read user information from a file](qcportal_connecting_file).\n",
+    "\n",
+    "```\n",
+    "\n",
+    "In the cell below, we read environment variables set in the local environment for our username and password. \n",
+    "We retrieve these using `os.environ.get`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import qcportal as ptl\n",
+    "from qcportal.molecules import Molecule\n",
+    "\n",
+    "client = ptl.PortalClient(\"https://qcademo.molssi.org\", \n",
+    "                          username=os.environ.get(\"QCArchiveUsername\"), \n",
+    "                          password=os.environ.get(\"QCArchivePWD\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have a QCPortal client that can be used to submit computations.\n",
+    "\n",
+    "### How do I submit a computation?\n",
+    "\n",
+    "QCArchive currently supports seven different computation types including single point, geometry optimization, reactions, and torsion drives.\n",
+    "\n",
+    "For this overview, we will show submitting a single point computation for water using two different methods.\n",
+    "This notebook shows inputting an XYZ string for our molecule, but there are a [number of ways](creating_molecules) to enter molecule information.\n",
+    "Our molecule geometry in this example is an optimized structure of water."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "water_xyz = \"\"\"\n",
+    "3\n",
+    "\n",
+    "H                     0.026223561887     1.224983815810     0.000000000000\n",
+    "H                     0.971741135004     0.039335313725     0.000000000000\n",
+    "O                     0.002035305512     0.235680871424     0.000000000000\n",
+    "\n",
+    "\"\"\"\n",
+    "\n",
+    "water = Molecule.from_data(water_xyz)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The molecule objects in QCArchive can be visualized using NGLView by putting\n",
+    "the variable representing the molecule as the last thing in a cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "water"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To submit our single point computation, we will use the `add_singlepoints` method.\n",
+    "We will submit two single point computations for the same molecule using different methods.\n",
+    "\n",
+    "For `add_singlepoints`, you specify the program you want to run (Psi4 in our case), the driver, the method and the basis set.\n",
+    "The `driver` determines what is in the `return_result` for the record. \n",
+    "For this demonstration, we are submitting two single point calculations for water with a differing method (`b3lyp` vs `mp2`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b3lyp_meta, b3lyp_record_ids = client.add_singlepoints([water], \n",
+    "                                                       program='psi4', \n",
+    "                                                       driver='energy', \n",
+    "                                                       method='b3lyp', \n",
+    "                                                       basis='def2-tzvp')\n",
+    "\n",
+    "mp2_meta, mp2_record_ids = client.add_singlepoints([water], \n",
+    "                                                   program='psi4', \n",
+    "                                                   driver='energy', \n",
+    "                                                   method='mp2', \n",
+    "                                                   basis='def2-tzvp')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once submitted, we can retrieve the results using the `get_records` method shown earlier in the tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b3lpy_record = client.get_records(b3lyp_record_ids[0])\n",
+    "mp2_record = client.get_records(mp2_record_ids[0])\n",
+    "\n",
+    "print(f\"B3LYP Status:\\t{b3lpy_record.status}\")\n",
+    "print(f\"MP2 Status:\\t{mp2_record.status}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the computations are complete, we can retrieve the energies in the same way we did earlier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"B3LYP result: {b3lpy_record.return_result}\")\n",
+    "print(f\"MP2 result: {mp2_record.return_result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How do I create datasets?\n",
+    "\n",
+    "Instead of submitting these computations separately, we could have grouped them together in a dataset. \n",
+    "This would allow us to more easily retrieve the results together.\n",
+    "\n",
+    "To create a dataset, you use the `create_dataset` method.\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "ds = client.add_dataset(\"singlepoint\",\n",
+    "                        name=\"Water calculations\",\n",
+    "                        description=\"Single point calculations of water at various levels of theory.\")\n",
+    "\n",
+    "```\n",
+    "\n",
+    "Creation of datasets is beyond the scope of this overview tutorial.\n",
+    "For more information on dataset construction, see the Dataset Quickstart."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qcportal2",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/source/quickstart/record_query.ipynb
+++ b/docs/source/quickstart/record_query.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d60cc0ff",
+   "metadata": {},
+   "source": [
+    "(query-quickstart)=\n",
+    "# How do I search for specific types of computations?\n",
+    "\n",
+    "This notebook introduces you to the basics of connecting to a QCArchive server and retrieving computation results using information like molecule, basis set, method, or other computation details.\n",
+    "\n",
+    "You can retrieve results from QCArchive using the `get_records` method if you know the ID of the computation you'd like to retrieve.\n",
+    "However, you can also query the database for computations having specific details using `query` methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17936106",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qcportal as ptl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77db1326",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "## Create a client object and connect to the demo server\n",
+    "\n",
+    "The `PortalClient` is how you interact with the server, including querying records and submitting computations.\n",
+    "\n",
+    "The demo server allows for unauthenticated guest access, so no username/password is necessary to read from the server. However, you will\n",
+    "need to log in to submit or modify computations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75672420",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Guest access\n",
+    "client = ptl.PortalClient(\"https://qcademo.molssi.org\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c63f21",
+   "metadata": {},
+   "source": [
+    "````{admonition} Connecting with username/password\n",
+    ":class: note\n",
+    "\n",
+    "If you have a username/password, you would include those in the client connection.\n",
+    "\n",
+    "```python\n",
+    "client = ptl.PortalClient(\"https://qcademo.molssi.org\", username=\"YOUR_USERNAME\", password=\"YOUR_PASSWORD\")\n",
+    "```\n",
+    "\n",
+    "⚠️Caution⚠️: Always handle credentials with care. Never commit sensitive information like usernames or passwords to public repositories.\n",
+    "\n",
+    "````"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a94c69ee",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "## Querying Records\n",
+    "\n",
+    "Use the `query_records method`` for general queries. \n",
+    "This method allows you to search across all records in the database, regardless of the computation type. \n",
+    "Please note that since query_records searches all record types, you can only query fields that are common to all records."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7c435a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(client.query_records)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c8b2584",
+   "metadata": {},
+   "source": [
+    "For example, to query for computations created between January 10, 2023 and January 14, 2023, we could do the following."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "325575ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = client.query_records(created_after=\"2023/01/10\", created_before=\"2023/01/14\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8235c32d",
+   "metadata": {},
+   "source": [
+    "Our results from this query will be in something called an iterator.\n",
+    "An iterator can be made into a list by casting or used in a `for` loop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "109bbc33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_list = list(results)\n",
+    "print(f\"Found {len(results_list)} results.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "775c55ec",
+   "metadata": {},
+   "source": [
+    "After the results are retrieved, you can work with the records as shown in the \"How do I work with computation records?\" tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65b65b8a",
+   "metadata": {},
+   "source": [
+    "## Querying by computation details\n",
+    "\n",
+    "If you want to query by computation specifications such as basis set, method, molecule, etc, you will need to use a more specific query methods.\n",
+    "For example, if you want to query single point computations, you should use the `query_singlepoints` method.\n",
+    "Documentation for the `query_singlepoints` method is shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b29b0e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(client.query_singlepoints)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2ccc525",
+   "metadata": {},
+   "source": [
+    "As shown in the help message above, you can query single points on many different parameters.\n",
+    "For example, you might choose to query the database for `mp2` calculations using the `aug-cc-pvtz` basis using the `psi4` program.\n",
+    "For the sake of demonstration in this notebook, we are limiting the number of results to 5 records."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ae7e4a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = client.query_singlepoints(method=\"mp2\", basis=\"aug-cc-pvtz\", program=\"psi4\", limit=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f3d1f3c",
+   "metadata": {},
+   "source": [
+    "After retrieving the results, we can loop through them and view information about the records."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ca53e2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for record in results:\n",
+    "    print(record.id, record.molecule)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/quickstart/record_retrieval.ipynb
+++ b/docs/source/quickstart/record_retrieval.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d60cc0ff",
+   "metadata": {},
+   "source": [
+    "# How do I retrieve computation results by ID?\n",
+    "\n",
+    "This tutorial introduces the basics of connecting to a QCArchive server and retrieving computation results. \n",
+    "\n",
+    "When you retrieve results from QCArchive, they can be in the form of single records or a larger dataset. \n",
+    "\n",
+    "A record represents a single quantum chemistry computation and contains the input details and the results. \n",
+    "While some records represent simple computations (like a single point computation), others can encapsulate more complex workflows and multiple associated computations.\n",
+    "\n",
+    "A *dataset* is a collection of similar records.\n",
+    "\n",
+    "In this QuickStart, you'll learn how to connect to the QCArchive Demo Server and retrieve records by their IDs.\n",
+    "If you'd like to learn more about records, see the \"How do I work with records?\" tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17936106",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qcportal as ptl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77db1326",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "## Create a client object and connect to the demo server\n",
+    "\n",
+    "The `PortalClient` is how you interact with the server, including querying records and submitting computations.\n",
+    "\n",
+    "The demo server allows for unauthenticated guest access, so no username/password is necessary to read from the server. However, you will\n",
+    "need to log in to submit or modify computations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75672420",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Guest access\n",
+    "client = ptl.PortalClient(\"https://qcademo.molssi.org\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c63f21",
+   "metadata": {},
+   "source": [
+    "````{admonition} Connecting with username/password\n",
+    ":class: note\n",
+    "\n",
+    "If you have a username/password, you would include those in the client connection.\n",
+    "\n",
+    "```python\n",
+    "client = ptl.PortalClient(\"https://qcademo.molssi.org\", username=\"YOUR_USERNAME\", password=\"YOUR_PASSWORD\")\n",
+    "```\n",
+    "\n",
+    "⚠️Caution⚠️: Always handle credentials with care. Never commit sensitive information like usernames or passwords to public repositories.\n",
+    "\n",
+    "````"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a94c69ee",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "## Retrieving a Single Record by ID\n",
+    "\n",
+    "To retrieve a record, you can use the `get_records` method. You pass in the IDs of the records you would like to retrieve.\n",
+    "\n",
+    "If a list of IDs is specified, then a list of records is returned. Otherwise, only a single record is returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7baae1c4",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "record = client.get_records(1)\n",
+    "print(record)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f952f1f",
+   "metadata": {},
+   "source": [
+    "From printing the record, we see that the record with ID 1 is a single point calculation (`SinglePointRecord`) and that this computation is \"complete\" (`RecordStatusEnum.complete`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10554f21",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "### Viewing Record Information\n",
+    "\n",
+    "Records have lots of features, and what they have depends on the type of record - we will only cover a few here.\n",
+    "\n",
+    "For the single point calculation we retrieved, we can see information about the molecule (`molecule` attribute), the method, basis, etc (`specification`), and more.\n",
+    "\n",
+    "To see information about the molecule used in the calculation, use `record.molecule`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "142dbe46",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The molecule that we computed\n",
+    "print(record.molecule)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26482a84",
+   "metadata": {},
+   "source": [
+    "The information above tells us that the single point calculation was \n",
+    "performed on a helium atom.\n",
+    "\n",
+    "````{admonition} Molecule \"hash\"\n",
+    "\n",
+    "The molecule hash is a unique identifier that takes atom identity,\n",
+    "connectivity, coordinates, and fragmentation into account.\n",
+    "\n",
+    "````\n",
+    "\n",
+    "The record specification shows the program used for the calculation,\n",
+    "as well as information about the method as basis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "132c7542",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The specification (method, basis, etc)\n",
+    "print(record.specification)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a854f87a",
+   "metadata": {},
+   "source": [
+    "The specification printed above tells us that this calculation was performed\n",
+    "with the Psi4 software using the `hf` method and `sto-3g` basis set."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9144e59",
+   "metadata": {},
+   "source": [
+    "## Retrieving Multiple Records\n",
+    "\n",
+    "The previous example showed retrieving just one record from QCArchive using the `get_records` method.\n",
+    "However, more than one record at a time can be retrieved by passing a list of computation IDs to the method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "769d9494",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records = client.get_records([1, 2, 3])\n",
+    "\n",
+    "print(f\"Retrieved {len(records)} records.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07ec31d0",
+   "metadata": {},
+   "source": [
+    "Using, the information presented earlier, we can see data about each computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf19c415",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for record in records:\n",
+    "    print(record, record.molecule)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8feccd99",
+   "metadata": {},
+   "source": [
+    "## Retrieving Records by Computation Type\n",
+    "\n",
+    "The QCArchive API also allows you to retrieve records based on the computation type. \n",
+    "QCArchive supports different types of computations including single points, optimizations,\n",
+    "torsion drives and more.\n",
+    "In addition to using `get_records`, you can also use methods specific to the type of computation of interest.\n",
+    "For example, to retrieve single point computations only, you can use the method `get_singlepoints`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8363f4cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records = client.get_singlepoints([1,2])\n",
+    "print(records)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/molecule.rst
+++ b/docs/source/user_guide/molecule.rst
@@ -6,6 +6,7 @@ The molecule objects used in QCArchive come from the
 from ``qcportal.molecules.Molecule``, but is otherwise the same as the
 `QCElemental Molecule <https://docs.qcarchive.molssi.org/projects/QCElemental/en/stable/model_molecule.html>`_.
 
+.. _creating_molecules:
 Creating Molecules
 ------------------
 


### PR DESCRIPTION
## Description
This PR adds a quickstart section and some quick start notebooks to the docs.

Quickstarts are added as jupyter notebooks. Jupyter notebooks are converted to html using [MyST-NB](https://myst-nb.readthedocs.io/en/latest/).

You can see a preview of these docs [here](https://janash.github.io/QCFractal/index.html).

Note that for these to build correctly, repository secrets must be added and set as environment variables in the workflow. [Here is how I did it for the sample docs.](https://github.com/janash/QCFractal/blob/fbd503fd0848b5d6a55bab141922c2453c8fa2c3/.github/workflows/build_docs.yml#L36). The repository owner would have to handle this for the main docs. No real idea if this is the best way!

## Status
- [ ] Code base linted - do i need to do this?
- [x] Ready to go
