### PR TITLE
Enable existing_ok=True for creating datasets

### DIFF
--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -94,6 +94,7 @@ def add_dataset_v1(dataset_type: str, body_data: DatasetAddBody):
         metadata=body_data.metadata,
         owner_user=g.username,
         owner_group=body_data.owner_group,
+        existing_ok=body_data.existing_ok,
     )
 
 

--- a/qcfractal/qcfractal/components/test_dataset_client.py
+++ b/qcfractal/qcfractal/components/test_dataset_client.py
@@ -65,10 +65,14 @@ def test_dataset_client_add_same_name(snowflake_client: PortalClient):
 
 
 def test_dataset_client_add_duplicate(snowflake_client: PortalClient):
-    snowflake_client.add_dataset("singlepoint", "Test dataset")
+    ds = snowflake_client.add_dataset("singlepoint", "Test dataset")
 
     with pytest.raises(PortalRequestError, match=r"Dataset.*already exists"):
+        # existing_ok = False by default
         snowflake_client.add_dataset("singlepoint", "TEST DATASET")
+
+    ds2 = snowflake_client.add_dataset("singlepoint", "Test dataset", existing_ok=True)
+    assert ds.id == ds2.id
 
 
 def test_dataset_client_delete_empty(snowflake_client: PortalClient):

--- a/qcfractal/qcfractal/components/test_dataset_socket.py
+++ b/qcfractal/qcfractal/components/test_dataset_socket.py
@@ -44,6 +44,7 @@ def test_dataset_socket_submit_defaults(
         metadata={},
         owner_user=default_user,
         owner_group=default_group,
+        existing_ok=False,
     )
 
     ds = storage_socket.datasets.get(ds_id)

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -315,6 +315,7 @@ class PortalClient(PortalClientBase):
         default_priority: PriorityEnum = PriorityEnum.normal,
         metadata: Optional[Dict[str, Any]] = None,
         owner_group: Optional[str] = None,
+        existing_ok: bool = False,
     ) -> BaseDataset:
 
         if description is None:
@@ -342,6 +343,7 @@ class PortalClient(PortalClientBase):
             default_priority=default_priority,
             metadata=metadata,
             owner_group=owner_group,
+            existing_ok=existing_ok,
         )
 
         ds_id = self.make_request("post", f"api/v1/datasets/{dataset_type}", int, body=body)

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1174,6 +1174,7 @@ class DatasetAddBody(RestModelBase):
     default_priority: PriorityEnum
     metadata: Dict[str, Any]
     owner_group: Optional[str]
+    existing_ok: bool = False
 
 
 class DatasetModifyMetadata(RestModelBase):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description

Adds the ability to specify `existing_ok=True` for `add_dataset`. If True, and a dataset exists with the same type & name, the existing dataset is returned and a new dataset is not created.

## Changelog description
`Add existing_ok=True` for `add_dataset`

## Status
- [X] Code base linted
- [x] Ready to go
