### PR TITLE
[WIP] Faster/better addition of dataset entries

### DIFF
--- a/qcfractal/qcfractal/components/singlepoint/dataset_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/dataset_socket.py
@@ -58,6 +58,7 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
                 molecule_id=molecule_id,
                 additional_keywords=entry.additional_keywords,
                 attributes=entry.attributes,
+                local_results=entry.local_results,
             )
 
             all_entries.append(new_ent)

--- a/qcportal/qcportal/reaction/dataset_models.py
+++ b/qcportal/qcportal/reaction/dataset_models.py
@@ -10,31 +10,27 @@ from qcportal.reaction.record_models import ReactionRecord, ReactionSpecificatio
 from qcportal.utils import make_list
 
 
-class ReactionDatasetNewEntry(BaseModel):
-    class Config:
-        extra = Extra.forbid
-
-    name: str
-    stoichiometries: List[Tuple[float, Union[int, Molecule]]]
-    additional_keywords: Dict[str, Any] = {}
-    attributes: Dict[str, Any] = {}
-    comment: Optional[str] = None
-
-
 class ReactionDatasetEntryStoichiometry(BaseModel):
     coefficient: float
     molecule: Molecule
 
 
-class ReactionDatasetEntry(BaseModel):
+class ReactionDatasetNewEntry(BaseModel):
     class Config:
         extra = Extra.forbid
 
     name: str
+    stoichiometries: List[Union[ReactionDatasetEntryStoichiometry, Tuple[float, Union[int, Molecule]]]]
+    additional_keywords: Dict[str, Any] = {}
+    attributes: Dict[str, Any] = {}
     comment: Optional[str] = None
+
+
+class ReactionDatasetEntry(ReactionDatasetNewEntry):
+    class Config:
+        extra = Extra.forbid
+
     stoichiometries: List[ReactionDatasetEntryStoichiometry]
-    additional_keywords: Optional[Dict[str, Any]] = {}
-    attributes: Optional[Dict[str, Any]] = {}
 
 
 class ReactionDatasetSpecification(BaseModel):

--- a/qcportal/qcportal/singlepoint/dataset_models.py
+++ b/qcportal/qcportal/singlepoint/dataset_models.py
@@ -22,11 +22,11 @@ class SinglepointDatasetNewEntry(BaseModel):
     additional_keywords: Dict[str, Any] = {}
     attributes: Dict[str, Any] = {}
     comment: Optional[str] = None
+    local_results: Optional[Dict[str, Any]] = None
 
 
 class SinglepointDatasetEntry(SinglepointDatasetNewEntry):
     molecule: Molecule
-    local_results: Optional[Dict[str, Any]] = None
 
 
 class SinglepointDatasetSpecification(BaseModel):

--- a/qcportal/qcportal/singlepoint/test_dataset_models.py
+++ b/qcportal/qcportal/singlepoint/test_dataset_models.py
@@ -18,6 +18,7 @@ test_entries = [
         name="HYDrogen_4",
         comment="a comment",
         attributes={"internal": "h2"},
+        local_results={"energy": -1.0, "other_energy": -2.0},
     ),
     SinglepointDatasetNewEntry(
         molecule=Molecule(symbols=["h", "h"], geometry=[0, 0, 0, 0, 0, 6]),
@@ -42,6 +43,7 @@ test_specs = [
 def entry_extra_compare(ent1, ent2):
     assert ent1.molecule == ent2.molecule
     assert ent1.additional_keywords == ent2.additional_keywords
+    assert ent1.local_results == ent2.local_results
 
 
 def record_compare(rec, ent, spec):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Improve the efficiency of adding large numbers of entries to a dataset

- [X] Fix expensive SQL queries. No need to retrieve all existing entries when adding a single entry. Use batching for large numbers
- [x] Improve usability of `add_entries` functions in dataset models

For the first, local tests of adding 10,000 entries to a singlepoint dataset one-by-one show a reduction of 75%, with consistent (rather than steadily increasing) insertion time. 

See https://github.com/openmm/spice-dataset/issues/82#issuecomment-1753480715 for the initial motivation

## Changelog description
Improve the efficiency of adding large numbers of entries to a dataset

## Status
- [x] Code base linted
- [x] Ready to go
