### PR TITLE
Remove client version checks and start new compatibility guarantees

### DIFF
--- a/qcfractal/qcfractal/client_versions.py
+++ b/qcfractal/qcfractal/client_versions.py
@@ -1,9 +1,0 @@
-"""
-Allowed client versions
-"""
-
-client_version_lower_limit = "0.50b12.post35"
-client_version_upper_limit = "1"
-
-manager_version_lower_limit = "0.50b12.post35"
-manager_version_upper_limit = "1"

--- a/qcfractal/qcfractal/components/serverinfo/routes.py
+++ b/qcfractal/qcfractal/components/serverinfo/routes.py
@@ -1,12 +1,6 @@
 from flask import current_app
 
 from qcfractal import __version__ as qcfractal_version
-from qcfractal.client_versions import (
-    client_version_lower_limit,
-    client_version_upper_limit,
-    manager_version_lower_limit,
-    manager_version_upper_limit,
-)
 from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.api_v1.helpers import wrap_route
@@ -25,17 +19,17 @@ from qcportal.utils import calculate_limit
 def get_information():
     qcf_cfg = current_app.config["QCFRACTAL_CONFIG"]
 
-    # TODO FOR RELEASE - change lower and upper version limits?
+    # TODO - remove version limits after a while. They are there to support older clients
     public_info = {
         "name": qcf_cfg.name,
         "manager_heartbeat_frequency": qcf_cfg.heartbeat_frequency,
         "manager_heartbeat_max_missed": qcf_cfg.heartbeat_max_missed,
         "version": qcfractal_version,
         "api_limits": qcf_cfg.api_limits.dict(),
-        "client_version_lower_limit": client_version_lower_limit,
-        "client_version_upper_limit": client_version_upper_limit,
-        "manager_version_lower_limit": manager_version_lower_limit,
-        "manager_version_upper_limit": manager_version_upper_limit,
+        "client_version_lower_limit": "0.50",
+        "client_version_upper_limit": "1.00",
+        "manager_version_lower_limit": "0.50",
+        "manager_version_upper_limit": "1.00",
         "motd": storage_socket.serverinfo.get_motd(),
     }
 

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -270,8 +270,15 @@ class PortalClient(PortalClientBase):
 
     def list_datasets_table(self) -> str:
         ds_list = self.list_datasets()
-        headers = ["id", "type", "record_count", "name"]
-        table = [(x["id"], x["dataset_type"], x["record_count"], x["dataset_name"]) for x in ds_list]
+
+        # older servers don't have record_count
+        if all("record_count" in x for x in ds_list):
+            headers = ["id", "type", "record_count", "name"]
+            table = [(x["id"], x["dataset_type"], x["record_count"], x["dataset_name"]) for x in ds_list]
+        else:
+            headers = ["id", "type", "name"]
+            table = [(x["id"], x["dataset_type"], x["dataset_name"]) for x in ds_list]
+
         return tabulate(table, headers=headers)
 
     def print_datasets_table(self) -> None:

--- a/qcportal/qcportal/client_base.py
+++ b/qcportal/qcportal/client_base.py
@@ -145,16 +145,15 @@ class PortalClientBase:
         self.server_name = self.server_info["name"]
         self.api_limits = self.server_info["api_limits"]
 
-        client_version_lower_limit = parse_version(self.server_info["client_version_lower_limit"])
-        client_version_upper_limit = parse_version(self.server_info["client_version_upper_limit"])
-
+        server_version = parse_version(self.server_info["version"])
         client_version = parse_version(__version__)
 
-        if not client_version_lower_limit <= client_version <= client_version_upper_limit:
-            raise RuntimeError(
-                f"This client version {str(client_version)} does not fall within the server's allowed "
-                f"client versions of [{str(client_version_lower_limit)}, {str(client_version_upper_limit)}]."
-                f"You may need to upgrade or downgrade"
+        if client_version > server_version:
+            self._logger.warning(
+                "WARNING: This client version is newer than the server version. This may work if the "
+                "versions are close, but expect exceptions and errors if attempting things the server "
+                "does not support. "
+                f"client version: {str(__version__)}, server version: {str(self.server_info['version'])}"
             )
 
         motd = self.server_info.get("motd", "")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Remove client/manager version checks against what the server reports.

Starting in 0.51, backwards-incompatible changes to the API will be handled by changing the version in the URI
(ie, `/api/v1/datasets` -> `/api/v2/datasets`). This will be done only on the endpoints that do change.

The `v1` API's will left in place, so older clients will still work with newer servers.

If a new client detects an old server, a warning is printed. The main hazard there is that the client may want new features the server does not provide.

Starting with QCFractal v1.0, we should move to semver, so we could at least check major versions between client and server. This would allow us to remove the older versioned endpoints.

## Changelog description
Removed forced version checks between client and server

## Status
- [X] Code base linted
- [ ] Ready to go
