### PR TITLE
Allow env vars for compute manager paths

### DIFF
--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -19,6 +19,7 @@ def _make_abs_path(path: Optional[str], base_folder: str, default_filename: Opti
         path = default_filename
 
     path = os.path.expanduser(path)
+    path = os.path.expandvars(path)
     if os.path.isabs(path):
         return path
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Enable use of environment variables when specifying paths in the compute manager config.
Simple one-line addition :)

Fixes #767 

For example,

```
logfile: ${LOG_PATH}/test.log
```

## Changelog description
Enable use of environment variables when specifying paths in the compute manager config

## Status
- [X] Code base linted
- [X] Ready to go
