### PR TITLE
Add automatic batching in ds.add_entries() and ds.submit()

### DIFF
--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -301,13 +301,15 @@ def run_dataset_model_submit(ds, test_entries, test_spec, record_compare):
     assert ds._client.list_datasets()[0]["record_count"] == record_count
 
 
-def run_dataset_model_submit_missing(ds):
+def run_dataset_model_submit_missing(ds, test_entries, test_spec):
+    ds.add_specification("spec_1", test_spec)
+    ds.add_entries(test_entries)
     ds.submit()  # should be ok
 
     with pytest.raises(PortalRequestError, match="Could not find all entries"):
-        ds.submit(entry_names="entry_1")
+        ds.submit(entry_names="non_entry_1")
     with pytest.raises(PortalRequestError, match="Could not find all specifications"):
-        ds.submit(specification_names="spec_1")
+        ds.submit(specification_names="non_spec_1")
 
 
 def run_dataset_model_iterate_updated(ds, test_entries, test_spec):

--- a/qcportal/qcportal/gridoptimization/dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/dataset_models.py
@@ -10,7 +10,6 @@ from qcportal.gridoptimization.record_models import (
 )
 from qcportal.metadata_models import InsertMetadata
 from qcportal.molecules import Molecule
-from qcportal.utils import make_list
 
 
 class GridoptimizationDatasetNewEntry(BaseModel):
@@ -60,6 +59,7 @@ class GridoptimizationDataset(BaseDataset):
 
     # Needed by the base class
     _entry_type = GridoptimizationDatasetEntry
+    _new_entry_type = GridoptimizationDatasetNewEntry
     _specification_type = GridoptimizationDatasetSpecification
     _record_item_type = GridoptimizationDatasetRecordItem
     _record_type = GridoptimizationRecord
@@ -69,32 +69,13 @@ class GridoptimizationDataset(BaseDataset):
     ) -> InsertMetadata:
 
         spec = GridoptimizationDatasetSpecification(name=name, specification=specification, description=description)
-
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/gridoptimization/{self.id}/specifications",
-            InsertMetadata,
-            body=[spec],
-        )
-
-        self._post_add_specification(name)
-        return ret
+        return self._add_specifications(spec)
 
     def add_entries(
         self, entries: Union[GridoptimizationDatasetNewEntry, Iterable[GridoptimizationDatasetNewEntry]]
     ) -> InsertMetadata:
 
-        entries = make_list(entries)
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/gridoptimization/{self.id}/entries/bulkCreate",
-            InsertMetadata,
-            body=entries,
-        )
-
-        new_names = [x.name for x in entries]
-        self._post_add_entries(new_names)
-        return ret
+        return self._add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/gridoptimization/test_dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/test_dataset_models.py
@@ -155,7 +155,7 @@ def test_gridoptimization_dataset_model_submit(snowflake_client: PortalClient):
 
 def test_gridoptimization_dataset_model_submit_missing(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("gridoptimization", "Test dataset")
-    ds_helpers.run_dataset_model_submit_missing(ds)
+    ds_helpers.run_dataset_model_submit_missing(ds, test_entries, test_specs[0])
 
 
 def test_gridoptimization_dataset_model_iterate_updated(snowflake_client: PortalClient):

--- a/qcportal/qcportal/manybody/dataset_models.py
+++ b/qcportal/qcportal/manybody/dataset_models.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Union, Optional, List, Iterable, Tuple
+from typing import Dict, Any, Union, Optional, Iterable, Tuple
 
 from pydantic import BaseModel, Extra
 from typing_extensions import Literal
@@ -7,7 +7,6 @@ from qcportal.dataset_models import BaseDataset
 from qcportal.manybody.record_models import ManybodyRecord, ManybodySpecification
 from qcportal.metadata_models import InsertMetadata
 from qcportal.molecules import Molecule
-from qcportal.utils import make_list
 
 
 class ManybodyDatasetNewEntry(BaseModel):
@@ -53,6 +52,7 @@ class ManybodyDataset(BaseDataset):
 
     # Needed by the base class
     _entry_type = ManybodyDatasetEntry
+    _new_entry_type = ManybodyDatasetNewEntry
     _specification_type = ManybodyDatasetSpecification
     _record_item_type = ManybodyDatasetRecordItem
     _record_type = ManybodyRecord
@@ -60,33 +60,12 @@ class ManybodyDataset(BaseDataset):
     def add_specification(
         self, name: str, specification: ManybodySpecification, description: Optional[str] = None
     ) -> InsertMetadata:
-        initial_molecules: Optional[List[Molecule]]
 
         spec = ManybodyDatasetSpecification(name=name, specification=specification, description=description)
-
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/manybody/{self.id}/specifications",
-            InsertMetadata,
-            body=[spec],
-        )
-
-        self._post_add_specification(name)
-        return ret
+        return self._add_specifications(spec)
 
     def add_entries(self, entries: Union[ManybodyDatasetNewEntry, Iterable[ManybodyDatasetNewEntry]]) -> InsertMetadata:
-
-        entries = make_list(entries)
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/manybody/{self.id}/entries/bulkCreate",
-            InsertMetadata,
-            body=entries,
-        )
-
-        new_names = [x.name for x in entries]
-        self._post_add_entries(new_names)
-        return ret
+        return self._add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/manybody/test_dataset_models.py
+++ b/qcportal/qcportal/manybody/test_dataset_models.py
@@ -111,7 +111,7 @@ def test_manybody_dataset_model_submit(snowflake_client: PortalClient):
 
 def test_manybody_dataset_model_submit_missing(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("manybody", "Test dataset")
-    ds_helpers.run_dataset_model_submit_missing(ds)
+    ds_helpers.run_dataset_model_submit_missing(ds, test_entries, test_specs[0])
 
 
 def test_manybody_dataset_model_iterate_updated(snowflake_client: PortalClient):

--- a/qcportal/qcportal/neb/dataset_models.py
+++ b/qcportal/qcportal/neb/dataset_models.py
@@ -10,7 +10,6 @@ from qcportal.neb.record_models import (
     NEBRecord,
     NEBSpecification,
 )
-from qcportal.utils import make_list
 
 
 class NEBDatasetNewEntry(BaseModel):
@@ -58,6 +57,7 @@ class NEBDataset(BaseDataset):
 
     # Needed by the base class
     _entry_type = NEBDatasetEntry
+    _new_entry_type = NEBDatasetNewEntry
     _specification_type = NEBDatasetSpecification
     _record_item_type = NEBDatasetRecordItem
     _record_type = NEBRecord
@@ -67,30 +67,10 @@ class NEBDataset(BaseDataset):
     ) -> InsertMetadata:
 
         spec = NEBDatasetSpecification(name=name, specification=specification, description=description)
-
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/neb/{self.id}/specifications",
-            InsertMetadata,
-            body=[spec],
-        )
-
-        self._post_add_specification(name)
-        return ret
+        return self._add_specifications(spec)
 
     def add_entries(self, entries: Union[NEBDatasetNewEntry, Iterable[NEBDatasetNewEntry]]) -> InsertMetadata:
-
-        entries = make_list(entries)
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/neb/{self.id}/entries/bulkCreate",
-            InsertMetadata,
-            body=entries,
-        )
-
-        new_names = [x.name for x in entries]
-        self._post_add_entries(new_names)
-        return ret
+        return self._add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/neb/test_dataset_models.py
+++ b/qcportal/qcportal/neb/test_dataset_models.py
@@ -161,7 +161,7 @@ def test_neb_dataset_model_submit(snowflake_client: PortalClient):
 
 def test_neb_dataset_model_submit_missing(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("neb", "Test dataset")
-    ds_helpers.run_dataset_model_submit_missing(ds)
+    ds_helpers.run_dataset_model_submit_missing(ds, test_entries, test_specs[0])
 
 
 def test_neb_dataset_model_iterate_updated(snowflake_client: PortalClient):

--- a/qcportal/qcportal/optimization/dataset_models.py
+++ b/qcportal/qcportal/optimization/dataset_models.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Union, Optional, List, Iterable, Tuple
+from typing import Dict, Any, Union, Optional, Iterable, Tuple
 
 from pydantic import BaseModel, Extra
 from typing_extensions import Literal
@@ -7,7 +7,6 @@ from qcportal.dataset_models import BaseDataset
 from qcportal.metadata_models import InsertMetadata
 from qcportal.molecules import Molecule
 from qcportal.optimization.record_models import OptimizationRecord, OptimizationSpecification
-from qcportal.utils import make_list
 
 
 class OptimizationDatasetNewEntry(BaseModel):
@@ -56,6 +55,7 @@ class OptimizationDataset(BaseDataset):
 
     # Needed by the base class
     _entry_type = OptimizationDatasetEntry
+    _new_entry_type = OptimizationDatasetNewEntry
     _specification_type = OptimizationDatasetSpecification
     _record_item_type = OptimizationDatasetRecordItem
     _record_type = OptimizationRecord
@@ -63,36 +63,14 @@ class OptimizationDataset(BaseDataset):
     def add_specification(
         self, name: str, specification: OptimizationSpecification, description: Optional[str] = None
     ) -> InsertMetadata:
-        initial_molecules: Optional[List[Molecule]]
 
         spec = OptimizationDatasetSpecification(name=name, specification=specification, description=description)
-
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/optimization/{self.id}/specifications",
-            InsertMetadata,
-            body=[spec],
-        )
-
-        self._post_add_specification(name)
-        return ret
+        return self._add_specifications(spec)
 
     def add_entries(
         self, entries: Union[OptimizationDatasetNewEntry, Iterable[OptimizationDatasetNewEntry]]
     ) -> InsertMetadata:
-
-        entries = make_list(entries)
-
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/optimization/{self.id}/entries/bulkCreate",
-            InsertMetadata,
-            body=entries,
-        )
-
-        new_names = [x.name for x in entries]
-        self._post_add_entries(new_names)
-        return ret
+        return self._add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/optimization/test_dataset_models.py
+++ b/qcportal/qcportal/optimization/test_dataset_models.py
@@ -113,7 +113,7 @@ def test_optimization_dataset_model_submit(snowflake_client: PortalClient):
 
 def test_optimization_dataset_model_submit_missing(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("optimization", "Test dataset")
-    ds_helpers.run_dataset_model_submit_missing(ds)
+    ds_helpers.run_dataset_model_submit_missing(ds, test_entries, test_specs[0])
 
 
 def test_optimization_dataset_model_iterate_updated(snowflake_client: PortalClient):

--- a/qcportal/qcportal/reaction/dataset_models.py
+++ b/qcportal/qcportal/reaction/dataset_models.py
@@ -7,7 +7,6 @@ from qcportal.dataset_models import BaseDataset
 from qcportal.metadata_models import InsertMetadata
 from qcportal.molecules import Molecule
 from qcportal.reaction.record_models import ReactionRecord, ReactionSpecification
-from qcportal.utils import make_list
 
 
 class ReactionDatasetEntryStoichiometry(BaseModel):
@@ -64,6 +63,7 @@ class ReactionDataset(BaseDataset):
 
     # Needed by the base class
     _entry_type = ReactionDatasetEntry
+    _new_entry_type = ReactionDatasetNewEntry
     _specification_type = ReactionDatasetSpecification
     _record_item_type = ReactionDatasetRecordItem
     _record_type = ReactionRecord
@@ -73,30 +73,10 @@ class ReactionDataset(BaseDataset):
     ) -> InsertMetadata:
 
         spec = ReactionDatasetSpecification(name=name, specification=specification, description=description)
-
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/reaction/{self.id}/specifications",
-            InsertMetadata,
-            body=[spec],
-        )
-
-        self._post_add_specification(name)
-        return ret
+        return self._add_specifications(spec)
 
     def add_entries(self, entries: Union[ReactionDatasetEntry, Iterable[ReactionDatasetNewEntry]]) -> InsertMetadata:
-
-        entries = make_list(entries)
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/reaction/{self.id}/entries/bulkCreate",
-            InsertMetadata,
-            body=make_list(entries),
-        )
-
-        new_names = [x.name for x in entries]
-        self._post_add_entries(new_names)
-        return ret
+        return self._add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/reaction/test_dataset_models.py
+++ b/qcportal/qcportal/reaction/test_dataset_models.py
@@ -133,7 +133,7 @@ def test_reaction_dataset_model_submit(snowflake_client: PortalClient):
 
 def test_reaction_dataset_model_submit_missing(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("reaction", "Test dataset")
-    ds_helpers.run_dataset_model_submit_missing(ds)
+    ds_helpers.run_dataset_model_submit_missing(ds, test_entries, test_specs[0])
 
 
 def test_reaction_dataset_model_iterate_updated(snowflake_client: PortalClient):

--- a/qcportal/qcportal/singlepoint/dataset_models.py
+++ b/qcportal/qcportal/singlepoint/dataset_models.py
@@ -10,7 +10,6 @@ from qcportal.singlepoint.record_models import (
     SinglepointRecord,
     QCSpecification,
 )
-from qcportal.utils import make_list
 
 
 class SinglepointDatasetNewEntry(BaseModel):
@@ -60,6 +59,7 @@ class SinglepointDataset(BaseDataset):
 
     # Needed by the base class
     _entry_type = SinglepointDatasetEntry
+    _new_entry_type = SinglepointDatasetNewEntry
     _specification_type = SinglepointDatasetSpecification
     _record_item_type = SinglepointDatasetRecordItem
     _record_type = SinglepointRecord
@@ -69,33 +69,12 @@ class SinglepointDataset(BaseDataset):
     ) -> InsertMetadata:
 
         spec = SinglepointDatasetSpecification(name=name, specification=specification, description=description)
-
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/singlepoint/{self.id}/specifications",
-            InsertMetadata,
-            body=[spec],
-        )
-
-        self._post_add_specification(name)
-        return ret
+        return self._add_specifications(spec)
 
     def add_entries(
         self, entries: Union[SinglepointDatasetNewEntry, Iterable[SinglepointDatasetNewEntry]]
     ) -> InsertMetadata:
-
-        entries = make_list(entries)
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/singlepoint/{self.id}/entries/bulkCreate",
-            InsertMetadata,
-            body=entries,
-        )
-
-        new_names = [x.name for x in entries]
-        self._post_add_entries(new_names)
-
-        return ret
+        return self._add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/singlepoint/test_dataset_models.py
+++ b/qcportal/qcportal/singlepoint/test_dataset_models.py
@@ -98,7 +98,7 @@ def test_singlepoint_dataset_model_submit(snowflake_client: PortalClient):
 
 def test_singlepoint_dataset_model_submit_missing(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("singlepoint", "Test dataset")
-    ds_helpers.run_dataset_model_submit_missing(ds)
+    ds_helpers.run_dataset_model_submit_missing(ds, test_entries, test_specs[0])
 
 
 def test_singlepoint_dataset_model_iterate_updated(snowflake_client: PortalClient):

--- a/qcportal/qcportal/test_dataset_models.py
+++ b/qcportal/qcportal/test_dataset_models.py
@@ -139,7 +139,7 @@ def test_dataset_model_status(snowflake: QCATestingSnowflake):
     assert ds.status() == {"spec_1": {RecordStatusEnum.complete: 1, RecordStatusEnum.waiting: 1}}
 
 
-def test_dataset_model_add_entry_many(snowflake_client: PortalClient):
+def test_dataset_model_add_submit_many(snowflake_client: PortalClient):
 
     ds: SinglepointDataset = snowflake_client.add_dataset("singlepoint", "Test dataset")
     assert ds.status() == {}
@@ -161,3 +161,14 @@ def test_dataset_model_add_entry_many(snowflake_client: PortalClient):
     assert meta.n_existing == 2999
     assert meta.existing_idx == list(range(2999))
     assert meta.n_errors == 0
+
+    ds.add_specification(
+        "test_spec", specification={"program": "test_prog", "driver": "energy", "method": "HF", "basis": "sto-3g"}
+    )
+    ds.add_specification(
+        "test_spec_2", specification={"program": "test_prog_2", "driver": "energy", "method": "HF", "basis": "sto-3g"}
+    )
+
+    ds.submit()
+
+    assert ds.record_count == 2999 * 2

--- a/qcportal/qcportal/test_metadata_models.py
+++ b/qcportal/qcportal/test_metadata_models.py
@@ -1,0 +1,24 @@
+from qcportal.metadata_models import InsertMetadata
+
+
+def test_insert_metadata_merge():
+    m1 = InsertMetadata(inserted_idx=[0, 1], existing_idx=[2, 3, 5], errors=[(4, "error1")])
+    m2 = InsertMetadata(inserted_idx=[], existing_idx=[0], errors=[])
+    m3 = InsertMetadata(inserted_idx=[0], existing_idx=[], errors=[])
+    m4 = InsertMetadata()
+    m5 = InsertMetadata(inserted_idx=[5], existing_idx=[0, 1, 2, 3], errors=[(4, "error2")])
+
+    all = InsertMetadata.merge([m1, m2, m3, m4, m5])
+
+    assert all.inserted_idx == [0, 1, 7, 13]
+    assert all.existing_idx == [2, 3, 5, 6, 8, 9, 10, 11]
+    assert all.error_idx == [4, 12]
+    assert all.errors == [(4, "error1"), (12, "error2")]
+    assert all.error_description is None
+
+    m1 = InsertMetadata(inserted_idx=[0, 1], error_description="errordesc1")
+    m2 = InsertMetadata(inserted_idx=[], existing_idx=[0])
+    m3 = InsertMetadata(inserted_idx=[0], error_description="errordesc2")
+
+    all = InsertMetadata.merge([m1, m2, m3])
+    assert all.error_description == "errordesc1\nerrordesc2"

--- a/qcportal/qcportal/torsiondrive/dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/dataset_models.py
@@ -7,7 +7,6 @@ from qcportal.dataset_models import BaseDataset
 from qcportal.metadata_models import InsertMetadata
 from qcportal.molecules import Molecule
 from qcportal.torsiondrive.record_models import TorsiondriveRecord, TorsiondriveSpecification
-from qcportal.utils import make_list
 
 
 class TorsiondriveDatasetNewEntry(BaseModel):
@@ -59,6 +58,7 @@ class TorsiondriveDataset(BaseDataset):
 
     # Needed by the base class
     _entry_type = TorsiondriveDatasetEntry
+    _new_entry_type = TorsiondriveDatasetNewEntry
     _specification_type = TorsiondriveDatasetSpecification
     _record_item_type = TorsiondriveDatasetRecordItem
     _record_type = TorsiondriveRecord
@@ -68,32 +68,13 @@ class TorsiondriveDataset(BaseDataset):
     ) -> InsertMetadata:
 
         spec = TorsiondriveDatasetSpecification(name=name, specification=specification, description=description)
-
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/torsiondrive/{self.id}/specifications",
-            InsertMetadata,
-            body=[spec],
-        )
-
-        self._post_add_specification(name)
-        return ret
+        return self._add_specifications(spec)
 
     def add_entries(
         self, entries: Union[TorsiondriveDatasetNewEntry, Iterable[TorsiondriveDatasetNewEntry]]
     ) -> InsertMetadata:
 
-        entries = make_list(entries)
-        ret = self._client.make_request(
-            "post",
-            f"api/v1/datasets/torsiondrive/{self.id}/entries/bulkCreate",
-            InsertMetadata,
-            body=entries,
-        )
-
-        new_names = [x.name for x in entries]
-        self._post_add_entries(new_names)
-        return ret
+        return self._add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/torsiondrive/test_dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/test_dataset_models.py
@@ -160,7 +160,7 @@ def test_torsiondrive_dataset_model_submit(snowflake_client: PortalClient):
 
 def test_torsiondrive_dataset_model_submit_missing(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("torsiondrive", "Test dataset")
-    ds_helpers.run_dataset_model_submit_missing(ds)
+    ds_helpers.run_dataset_model_submit_missing(ds, test_entries, test_specs[0])
 
 
 def test_torsiondrive_dataset_model_iterate_updated(snowflake_client: PortalClient):

--- a/qcportal/qcportal/utils.py
+++ b/qcportal/qcportal/utils.py
@@ -30,26 +30,6 @@ def make_list(obj: Optional[Union[_T, Sequence[_T]]]) -> Optional[List[_T]]:
     return list(obj)
 
 
-def make_str(obj: Optional[Union[_T, Sequence[_T]]]) -> Optional[List[_T]]:
-    """
-    Returns a list containing obj if obj is not a list or sequence type object
-    """
-
-    if obj is None:
-        return None
-    # Be careful. strings are sequences
-    if isinstance(obj, str):
-        return obj
-    if not isinstance(obj, Sequence):
-        return str(obj)
-    if isinstance(obj, list):
-        return [str(i) for i in obj]
-    if isinstance(obj, tuple):
-        return tuple(str(i) for i in obj)
-    else:
-        raise ValueError("`obj` must be `None`, a str, list, tuple, or non-sequence")
-
-
 def chunk_iterable(it: Iterable[_T], chunk_size: int) -> Generator[List[_T], None, None]:
     """
     Split an iterable (such as a list) into batches/chunks


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Trying to add a large number of entries can cause a timeout on the server. This adds automatic batching (with progress bars) so that this doesn't happen.

Also adds similar functionality to `submit()`.

In the future, `submit()` (and maybe `add_entries()`) should move to an asynchronous operation, where an internal job is created, which can be viewed/polled with some future-like object.

See https://github.com/openmm/spice-dataset/issues/82 for some motivation, although that's not the only one.

## Changelog description
Add automatic batching in ds.add_entries() and ds.submit()

## Status
- [X] Code base linted
- [X] Ready to go
