### PR TITLE
Improve compile_values and related functions

### DIFF
--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1116,7 +1116,7 @@ class BaseDataset(BaseModel):
     def compile_values(
         self,
         value_call: Callable,
-        value_names: Union[List[str], str] = "value",
+        value_names: Union[Sequence[str], str] = "value",
         entry_names: Optional[Union[str, Iterable[str]]] = None,
         specification_names: Optional[Union[str, Iterable[str]]] = None,
         unpack: bool = False,
@@ -1126,23 +1126,23 @@ class BaseDataset(BaseModel):
 
         Parameters
         -----------
-        value_call : Callable
+        value_call 
             Function to call on each record to extract the desired value. Must return a scalar value or 
             a sequence of values if 'unpack' is set to True.
 
-        value_names : Union[List[str], str], optional
+        value_names
             Column name(s) for the extracted value(s). If a string is provided and multiple values are 
             returned by 'value_call', columns are named by appending an index to this string. If a list 
             of strings is provided, it must match the length of the sequence returned by 'value_call'.
             Default is "value".
 
-        entry_names : Optional[Union[str, Iterable[str]]], optional
+        entry_names 
             Entry names to filter records. If not provided, considers all entries.
 
-        specification_names : Optional[Union[str, Iterable[str]]], optional
+        specification_names 
             Specification names to filter records. If not provided, considers all specifications.
 
-        unpack : bool, optional
+        unpack
             If True, unpack the sequence of values returned by 'value_call' into separate columns.
             Default is False.
 
@@ -1209,7 +1209,7 @@ class BaseDataset(BaseModel):
         # Make specification top level index.
         return return_val.swaplevel(axis=1)
 
-    def get_properties_df(self, properties_list: List[str]) -> pd.DataFrame:
+    def get_properties_df(self, properties_list: Sequence[str]) -> pd.DataFrame:
         """
         Retrieve a DataFrame populated with the specified properties from dataset records.
 
@@ -1221,7 +1221,7 @@ class BaseDataset(BaseModel):
 
         Parameters:
         -----------
-        properties_list : List[str]
+        properties_list 
             List of property names to retrieve from the records.
 
         Returns:

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1168,15 +1168,10 @@ class BaseDataset(BaseModel):
         return return_val.swaplevel(axis=1)
 
     def get_properties_df(self, properties_list: List):
+        func = lambda x: [x.properties.get(property_name) for property_name in properties_list]
 
-        dfs = []
-        for property_name in properties_list:
-            property_df = self.compile_values(
-                lambda x: x.properties.get(property_name), property_name
-            )
-            dfs.append(property_df)
+        result = self.compile_values(func, value_name=properties_list, unpack=True)
 
-        result = pd.concat(dfs, axis=1)
         result.dropna(how="all", axis=1, inplace=True)
         return result
 

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1116,7 +1116,7 @@ class BaseDataset(BaseModel):
     def compile_values(
         self,
         value_call: Callable,
-        value_name: Union[List[str], str] = "value",
+        value_names: Union[List[str], str] = "value",
         entry_names: Optional[Union[str, Iterable[str]]] = None,
         specification_names: Optional[Union[str, Iterable[str]]] = None,
         include: Optional[Iterable[str]] = None,
@@ -1147,20 +1147,20 @@ class BaseDataset(BaseModel):
         first_value = _check_first()
 
         if unpack and isinstance(first_value, Sequence) and not isinstance(first_value, str):
-            if isinstance(value_name, str):
-                column_names = [value_name + str(i) for i in range(len(first_value))]
+            if isinstance(value_names, str):
+                column_names = [value_names + str(i) for i in range(len(first_value))]
             else:
-                if len(first_value) != len(value_name):
+                if len(first_value) != len(value_names):
                     raise ValueError(
                         "Number of column names must match number of values returned by provided function."
                     )
-                column_names = value_name
+                column_names = value_names
 
             df = pd.DataFrame(_data_generator(unpack=True), columns=("entry", "specification", *column_names))
 
         else:
-            column_names = [value_name]
-            df = pd.DataFrame(_data_generator(), columns=("entry", "specification", value_name))
+            column_names = [value_names]
+            df = pd.DataFrame(_data_generator(), columns=("entry", "specification", value_names))
 
         return_val = df.pivot(index="entry", columns="specification", values=column_names)
 
@@ -1170,7 +1170,7 @@ class BaseDataset(BaseModel):
     def get_properties_df(self, properties_list: List):
         func = lambda x: [x.properties.get(property_name) for property_name in properties_list]
 
-        result = self.compile_values(func, value_name=properties_list, unpack=True)
+        result = self.compile_values(func, value_names=properties_list, unpack=True)
 
         result.dropna(how="all", axis=1, inplace=True)
         return result

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1168,12 +1168,11 @@ class BaseDataset(BaseModel):
         return return_val.swaplevel(axis=1)
 
     def get_properties_df(self, properties_list: List):
-        from collections import defaultdict
 
         dfs = []
         for property_name in properties_list:
             property_df = self.compile_values(
-                lambda x: defaultdict(None, x.properties).get(property_name), property_name
+                lambda x: x.properties.get(property_name), property_name
             )
             dfs.append(property_df)
 


### PR DESCRIPTION
This PR makes some edits to the `compile_values` method and adds a new dataset method called `get_properties_df`.

The following changes are made to `compile_values`:

* `compile_values` now always returns a multi-level index where the specification is the top leve index.
* `compile_values` now has an option to unpack results from the callable, allowing more than one dataframe column to be built at a time.
* `entry_name` may be a string or list of strings, but now also has a default value in case the user doesn't provide it.

Example use:
```python
import qcportal as ptl

client = ptl.PortalClient("https://qcademo.molssi.org")
dataset = client.get_dataset_by_id(1)

# Case 1 - Single value returned from callable.
df1 = dataset.compile_values(lambda x: x.properties["scf_total_energy"],"scf_total_energy" )

# Case 2 - Tuple of two values returned from callable with unpack True
df2 = dataset.compile_values(lambda x: (x.properties["scf_total_energy"], x.properties["scf_iterations"]), unpack=True)
```

The function `get_properties_df` is added to allow easier compilation of record properties into a dataframe. The function takes a list of properties and returns a multi-level index dataframe similar to the type returned from `compile_values`. Under the hood, the function uses `compile_values`  accessing the `properties` using `.get` in case property doesn't exist for a particular specification. Additionally, before the df is returned to the user any columns containing all `nan` are dropped.

Example use (continuing from example above)
```python
properties = dataset.get_properties_df(["scf_total_energy", "scf dipole", "mp2 dipole"])
```