### PR TITLE
Add display of number of records in a dataset

### DIFF
--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -136,6 +136,13 @@ def get_dataset_detailed_status_v1(dataset_type: str, dataset_id: int):
     return ds_socket.detailed_status(dataset_id)
 
 
+@api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/record_count", methods=["GET"])
+@wrap_route("READ")
+def get_dataset_record_count_v1(dataset_type: str, dataset_id: int):
+    ds_socket = storage_socket.datasets.get_socket(dataset_type)
+    return ds_socket.get_record_count(dataset_id)
+
+
 #########################
 # Modifying metadata
 #########################

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -270,8 +270,8 @@ class PortalClient(PortalClientBase):
 
     def list_datasets_table(self) -> str:
         ds_list = self.list_datasets()
-        headers = ["id", "type", "name"]
-        table = [(x["id"], x["dataset_type"], x["dataset_name"]) for x in ds_list]
+        headers = ["id", "type", "record_count", "name"]
+        table = [(x["id"], x["dataset_type"], x["record_count"], x["dataset_name"]) for x in ds_list]
         return tabulate(table, headers=headers)
 
     def print_datasets_table(self) -> None:

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -283,6 +283,16 @@ class BaseDataset(BaseModel):
             raise RuntimeError("Dataset does not connected to a QCFractal server")
 
     @property
+    def record_count(self) -> int:
+        self.assert_online()
+
+        return self._client.make_request(
+            "get",
+            f"api/v1/datasets/{self.dataset_type}/{self.id}/record_count",
+            int,
+        )
+
+    @property
     def is_view(self) -> bool:
         return self._view_data is not None
 

--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -243,6 +243,9 @@ def run_dataset_model_remove_record(snowflake_client, ds, test_entries, test_spe
 
 def run_dataset_model_submit(ds, test_entries, test_spec, record_compare):
 
+    assert ds.record_count == 0
+    assert ds._client.list_datasets()[0]["record_count"] == 0
+
     # test_entries[2] should have additional keywords
     assert test_entries[2].additional_keywords
 
@@ -292,6 +295,10 @@ def run_dataset_model_submit(ds, test_entries, test_spec, record_compare):
     else:
         assert rec.task.tag == "default_tag"
         assert rec.task.priority == PriorityEnum.low
+
+    record_count = len(ds.entry_names) * len(ds.specifications)
+    assert ds.record_count == record_count
+    assert ds._client.list_datasets()[0]["record_count"] == record_count
 
 
 def run_dataset_model_submit_missing(ds):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Adds the number of records in a dataset to the `list_datasets` functionality, and also the ability to request from the server the number of records in a dataset via the dataset model (`ds.record_count`). Requested in issue #756

The record count is computed on the fly. For now, this is fine, but we will have to keep an eye on it as the database size increases, though, as then listing dataset size could take too long. There could be more database trickery we could do.

Example output from `print_dataset_list` (for a small subset of the production database):

```
 id  type                record_count  name
----  ----------------  --------------  -----------------------------------
  48  torsiondrive                   3  SMIRNOFF Coverage Torsion Set 1
  50  optimization                   3  OpenFF Discrepancy Benchmark 1
 155  singlepoint                   24  QM9
 159  singlepoint                    3  OpenFF Discrepancy Benchmark 1
 184  manybody                       0  S22
 207  singlepoint                   24  COMP6 DrugBank
 237  gridoptimization               5  OpenFF Trivalent Nitrogen Set 2
 253  optimization                   3  OpenFF Gen 2 Opt Set 2 Coverage
 309  torsiondrive                  39  OpenFF Theory Benchmarking Set v1.0
```


## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Add display of number of records in a dataset, and ability to get number of records in a dataset

## Status
- [X] Code base linted
- [X] Ready to go
