### PR TITLE
Implement getting reason a record is waiting

### DIFF
--- a/qcfractal/qcfractal/components/record_routes.py
+++ b/qcfractal/qcfractal/components/record_routes.py
@@ -56,6 +56,12 @@ def bulk_delete_records_v1(body_data: RecordDeleteBody):
     )
 
 
+@api_v1.route("/records/<int:record_id>/waiting_reason", methods=["GET"])
+@wrap_route("READ")
+def get_record_waiting_reason_v1(record_id: int):
+    return storage_socket.records.get_waiting_reason(record_id)
+
+
 #################################################################
 # Routes for individual record types
 # These can also be accessed through /records

--- a/qcfractal/qcfractal/components/test_record_client_waiting_reason.py
+++ b/qcfractal/qcfractal/components/test_record_client_waiting_reason.py
@@ -1,0 +1,193 @@
+"""
+Tests the tasks socket (claiming & returning data)
+"""
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from qcarchivetesting.testing_classes import QCATestingSnowflake
+from qcfractal.components.optimization.testing_helpers import load_test_data as load_opt_test_data
+from qcfractal.components.singlepoint.testing_helpers import (
+    load_test_data as load_sp_test_data,
+)
+from qcfractal.components.torsiondrive.testing_helpers import load_test_data as load_td_test_data
+from qcportal.managers import ManagerName
+from qcportal.record_models import PriorityEnum
+
+if TYPE_CHECKING:
+    pass
+
+
+def test_record_client_waiting_reason(snowflake: QCATestingSnowflake):
+    storage_socket = snowflake.get_storage_socket()
+    snowflake_client = snowflake.client()
+
+    input_spec_1, molecule_1, result_data_1 = load_sp_test_data("sp_psi4_water_energy")
+    input_spec_2, molecule_2, result_data_2 = load_opt_test_data("opt_psi4_benzene")
+    input_spec_3, molecule_3, result_data_3 = load_sp_test_data("sp_rdkit_benzene_energy")
+
+    meta, id_1 = storage_socket.records.singlepoint.add(
+        [molecule_1], input_spec_1, "tag1", PriorityEnum.low, None, None, True
+    )
+    meta, id_2 = storage_socket.records.optimization.add(
+        [molecule_2], input_spec_2, "tag2", PriorityEnum.normal, None, None, True
+    )
+    meta, id_3 = storage_socket.records.singlepoint.add(
+        [molecule_3], input_spec_3, "tag3", PriorityEnum.high, None, None, True
+    )
+    id_1 = id_1[0]
+    id_2 = id_2[0]
+    id_3 = id_3[0]
+    all_id = [id_1, id_2, id_3]
+
+    for i in all_id:
+        reason = snowflake_client.get_waiting_reason(i)
+        assert reason["reason"] == "No active managers"
+
+    # Activate some managers
+    mname1 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-5678")
+    storage_socket.managers.activate(
+        name_data=mname1,
+        manager_version="v2.0",
+        username="bill",
+        programs={"qcengine": ["unknown"], "other_prog": ["unknown"]},
+        tags=["tag1"],
+    )
+
+    mname2 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-7890")
+    storage_socket.managers.activate(
+        name_data=mname2,
+        manager_version="v2.0",
+        username="bill",
+        programs={"qcengine": ["unknown"], "geometric": ["unknown"]},
+        tags=["tag2"],
+    )
+
+    mname3 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-8888")
+    storage_socket.managers.activate(
+        name_data=mname3,
+        manager_version="v2.0",
+        username="bill",
+        programs={"qcengine": ["unknown"], "psi4": ["unknown"]},
+        tags=["tag999"],
+    )
+
+    mname4 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-0123")
+    storage_socket.managers.activate(
+        name_data=mname4,
+        manager_version="v2.0",
+        username="bill",
+        programs={"qcengine": ["unknown"], "psi4": ["unknown"], "geometric": ["unknown"]},
+        tags=["tag999"],
+    )
+
+    reason = snowflake_client.get_waiting_reason(id_1)
+    assert reason["reason"] == "No manager matches programs & tags"
+    assert re.search(r"missing programs.*psi4", reason["details"][mname1.fullname])
+    assert re.search(r"missing programs.*psi4", reason["details"][mname2.fullname])
+    assert re.search(r"does not handle tag.*tag1", reason["details"][mname3.fullname])
+    assert re.search(r"does not handle tag.*tag1", reason["details"][mname4.fullname])
+
+    reason = snowflake_client.get_waiting_reason(id_2)
+    assert reason["reason"] == "No manager matches programs & tags"
+    assert re.search(r"missing programs.*psi4", reason["details"][mname1.fullname])
+    assert re.search(r"missing programs.*geometric", reason["details"][mname1.fullname])
+    assert re.search(r"missing programs.*psi4", reason["details"][mname2.fullname])
+    assert re.search(r"missing programs.*geometric", reason["details"][mname3.fullname])
+    assert re.search(r"does not handle tag.*tag2", reason["details"][mname4.fullname])
+
+    # Add a working manager
+    mname5 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-2222")
+    storage_socket.managers.activate(
+        name_data=mname5,
+        manager_version="v2.0",
+        username="bill",
+        programs={"qcengine": ["unknown"], "psi4": ["unknown"], "geometric": ["unknown"]},
+        tags=["tag1", "tag2"],
+    )
+
+    reason = snowflake_client.get_waiting_reason(id_1)
+    assert reason["reason"] == "Waiting for a free manager"
+    assert reason["details"][mname5.fullname] == "Manager is busy"
+
+    reason = snowflake_client.get_waiting_reason(id_2)
+    assert reason["reason"] == "Waiting for a free manager"
+    assert reason["details"][mname5.fullname] == "Manager is busy"
+
+    # third test record requires rdkit, which we haven't given yet
+    reason = snowflake_client.get_waiting_reason(id_3)
+    assert reason["reason"] == "No manager matches programs & tags"
+    assert re.search(r"missing programs.*rdkit", reason["details"][mname1.fullname])
+    assert re.search(r"missing programs.*rdkit", reason["details"][mname2.fullname])
+    assert re.search(r"missing programs.*rdkit", reason["details"][mname3.fullname])
+    assert re.search(r"missing programs.*rdkit", reason["details"][mname4.fullname])
+    assert re.search(r"missing programs.*rdkit", reason["details"][mname5.fullname])
+
+    # Also try through the record
+    record = snowflake_client.get_records(id_3)
+    assert record.get_waiting_reason() == reason
+
+    # Add a working manager with * tag
+    mname6 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-0011")
+    storage_socket.managers.activate(
+        name_data=mname6,
+        manager_version="v2.0",
+        username="bill",
+        programs={"qcengine": ["unknown"], "psi4": ["unknown"], "geometric": ["unknown"], "rdkit": ["unknown"]},
+        tags=["tag1", "*"],
+    )
+
+    reason = snowflake_client.get_waiting_reason(id_3)
+    assert reason["reason"] == "Waiting for a free manager"
+    assert re.search(r"Manager is busy", reason["details"][mname6.fullname])
+
+
+def test_record_client_waiting_reason_2(snowflake: QCATestingSnowflake):
+    storage_socket = snowflake.get_storage_socket()
+    snowflake_client = snowflake.client()
+
+    input_spec_1, molecule_1, result_data_1 = load_sp_test_data("sp_psi4_water_energy")
+    input_spec_2, molecule_2, _ = load_td_test_data("td_H2O2_mopac_pm6")
+
+    meta, id_1 = storage_socket.records.singlepoint.add(
+        [molecule_1], input_spec_1, "tag1", PriorityEnum.low, None, None, True
+    )
+
+    meta, id_2 = snowflake_client.add_torsiondrives(
+        [molecule_2],
+        "torsiondrive",
+        keywords=input_spec_2.keywords,
+        optimization_specification=input_spec_2.optimization_specification,
+    )
+
+    id_1 = id_1[0]
+    id_2 = id_2[0]
+
+    # Add a working manager with * tag
+    mname6 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-0011")
+    storage_socket.managers.activate(
+        name_data=mname6,
+        manager_version="v2.0",
+        username="bill",
+        programs={"qcengine": ["unknown"], "psi4": ["unknown"], "geometric": ["unknown"], "rdkit": ["unknown"]},
+        tags=["tag1", "*"],
+    )
+
+    # Should be able to be picked up
+    reason = snowflake_client.get_waiting_reason(id_1)
+    assert reason["reason"] == "Waiting for a free manager"
+    assert re.search(r"Manager is busy", reason["details"][mname6.fullname])
+
+    # Reason: not actually waiting
+    storage_socket.records.cancel([id_1])
+    reason = snowflake_client.get_waiting_reason(id_1)
+    assert reason["reason"] == "Record is not waiting"
+
+    # Reason: does not exist
+    reason = snowflake_client.get_waiting_reason(id_1 + id_2)
+    assert reason["reason"] == "Record does not exist"
+
+    # Reason: is a service
+    reason = snowflake_client.get_waiting_reason(id_2)
+    assert reason["reason"] == "Record is a service"

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -897,6 +897,26 @@ class PortalClient(PortalClientBase):
         body_data = RecordModifyBody(record_ids=record_ids, comment=comment)
         return self.make_request("patch", "api/v1/records", UpdateMetadata, body=body_data)
 
+    def get_waiting_reason(self, record_id: int) -> Dict[str, Any]:
+        """
+        Get the reason a record is in the waiting status
+
+        The return is a dictionary, with a 'reason' key containing the overall reason the record is
+        waiting. If appropriate, there is a 'details' key that contains information for each
+        active compute manager on why that manager is not able to pick up the record's task.
+
+        Parameters
+        ----------
+        record_id
+            The record ID to test
+
+        Returns
+        -------
+        :
+            A dictionary containing information about why the record is not being picked up by compute managers
+        """
+        return self.make_request("get", f"api/v1/records/{record_id}/waiting_reason", Dict[str, Any])
+
     ##############################################################
     # Singlepoint calculations
     ##############################################################

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -540,6 +540,9 @@ class BaseRecord(BaseModel):
             self._fetch_service()
         return self.service_
 
+    def get_waiting_reason(self) -> Dict[str, Any]:
+        return self._client.make_request("get", f"api/v1/records/{self.id}/waiting_reason", Dict[str, Any])
+
     @property
     def comments(self) -> Optional[List[RecordComment]]:
         if self.comments_ is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Implement functionality for testing why a record is in the `waiting` status. Inspired by https://github.com/openmm/spice-dataset/issues/82#issuecomment-1732462457

Often, a record will be waiting because managers don't exist or have the wrong tags/programs. This was opaque to the user. This allows for the user to test why a record is waiting.

```
r = client.get_record(record_id)
reason = r.get_waiting_reason()
print(reason)

# or

reason = client.get_waiting_reason(record_id)
print(reason)
```

## Changelog description
Implement functionality for checking why a record is in the `waiting` state

## Status
- [X] Code base linted
- [x] Ready to go
