### PR TITLE
add environment variables to docs build

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -33,6 +33,8 @@ jobs:
         shell: bash -l {0}
         working-directory: docs
         run: |
+          export QCArchiveUsername=${{ secrets.QCARCHIVEUSERNAME }}
+          export QCArchivePWD=${{ secrets.QCARCHIVEPWD }}
           cd docs
           make html
 


### PR DESCRIPTION
This PR adds the environment variables needed for executing notebooks to the GitHub Actions workflow for docs.
