### PR TITLE
Add ability to get status overview of child records

### DIFF
--- a/qcfractal/qcfractal/components/gridoptimization/test_record_client.py
+++ b/qcfractal/qcfractal/components/gridoptimization/test_record_client.py
@@ -85,6 +85,9 @@ def test_gridoptimization_client_add_get(
         assert r.record_type == "gridoptimization"
         assert compare_gridoptimization_specs(spec, r.specification)
 
+        assert r.status == RecordStatusEnum.waiting
+        assert r.children_status == {}
+
         assert r.service.tag == "tag1"
         assert r.service.priority == PriorityEnum.low
 
@@ -195,6 +198,8 @@ def test_gridoptimization_client_delete(snowflake: QCATestingSnowflake):
 
     child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
     assert all(x.status == RecordStatusEnum.complete for x in child_recs)
+    go_rec = snowflake_client.get_records(go_id)
+    assert go_rec.children_status == {RecordStatusEnum.complete: len(child_ids)}
 
     snowflake_client.undelete_records(go_id)
 
@@ -205,6 +210,8 @@ def test_gridoptimization_client_delete(snowflake: QCATestingSnowflake):
 
     child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
     assert all(x.status == RecordStatusEnum.deleted for x in child_recs)
+    go_rec = snowflake_client.get_records(go_id)
+    assert go_rec.children_status == {RecordStatusEnum.deleted: len(child_ids)}
 
     meta = snowflake_client.delete_records(go_id, soft_delete=False, delete_children=True)
     assert meta.success

--- a/qcfractal/qcfractal/components/manybody/test_record_client.py
+++ b/qcfractal/qcfractal/components/manybody/test_record_client.py
@@ -69,6 +69,9 @@ def test_manybody_client_add_get(
         assert r.record_type == "manybody"
         assert compare_manybody_specs(spec, r.specification)
 
+        assert r.status == RecordStatusEnum.waiting
+        assert r.children_status == {}
+
         assert r.service.tag == "tag1"
         assert r.service.priority == PriorityEnum.low
 
@@ -177,6 +180,8 @@ def test_manybody_client_delete(snowflake: QCATestingSnowflake):
 
     child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
     assert all(x.status == RecordStatusEnum.complete for x in child_recs)
+    mb_rec = snowflake_client.get_records(mb_id)
+    assert mb_rec.children_status == {RecordStatusEnum.complete: len(child_ids)}
 
     snowflake_client.undelete_records(mb_id)
 
@@ -187,6 +192,8 @@ def test_manybody_client_delete(snowflake: QCATestingSnowflake):
 
     child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
     assert all(x.status == RecordStatusEnum.deleted for x in child_recs)
+    mb_rec = snowflake_client.get_records(mb_id)
+    assert mb_rec.children_status == {RecordStatusEnum.deleted: len(child_ids)}
 
     meta = snowflake_client.delete_records(mb_id, soft_delete=False, delete_children=True)
     assert meta.success

--- a/qcfractal/qcfractal/components/neb/test_record_client.py
+++ b/qcfractal/qcfractal/components/neb/test_record_client.py
@@ -81,6 +81,9 @@ def test_neb_client_add_get(submitter_client: PortalClient, spec: NEBSpecificati
         assert r.record_type == "neb"
         assert compare_neb_specs(spec, r.specification)
 
+        assert r.status == RecordStatusEnum.waiting
+        assert r.children_status == {}
+
         assert r.service.tag == "tag1"
         assert r.service.priority == PriorityEnum.low
 
@@ -180,15 +183,17 @@ def test_neb_client_delete(snowflake: QCATestingSnowflake):
         rec = session.get(NEBRecordORM, neb_id)
 
         # Children are singlepoints, optimizations, and the trajectory of the optimizations (also singlepoints)
-        child_ids = [x.singlepoint_id for x in rec.singlepoints]
+        direct_child_ids = [x.singlepoint_id for x in rec.singlepoints]
         opt_ids = [x.optimization_id for x in rec.optimizations]
-        child_ids.extend(opt_ids)
+        direct_child_ids.extend(opt_ids)
 
+        child_ids = direct_child_ids.copy()
         for opt in rec.optimizations:
             traj_ids = [x.singlepoint_id for x in opt.optimization_record.trajectory]
             child_ids.extend(traj_ids)
 
     # Some duplicates here
+    direct_child_ids = list(set(direct_child_ids))
     child_ids = list(set(child_ids))
 
     meta = snowflake_client.delete_records(neb_id, soft_delete=True, delete_children=False)
@@ -196,9 +201,10 @@ def test_neb_client_delete(snowflake: QCATestingSnowflake):
     assert meta.deleted_idx == [0]
     assert meta.n_children_deleted == 0
 
-    for cid in child_ids:
-        child_rec = snowflake_client.get_records(cid, missing_ok=True)
-        assert child_rec.status == RecordStatusEnum.complete
+    child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
+    assert all(x.status == RecordStatusEnum.complete for x in child_recs)
+    neb_rec = snowflake_client.get_records(neb_id)
+    assert neb_rec.children_status == {RecordStatusEnum.complete: len(direct_child_ids)}
 
     snowflake_client.undelete_records(neb_id)
 
@@ -207,9 +213,10 @@ def test_neb_client_delete(snowflake: QCATestingSnowflake):
     assert meta.deleted_idx == [0]
     assert meta.n_children_deleted == len(child_ids)
 
-    for cid in child_ids:
-        child_rec = snowflake_client.get_records(cid, missing_ok=True)
-        assert child_rec.status == RecordStatusEnum.deleted
+    child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
+    assert all(x.status == RecordStatusEnum.deleted for x in child_recs)
+    neb_rec = snowflake_client.get_records(neb_id)
+    assert neb_rec.children_status == {RecordStatusEnum.deleted: len(direct_child_ids)}
 
     meta = snowflake_client.delete_records(neb_id, soft_delete=False, delete_children=True)
     assert meta.success
@@ -219,9 +226,8 @@ def test_neb_client_delete(snowflake: QCATestingSnowflake):
     recs = snowflake_client.get_nebs(neb_id, missing_ok=True)
     assert recs is None
 
-    for cid in child_ids:
-        child_rec = snowflake_client.get_records(cid, missing_ok=True)
-        assert child_rec is None
+    child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
+    assert all(x is None for x in child_recs)
 
     # DB should be pretty empty now
     query_res = snowflake_client.query_records()

--- a/qcfractal/qcfractal/components/reaction/test_record_client.py
+++ b/qcfractal/qcfractal/components/reaction/test_record_client.py
@@ -77,6 +77,9 @@ def test_reaction_client_add_get(
         assert r.record_type == "reaction"
         assert compare_reaction_specs(spec, r.specification)
 
+        assert r.status == RecordStatusEnum.waiting
+        assert r.children_status == {}
+
         assert r.service.tag == "tag1"
         assert r.service.priority == PriorityEnum.low
 
@@ -205,6 +208,8 @@ def test_reaction_client_delete(snowflake: QCATestingSnowflake):
 
     child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
     assert all(x.status == RecordStatusEnum.complete for x in child_recs)
+    rxn_rec = snowflake_client.get_records(rxn_id)
+    assert rxn_rec.children_status == {RecordStatusEnum.complete: len(child_ids)}
 
     snowflake_client.undelete_records(rxn_id)
 
@@ -215,6 +220,8 @@ def test_reaction_client_delete(snowflake: QCATestingSnowflake):
 
     child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
     assert all(x.status == RecordStatusEnum.deleted for x in child_recs)
+    rxn_rec = snowflake_client.get_records(rxn_id)
+    assert rxn_rec.children_status == {RecordStatusEnum.deleted: len(child_ids)}
 
     meta = snowflake_client.delete_records(rxn_id, soft_delete=False, delete_children=True)
     assert meta.success

--- a/qcfractal/qcfractal/components/record_routes.py
+++ b/qcfractal/qcfractal/components/record_routes.py
@@ -197,3 +197,10 @@ def get_record_native_file_single_v1(record_id: int, name: str, record_type: Opt
 def get_record_native_file_data_v1(record_id: int, name: str, record_type: Optional[str] = None):
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_single_native_file_rawdata(record_id, name)
+
+
+@api_v1.route("/records/<string:record_type>/<int:record_id>/children_status", methods=["GET"])
+@wrap_route("READ")
+def get_record_children_status_v1(record_id: int, record_type: Optional[str] = None):
+    record_socket = storage_socket.records.get_socket(record_type)
+    return record_socket.get_children_status(record_id)

--- a/qcfractal/qcfractal/components/services/test_socket.py
+++ b/qcfractal/qcfractal/components/services/test_socket.py
@@ -43,6 +43,9 @@ def test_service_socket_error(storage_socket: SQLAlchemySocket, session: Session
     rec = session.get(BaseRecordORM, id_1)
 
     assert rec.status == RecordStatusEnum.error
+
+    child_stat = storage_socket.records.torsiondrive.get_children_status(id_1, session=session)
+    assert child_stat[RecordStatusEnum.error] == 1
     assert len(rec.compute_history) == 1
     assert len(rec.compute_history[-1].outputs) == 2  # stdout and error
     assert rec.compute_history[-1].status == RecordStatusEnum.error

--- a/qcfractal/qcfractal/components/singlepoint/test_record_client.py
+++ b/qcfractal/qcfractal/components/singlepoint/test_record_client.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 import pytest
 
 from qcarchivetesting import load_molecule_data
-from qcportal.record_models import PriorityEnum
+from qcportal.record_models import PriorityEnum, RecordStatusEnum
 from qcportal.singlepoint import QCSpecification, SinglepointDriver
 from .testing_helpers import submit_test_data, run_test_data, compare_singlepoint_specs, test_specs
 
@@ -67,6 +67,10 @@ def test_singlepoint_client_add_get(submitter_client: PortalClient, spec: QCSpec
         assert r.record_type == "singlepoint"
         assert r.record_type == "singlepoint"
         assert compare_singlepoint_specs(spec, r.specification)
+
+        assert r.status == RecordStatusEnum.waiting
+        assert r.children_status == {}
+
         assert r.task.function is None
         assert r.task.tag == "tag1"
         assert r.task.priority == PriorityEnum.high

--- a/qcfractal/qcfractal/components/torsiondrive/test_record_client.py
+++ b/qcfractal/qcfractal/components/torsiondrive/test_record_client.py
@@ -77,6 +77,9 @@ def test_torsiondrive_client_add_get(
         assert r.record_type == "torsiondrive"
         assert compare_torsiondrive_specs(spec, r.specification)
 
+        assert r.status == RecordStatusEnum.waiting
+        assert r.children_status == {}
+
         assert r.service.tag == "tag1"
         assert r.service.priority == PriorityEnum.low
 
@@ -195,6 +198,8 @@ def test_torsiondrive_client_delete(snowflake: QCATestingSnowflake):
 
     child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
     assert all(x.status == RecordStatusEnum.complete for x in child_recs)
+    td_rec = snowflake_client.get_records(td_id)
+    assert td_rec.children_status == {RecordStatusEnum.complete: len(child_ids)}
 
     snowflake_client.undelete_records(td_id)
 
@@ -205,6 +210,8 @@ def test_torsiondrive_client_delete(snowflake: QCATestingSnowflake):
 
     child_recs = snowflake_client.get_records(child_ids, missing_ok=True)
     assert all(x.status == RecordStatusEnum.deleted for x in child_recs)
+    td_rec = snowflake_client.get_records(td_id)
+    assert td_rec.children_status == {RecordStatusEnum.deleted: len(child_ids)}
 
     meta = snowflake_client.delete_records(td_id, soft_delete=False, delete_children=True)
     assert meta.success

--- a/qcfractal/qcfractal/components/torsiondrive/testing_helpers.py
+++ b/qcfractal/qcfractal/components/torsiondrive/testing_helpers.py
@@ -154,7 +154,7 @@ def run_test_data(
     assert finished
 
     with storage_socket.session_scope() as session:
-        record = storage_socket.records.get([record_id])[0]
-        assert record["status"] == end_status
+        record = session.get(TorsiondriveRecordORM, record_id)
+        assert record.status == end_status
 
     return record_id

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -526,6 +526,17 @@ class BaseRecord(BaseModel):
         return self._client is None
 
     @property
+    def children_status(self) -> Dict[RecordStatusEnum, int]:
+        """Returns a dicionary of the status of all children of this record"""
+        self._assert_online()
+
+        return self._client.make_request(
+            "get",
+            f"{self._base_url}/children_status",
+            Dict[RecordStatusEnum, int],
+        )
+
+    @property
     def compute_history(self) -> List[ComputeHistory]:
         if self.compute_history_ is None:
             self._fetch_compute_history()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This adds the ability to get the status counts of 'child' records (for example, optimizations as part of a torsiondrive or gridoptimization service). See Issue #791 

It should be noted that most services generate records as needed, so the status that is returned is not indicative of progress (ie, if there is only one record remaining to be run, it is not guaranteed that that is the last remaining calculation to be run - others may be generated after that is completed).

Status can be obtained with the `record.children_status` property. This is available on all record types, although Singlepoint records will always return an empty dictionary.

## Changelog description
Add ability to get status overview of child records

## Status
- [X] Code base linted
- [x] Ready to go
