### PR TITLE
Rework dataset model internals a bit

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,7 +12,7 @@ Notable pull requests and features:
 - (:pr:`781`) Fixes issues related to shutdown of snowflakes, particularly with Python 3.12
 - (:pr:`783`, :pr:`793`) Fixes JWT refresh issues that cause errors in clients
 - (:pr:`785`) Some cleanups related to Python 3.12 (including removing use of removing `pkg_resources` module)
-- (:pr:`787`) Pydantic v1/v2 dual compatibility (L. Naden :contrib:`lnaden`, M. Thompson `mattwthompson`, L. Burns `loriab`)
+- (:pr:`787`) Pydantic v1/v2 dual compatibility (L. Naden :contrib:`lnaden`, M. Thompson :contrib:`mattwthompson`, L. Burns :contrib:`loriab`)
 - (:pr:`792`) Add ability to get status overview of child records (such as optimizations of a torsiondrive)
 - (:pr:`794`) Remove use of now-deprecated `utctime` function and improve handling of timezones
 

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -329,7 +329,7 @@ class BaseDataset(BaseModel):
 
     def assert_online(self):
         if self.offline:
-            raise RuntimeError("Dataset does not connected to a QCFractal server")
+            raise RuntimeError("Dataset is not connected to a QCFractal server")
 
     @property
     def record_count(self) -> int:

--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -95,10 +95,10 @@ def run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_spec
 
     # Were removed from the model
     for name in [entry_name_1, entry_name_2]:
-        assert len(ds.record_map_) == 1
-        assert name not in ds.entries_
+        assert len(ds._record_map) == 1
+        assert name not in ds._entries
         assert name not in ds.entry_names
-        assert all(name != x for x, _ in ds.record_map_.keys())
+        assert all(name != x for x, _ in ds._record_map.keys())
         assert all(name != ent_name for ent_name, _, _ in ds.iterate_records())
 
     # Delete when it doesn't exist
@@ -184,9 +184,9 @@ def run_dataset_model_delete_spec(snowflake_client, ds, test_entries, test_specs
 
     # Were removed from the model
     for name in ["spec_1", "spec_2"]:
-        assert len(ds.record_map_) == 0
+        assert len(ds._record_map) == 0
         assert name not in ds.specifications
-        assert all(name != x for _, x in ds.record_map_.keys())
+        assert all(name != x for _, x in ds._record_map.keys())
         assert all(name != spec_name for _, spec_name, _ in ds.iterate_records())
 
     # Delete when it doesn't exist

--- a/qcportal/qcportal/gridoptimization/dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/dataset_models.py
@@ -56,9 +56,9 @@ class GridoptimizationDataset(BaseDataset):
     ########################################
     # Caches of information
     ########################################
-    specifications_: Dict[str, GridoptimizationDatasetSpecification] = {}
-    entries_: Dict[str, GridoptimizationDatasetEntry] = {}
-    record_map_: Dict[Tuple[str, str], GridoptimizationRecord] = {}
+    _specifications: Dict[str, GridoptimizationDatasetSpecification]
+    _entries: Dict[str, GridoptimizationDatasetEntry]
+    _record_map: Dict[Tuple[str, str], GridoptimizationRecord]
 
     # Needed by the base class
     _entry_type = GridoptimizationDatasetEntry

--- a/qcportal/qcportal/manybody/dataset_models.py
+++ b/qcportal/qcportal/manybody/dataset_models.py
@@ -49,9 +49,9 @@ class ManybodyDataset(BaseDataset):
     ########################################
     # Caches of information
     ########################################
-    specifications_: Dict[str, ManybodyDatasetSpecification] = {}
-    entries_: Dict[str, ManybodyDatasetEntry] = {}
-    record_map_: Dict[Tuple[str, str], ManybodyRecord] = {}
+    _specifications: Dict[str, ManybodyDatasetSpecification]
+    _entries: Dict[str, ManybodyDatasetEntry]
+    _record_map: Dict[Tuple[str, str], ManybodyRecord]
 
     # Needed by the base class
     _entry_type = ManybodyDatasetEntry

--- a/qcportal/qcportal/neb/dataset_models.py
+++ b/qcportal/qcportal/neb/dataset_models.py
@@ -54,9 +54,9 @@ class NEBDatasetRecordItem(BaseModel):
 class NEBDataset(BaseDataset):
     dataset_type: Literal["neb"] = "neb"
 
-    specifications_: Dict[str, NEBDatasetSpecification] = {}
-    entries_: Dict[str, NEBDatasetEntry] = {}
-    record_map_: Dict[Tuple[str, str], NEBRecord] = {}
+    _specifications: Dict[str, NEBDatasetSpecification]
+    _entries: Dict[str, NEBDatasetEntry]
+    _record_map: Dict[Tuple[str, str], NEBRecord]
 
     # Needed by the base class
     _entry_type = NEBDatasetEntry

--- a/qcportal/qcportal/optimization/dataset_models.py
+++ b/qcportal/qcportal/optimization/dataset_models.py
@@ -52,9 +52,9 @@ class OptimizationDataset(BaseDataset):
     ########################################
     # Caches of information
     ########################################
-    specifications_: Dict[str, OptimizationDatasetSpecification] = {}
-    entries_: Dict[str, OptimizationDatasetEntry] = {}
-    record_map_: Dict[Tuple[str, str], OptimizationRecord] = {}
+    _specifications: Dict[str, OptimizationDatasetSpecification]
+    _entries: Dict[str, OptimizationDatasetEntry]
+    _record_map: Dict[Tuple[str, str], OptimizationRecord]
 
     # Needed by the base class
     _entry_type = OptimizationDatasetEntry

--- a/qcportal/qcportal/reaction/dataset_models.py
+++ b/qcportal/qcportal/reaction/dataset_models.py
@@ -60,9 +60,9 @@ class ReactionDataset(BaseDataset):
     ########################################
     # Caches of information
     ########################################
-    specifications_: Dict[str, ReactionDatasetSpecification] = {}
-    entries_: Dict[str, ReactionDatasetEntry] = {}
-    record_map_: Dict[Tuple[str, str], ReactionRecord] = {}
+    _specifications: Dict[str, ReactionDatasetSpecification]
+    _entries: Dict[str, ReactionDatasetEntry]
+    _record_map: Dict[Tuple[str, str], ReactionRecord]
 
     # Needed by the base class
     _entry_type = ReactionDatasetEntry

--- a/qcportal/qcportal/singlepoint/dataset_models.py
+++ b/qcportal/qcportal/singlepoint/dataset_models.py
@@ -56,9 +56,9 @@ class SinglepointDataset(BaseDataset):
     ########################################
     # Caches of information
     ########################################
-    specifications_: Dict[str, SinglepointDatasetSpecification] = {}
-    entries_: Dict[str, SinglepointDatasetEntry] = {}
-    record_map_: Dict[Tuple[str, str], SinglepointRecord] = {}
+    _specifications: Dict[str, SinglepointDatasetSpecification]
+    _entries: Dict[str, SinglepointDatasetEntry]
+    _record_map: Dict[Tuple[str, str], SinglepointRecord]
 
     # Needed by the base class
     _entry_type = SinglepointDatasetEntry

--- a/qcportal/qcportal/torsiondrive/dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/dataset_models.py
@@ -55,9 +55,9 @@ class TorsiondriveDataset(BaseDataset):
     ########################################
     # Caches of information
     ########################################
-    specifications_: Dict[str, TorsiondriveDatasetSpecification] = {}
-    entries_: Dict[str, TorsiondriveDatasetEntry] = {}
-    record_map_: Dict[Tuple[str, str], TorsiondriveRecord] = {}
+    _specifications: Dict[str, TorsiondriveDatasetSpecification]
+    _entries: Dict[str, TorsiondriveDatasetEntry]
+    _record_map: Dict[Tuple[str, str], TorsiondriveRecord]
 
     # Needed by the base class
     _entry_type = TorsiondriveDatasetEntry


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This changes the internals of dataset models to use `PrivateAttr` for its caches. This is part of the move to file-based caches in the future, but helpful to do separately to avoid painful merge conflicts in the future.

Also fixes dumb formatting issues in the release notes.

## Changelog description
N/A

## Status
- [X] Code base linted
- [X] Ready to go
