### PR TITLE
Resetting records should not affect running records

### DIFF
--- a/qcfractal/qcfractal/components/record_socket.py
+++ b/qcfractal/qcfractal/components/record_socket.py
@@ -1458,12 +1458,17 @@ class RecordSocket:
 
     def reset(self, record_ids: Sequence[int], *, session: Optional[Session] = None):
         """
-        Resets running or errored records to be waiting again
+        Resets errored records to be waiting again
         """
 
-        return self._revert_common(
-            record_ids, applicable_status=[RecordStatusEnum.running, RecordStatusEnum.error], session=session
-        )
+        return self._revert_common(record_ids, applicable_status=[RecordStatusEnum.error], session=session)
+
+    def reset_running(self, record_ids: Sequence[int], *, session: Optional[Session] = None):
+        """
+        Resets running records to be waiting again
+        """
+
+        return self._revert_common(record_ids, applicable_status=[RecordStatusEnum.running], session=session)
 
     def delete(
         self,

--- a/qcfractal/qcfractal/components/tasks/test_socket_badmanagers.py
+++ b/qcfractal/qcfractal/components/tasks/test_socket_badmanagers.py
@@ -209,7 +209,7 @@ def test_task_socket_return_manager_badstatus_1(storage_socket: SQLAlchemySocket
 
     tasks = storage_socket.tasks.claim_tasks(mname1.fullname, _manager_programs, ["tag1"])
 
-    storage_socket.records.reset([record_id])
+    storage_socket.records.reset_running([record_id])
 
     with caplog_handler_at_level(caplog, logging.WARNING):
         rmeta = storage_socket.tasks.update_finished(mname1.fullname, {tasks[0]["id"]: result_data_compressed})

--- a/qcfractal/qcfractal/components/test_record_status_changes.py
+++ b/qcfractal/qcfractal/components/test_record_status_changes.py
@@ -95,11 +95,11 @@ def test_record_client_reset(snowflake: QCATestingSnowflake):
 
     all_id = populate_records_status(storage_socket)
 
-    # Can reset only running, error
+    # Can reset only error
     time_0 = datetime.utcnow()
     meta = snowflake_client.reset_records(all_id)
     time_1 = datetime.utcnow()
-    assert meta.n_updated == 2
+    assert meta.n_updated == 1
 
     with storage_socket.session_scope() as session:
         rec = [session.get(BaseRecordORM, i) for i in all_id]
@@ -110,7 +110,7 @@ def test_record_client_reset(snowflake: QCATestingSnowflake):
 
         assert rec[0].status == RecordStatusEnum.waiting
         assert rec[1].status == RecordStatusEnum.complete
-        assert rec[2].status == RecordStatusEnum.waiting
+        assert rec[2].status == RecordStatusEnum.running
         assert rec[3].status == RecordStatusEnum.waiting
         assert rec[4].status == RecordStatusEnum.cancelled
         assert rec[5].status == RecordStatusEnum.deleted
@@ -126,7 +126,7 @@ def test_record_client_reset(snowflake: QCATestingSnowflake):
 
         assert rec[0].manager_name is None
         assert rec[1].manager_name is not None
-        assert rec[2].manager_name is None
+        assert rec[2].manager_name is not None
         assert rec[3].manager_name is None
         assert rec[4].manager_name is None
         assert rec[5].manager_name is None
@@ -134,7 +134,7 @@ def test_record_client_reset(snowflake: QCATestingSnowflake):
 
         assert rec[0].modified_on < time_0
         assert rec[1].modified_on < time_0
-        assert time_0 < rec[2].modified_on < time_1
+        assert rec[2].modified_on < time_0
         assert time_0 < rec[3].modified_on < time_1
         assert rec[4].modified_on < time_0
         assert rec[5].modified_on < time_0
@@ -162,7 +162,7 @@ def test_record_client_reset_missing(snowflake: QCATestingSnowflake):
     snowflake_client = snowflake.client()
 
     all_id = populate_records_status(storage_socket)
-    meta = snowflake_client.reset_records([all_id[2], 9999])
+    meta = snowflake_client.reset_records([all_id[3], 9999])
     assert meta.success is False
     assert meta.n_updated == 1
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Reset records should only reset errored records

Initial this worked for running records, but that often results in erroneously resetting records that shouldn't have been reset.

There is nowl a `reset_running` function in the socket, in case we need it. But hopefully all the issues that required resetting running records have been ironed out. If needed, it can be re-added, or a user can cancel, then uncancel a record.

## Changelog description
`reset_records` only resets errored records now

## Status
- [X] Code base linted
- [X] Ready to go
