### PR TITLE
[WIP] Python 3.12 & 3.13 support

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         encoding: ["application/json", "application/msgpack"]
         
     steps:
@@ -47,7 +47,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -e ./qcportal -e ./qcfractalcompute -e ./qcfractal[services,geoip,snowflake] -e ./qcarchivetesting
-          pip install scipy "geometric @ git+https://github.com/leeping/geomeTRIC"
+          pip install "geometric @ git+https://github.com/leeping/geomeTRIC"
 
       - name: Run tests
         shell: bash -l {0}

--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/full_tests_snowflake.yml
+++ b/.github/workflows/full_tests_snowflake.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/qcarchivetesting/conda-envs/fulltest_server.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_server.yaml
@@ -40,4 +40,3 @@ dependencies:
 
   - pip:
       - "geometric @ git+https://github.com/leeping/geomeTRIC"
-      - scipy # for geometric

--- a/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
@@ -52,4 +52,3 @@ dependencies:
 
   - pip:
       - "geometric @ git+https://github.com/leeping/geomeTRIC"
-      - scipy # for geometric

--- a/qcarchivetesting/conda-envs/fulltest_worker.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_worker.yaml
@@ -35,5 +35,4 @@ dependencies:
 
   # Geometric service
   - pip:
-    - scipy
     - "geometric @ git+https://github.com/leeping/geomeTRIC"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR makes the QCArchive packages 3.12 complient, and adds tests

Currently blocked by 3.12 support for geometric. See https://github.com/leeping/geomeTRIC/issues/173 (see https://github.com/leeping/geomeTRIC/pull/174 for progress)

## Changelog description
Add support for python 3.12

## Status
- [ ] Code base linted
- [ ] Ready to go
