### PR TITLE
Implement getting computed properties for a dataset

### DIFF
--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -143,6 +143,13 @@ def get_dataset_record_count_v1(dataset_type: str, dataset_id: int):
     return ds_socket.get_record_count(dataset_id)
 
 
+@api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/computed_properties", methods=["GET"])
+@wrap_route("READ")
+def get_dataset_computed_properties_v1(dataset_type: str, dataset_id: int):
+    ds_socket = storage_socket.datasets.get_socket(dataset_type)
+    return ds_socket.get_computed_properties(dataset_id)
+
+
 #########################
 # Modifying metadata
 #########################

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -293,6 +293,16 @@ class BaseDataset(BaseModel):
         )
 
     @property
+    def computed_properties(self):
+        self.assert_online()
+
+        return self._client.make_request(
+            "get",
+            f"api/v1/datasets/{self.dataset_type}/{self.id}/computed_properties",
+            Dict[str, List[str]],
+        )
+
+    @property
     def is_view(self) -> bool:
         return self._view_data is not None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Enable getting lists of all properties computed by a dataset

This function returns a dictionary of specifications -> list of properties found in the records for this specification.
Since most of the time every record for a given specification will have the same property keys, only one record is chosen.
There could be the rare case where this isn't true.

## Changelog description
Add ability to get a list of properties computed in a dataset

## Status
- [X] Code base linted
- [X] Ready to go
