### PR TITLE
Cleanup some ORM stuff - better exclude handling

### DIFF
--- a/qcfractal/qcfractal/components/auth/db_models.py
+++ b/qcfractal/qcfractal/components/auth/db_models.py
@@ -51,10 +51,7 @@ class RoleORM(BaseORM):
 
     __table_args__ = (UniqueConstraint("rolename", name="ux_role_rolename"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id"]
 
 
 class UserORM(BaseORM):
@@ -82,9 +79,9 @@ class UserORM(BaseORM):
 
     __table_args__ = (UniqueConstraint("username", name="ux_user_username"),)
 
+    _qcportal_model_excludes = ["role_orm", "groups_orm", "role_id", "password"]
+
     def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Removes some sensitive or useless fields
-        exclude = self.append_exclude(exclude, "role_orm", "groups_orm", "role_id", "password")
         d = BaseORM.model_dict(self, exclude)
 
         d["role"] = self.role_orm.rolename

--- a/qcfractal/qcfractal/components/dataset_db_models.py
+++ b/qcfractal/qcfractal/components/dataset_db_models.py
@@ -91,11 +91,9 @@ class BaseDatasetORM(BaseORM):
 
     __mapper_args__ = {"polymorphic_on": "dataset_type"}
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # lname is only for the server
-        # strip user/group ids
-        exclude = self.append_exclude(exclude, "lname", "owner_user_id", "owner_group_id")
+    _qcportal_model_excludes = ["lname", "owner_user_id", "owner_group_id"]
 
+    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         d = BaseORM.model_dict(self, exclude)
 
         # meta -> metadata
@@ -130,6 +128,4 @@ class ContributedValuesORM(BaseORM):
 
     __table_args__ = (Index("ix_contributed_values_dataset_id", "dataset_id"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]

--- a/qcfractal/qcfractal/components/gridoptimization/dataset_db_models.py
+++ b/qcfractal/qcfractal/components/gridoptimization/dataset_db_models.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, UniqueConstraint, Index
+from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
@@ -13,9 +11,6 @@ from qcfractal.components.gridoptimization.record_db_models import (
 )
 from qcfractal.components.molecules.db_models import MoleculeORM
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class GridoptimizationDatasetEntryORM(BaseORM):
@@ -39,10 +34,7 @@ class GridoptimizationDatasetEntryORM(BaseORM):
         Index("ix_gridoptimization_dataset_entry_initial_molecule_id", "initial_molecule_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "initial_molecule_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "initial_molecule_id"]
 
 
 class GridoptimizationDatasetSpecificationORM(BaseORM):
@@ -61,10 +53,7 @@ class GridoptimizationDatasetSpecificationORM(BaseORM):
         Index("ix_gridoptimization_dataset_specification_specification_id", "specification_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "specification_id"]
 
 
 class GridoptimizationDatasetRecordItemORM(BaseORM):
@@ -93,10 +82,7 @@ class GridoptimizationDatasetRecordItemORM(BaseORM):
         Index("ix_gridoptimization_dataset_record_record_id", "record_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class GridoptimizationDatasetORM(BaseDatasetORM):

--- a/qcfractal/qcfractal/components/gridoptimization/record_db_models.py
+++ b/qcfractal/qcfractal/components/gridoptimization/record_db_models.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import (
     select,
     UniqueConstraint,
@@ -26,9 +24,6 @@ from qcfractal.components.optimization.record_db_models import (
 from qcfractal.components.record_db_models import BaseRecordORM
 from qcfractal.db_socket import BaseORM
 
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
-
 
 class GridoptimizationOptimizationORM(BaseORM):
     """
@@ -51,10 +46,7 @@ class GridoptimizationOptimizationORM(BaseORM):
 
     __table_args__ = (Index("ix_gridoptimization_optimization_id", "optimization_id"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "gridoptimization_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["gridoptimization_id"]
 
 
 class GridoptimizationSpecificationORM(BaseORM):
@@ -89,10 +81,7 @@ class GridoptimizationSpecificationORM(BaseORM):
         CheckConstraint("program = LOWER(program)", name="ck_gridoptimization_specification_program_lower"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id", "keywords_hash", "optimization_specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id", "keywords_hash", "optimization_specification_id"]
 
     @property
     def short_description(self) -> str:
@@ -125,10 +114,7 @@ class GridoptimizationRecordORM(BaseRecordORM):
         "polymorphic_identity": "gridoptimization",
     }
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "specification_id")
-        return BaseRecordORM.model_dict(self, exclude)
+    _qcportal_model_excludes = [*BaseRecordORM._qcportal_model_excludes, "specification_id"]
 
     @property
     def short_description(self) -> str:

--- a/qcfractal/qcfractal/components/internal_jobs/db_models.py
+++ b/qcfractal/qcfractal/components/internal_jobs/db_models.py
@@ -62,9 +62,9 @@ class InternalJobORM(BaseORM):
         UniqueConstraint("unique_name", name="ux_internal_jobs_unique_name"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        exclude = self.append_exclude(exclude, "unique_name", "user_id")
+    _qcportal_model_excludes = ["unique_name", "user_id"]
 
+    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         d = BaseORM.model_dict(self, exclude)
         d["user"] = self.user.username if self.user is not None else None
         return d

--- a/qcfractal/qcfractal/components/manybody/dataset_db_models.py
+++ b/qcfractal/qcfractal/components/manybody/dataset_db_models.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, UniqueConstraint, Index
+from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
@@ -10,9 +8,6 @@ from qcfractal.components.dataset_db_models import BaseDatasetORM
 from qcfractal.components.manybody.record_db_models import ManybodySpecificationORM, ManybodyRecordORM
 from qcfractal.components.molecules.db_models import MoleculeORM
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class ManybodyDatasetEntryORM(BaseORM):
@@ -35,10 +30,7 @@ class ManybodyDatasetEntryORM(BaseORM):
         Index("ix_manybody_dataset_entry_initial_molecule_id", "initial_molecule_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "initial_molecule_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "initial_molecule_id"]
 
 
 class ManybodyDatasetSpecificationORM(BaseORM):
@@ -57,10 +49,7 @@ class ManybodyDatasetSpecificationORM(BaseORM):
         Index("ix_manybody_dataset_specification_specification_id", "specification_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "specification_id"]
 
 
 class ManybodyDatasetRecordItemORM(BaseORM):
@@ -89,10 +78,7 @@ class ManybodyDatasetRecordItemORM(BaseORM):
         Index("ix_manybody_dataset_record_record_id", "record_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class ManybodyDatasetORM(BaseDatasetORM):

--- a/qcfractal/qcfractal/components/manybody/record_db_models.py
+++ b/qcfractal/qcfractal/components/manybody/record_db_models.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import Column, String, Integer, ForeignKey, UniqueConstraint, Index, CheckConstraint, event, DDL
 from sqlalchemy.dialects.postgresql import JSONB, ARRAY
 from sqlalchemy.orm import relationship
@@ -10,9 +8,6 @@ from qcfractal.components.molecules.db_models import MoleculeORM
 from qcfractal.components.record_db_models import BaseRecordORM
 from qcfractal.components.singlepoint.record_db_models import SinglepointRecordORM, QCSpecificationORM
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class ManybodyClusterORM(BaseORM):
@@ -41,10 +36,7 @@ class ManybodyClusterORM(BaseORM):
         Index("ix_manybody_cluster_singlepoint_id", "singlepoint_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "manybody_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["manybody_id"]
 
 
 class ManybodySpecificationORM(BaseORM):
@@ -75,10 +67,7 @@ class ManybodySpecificationORM(BaseORM):
         CheckConstraint("program = LOWER(program)", name="ck_manybody_specification_program_lower"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id", "keywords_hash", "singlepoint_specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id", "keywords_hash", "singlepoint_specification_id"]
 
     @property
     def short_description(self) -> str:
@@ -107,10 +96,7 @@ class ManybodyRecordORM(BaseRecordORM):
         "polymorphic_identity": "manybody",
     }
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "specification_id")
-        return BaseRecordORM.model_dict(self, exclude)
+    _qcportal_model_excludes = [*BaseRecordORM._qcportal_model_excludes, "specification_id"]
 
     @property
     def short_description(self) -> str:

--- a/qcfractal/qcfractal/components/molecules/db_models.py
+++ b/qcfractal/qcfractal/components/molecules/db_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, Integer, String, JSON, Float, Index, CHAR, Boolean, UniqueConstraint
+from sqlalchemy import Column, Integer, String, JSON, Float, Index, CHAR, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import column_property
 
@@ -69,10 +69,9 @@ class MoleculeORM(BaseORM):
         UniqueConstraint("molecule_hash", name="ux_molecule_molecule_hash"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # molecule_hash is only used for indexing. It is otherwise stored in identifiers
-        exclude = self.append_exclude(exclude, "molecule_hash")
+    _qcportal_model_excludes = ["molecule_hash"]
 
+    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         d = BaseORM.model_dict(self, exclude)
 
         # TODO - this is because the pydantic models are goofy

--- a/qcfractal/qcfractal/components/molecules/socket.py
+++ b/qcfractal/qcfractal/components/molecules/socket.py
@@ -61,9 +61,6 @@ class MoleculeSocket:
         mol_dict["identifiers"]["molecule_hash"] = mol_dict["molecule_hash"]
         mol_dict["identifiers"]["molecular_formula"] = molecule.get_molecular_formula()
 
-        mol_dict["fix_com"] = True
-        mol_dict["fix_orientation"] = True
-
         return MoleculeORM(**mol_dict)
 
     def add(

--- a/qcfractal/qcfractal/components/neb/dataset_db_models.py
+++ b/qcfractal/qcfractal/components/neb/dataset_db_models.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, UniqueConstraint, Index
+from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
@@ -10,9 +8,6 @@ from qcfractal.components.dataset_db_models import BaseDatasetORM
 from qcfractal.components.molecules.db_models import MoleculeORM
 from qcfractal.components.neb.record_db_models import NEBRecordORM, NEBSpecificationORM
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class NEBDatasetInitialMoleculeORM(BaseORM):
@@ -41,10 +36,7 @@ class NEBDatasetInitialMoleculeORM(BaseORM):
         ),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "molecule_id", "entry_name", "position")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "molecule_id", "entry_name", "position"]
 
 
 class NEBDatasetEntryORM(BaseORM):
@@ -81,10 +73,7 @@ class NEBDatasetEntryORM(BaseORM):
         Index("ix_neb_dataset_entry_name", "name"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class NEBDatasetSpecificationORM(BaseORM):
@@ -103,10 +92,7 @@ class NEBDatasetSpecificationORM(BaseORM):
         Index("ix_neb_dataset_specification_specification_id", "specification_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "specification_id"]
 
 
 class NEBDatasetRecordItemORM(BaseORM):
@@ -135,10 +121,7 @@ class NEBDatasetRecordItemORM(BaseORM):
         Index("ix_neb_dataset_record_record_id", "record_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class NEBDatasetORM(BaseDatasetORM):

--- a/qcfractal/qcfractal/components/neb/record_db_models.py
+++ b/qcfractal/qcfractal/components/neb/record_db_models.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Iterable, Any
-
 from sqlalchemy import Column, Integer, ForeignKey, String, UniqueConstraint, Index, Boolean, event, DDL
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.orderinglist import ordering_list
@@ -25,9 +23,7 @@ class NEBOptimizationsORM(BaseORM):
 
     __table_args__ = (Index("ix_neb_optimizations_optimization_id", "optimization_id"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        exclude = self.append_exclude(exclude, "neb_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["neb_id"]
 
 
 class NEBSinglepointsORM(BaseORM):
@@ -41,9 +37,7 @@ class NEBSinglepointsORM(BaseORM):
 
     __table_args__ = (Index("ix_neb_singlepoints_singlepoint_id", "singlepoint_id"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        exclude = self.append_exclude(exclude, "neb_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["neb_id"]
 
 
 class NEBInitialchainORM(BaseORM):
@@ -55,9 +49,7 @@ class NEBInitialchainORM(BaseORM):
 
     molecule = relationship(MoleculeORM)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        exclude = self.append_exclude(exclude, "neb_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["neb_id"]
 
 
 class NEBSpecificationORM(BaseORM):
@@ -94,11 +86,7 @@ class NEBSpecificationORM(BaseORM):
         # Enforce lowercase on some fields
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        exclude = self.append_exclude(
-            exclude, "id", "keywords_hash", "singlepoint_specification_id", "optimization_specification_id"
-        )
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id", "keywords_hash", "singlepoint_specification_id", "optimization_specification_id"]
 
     @property
     def short_description(self) -> str:
@@ -141,9 +129,7 @@ class NEBRecordORM(BaseRecordORM):
         "polymorphic_identity": "neb",
     }
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        exclude = self.append_exclude(exclude, "specification_id")
-        return BaseRecordORM.model_dict(self, exclude)
+    _qcportal_model_excludes = [*BaseRecordORM._qcportal_model_excludes, "specification_id"]
 
     @property
     def short_description(self) -> str:

--- a/qcfractal/qcfractal/components/optimization/dataset_db_models.py
+++ b/qcfractal/qcfractal/components/optimization/dataset_db_models.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, UniqueConstraint, Index
+from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
@@ -13,9 +11,6 @@ from qcfractal.components.optimization.record_db_models import (
     OptimizationRecordORM,
 )
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class OptimizationDatasetEntryORM(BaseORM):
@@ -38,10 +33,7 @@ class OptimizationDatasetEntryORM(BaseORM):
         Index("ix_optimization_dataset_entry_initial_molecule_id", "initial_molecule_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "initial_molecule_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "initial_molecule_id"]
 
 
 class OptimizationDatasetSpecificationORM(BaseORM):
@@ -60,10 +52,7 @@ class OptimizationDatasetSpecificationORM(BaseORM):
         Index("ix_optimization_dataset_specification_specification_id", "specification_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "specification_id"]
 
 
 class OptimizationDatasetRecordItemORM(BaseORM):
@@ -92,10 +81,7 @@ class OptimizationDatasetRecordItemORM(BaseORM):
         Index("ix_optimization_dataset_record_record_id", "record_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class OptimizationDatasetORM(BaseDatasetORM):

--- a/qcfractal/qcfractal/components/outputstore/db_models.py
+++ b/qcfractal/qcfractal/components/outputstore/db_models.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import event, DDL
 
 from qcfractal.components.record_db_models import OutputStoreORM
-
-if TYPE_CHECKING:
-    pass
 
 # Mark the storage of the data column as external
 event.listen(

--- a/qcfractal/qcfractal/components/reaction/dataset_db_models.py
+++ b/qcfractal/qcfractal/components/reaction/dataset_db_models.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, UniqueConstraint, Index
+from sqlalchemy import Column, Integer, ForeignKey, String, ForeignKeyConstraint, Index
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, JSONB
 from sqlalchemy.orm import relationship
 
@@ -10,9 +8,6 @@ from qcfractal.components.dataset_db_models import BaseDatasetORM
 from qcfractal.components.molecules.db_models import MoleculeORM
 from qcfractal.components.reaction.record_db_models import ReactionRecordORM, ReactionSpecificationORM
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class ReactionDatasetStoichiometryORM(BaseORM):
@@ -38,10 +33,7 @@ class ReactionDatasetStoichiometryORM(BaseORM):
         ),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "molecule_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "molecule_id"]
 
 
 class ReactionDatasetEntryORM(BaseORM):
@@ -64,10 +56,7 @@ class ReactionDatasetEntryORM(BaseORM):
         Index("ix_reaction_dataset_entry_name", "name"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class ReactionDatasetSpecificationORM(BaseORM):
@@ -86,10 +75,7 @@ class ReactionDatasetSpecificationORM(BaseORM):
         Index("ix_reaction_dataset_specification_specification_id", "specification_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "specification_id"]
 
 
 class ReactionDatasetRecordItemORM(BaseORM):
@@ -118,10 +104,7 @@ class ReactionDatasetRecordItemORM(BaseORM):
         Index("ix_reaction_dataset_record_record_id", "record_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class ReactionDatasetORM(BaseDatasetORM):

--- a/qcfractal/qcfractal/components/reaction/record_db_models.py
+++ b/qcfractal/qcfractal/components/reaction/record_db_models.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import Column, String, Integer, ForeignKey, CheckConstraint, Index, UniqueConstraint, event, DDL
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, JSONB
 from sqlalchemy.orm import relationship
@@ -14,9 +12,6 @@ from qcfractal.components.optimization.record_db_models import (
 from qcfractal.components.record_db_models import BaseRecordORM
 from qcfractal.components.singlepoint.record_db_models import SinglepointRecordORM, QCSpecificationORM
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class ReactionComponentORM(BaseORM):
@@ -42,10 +37,7 @@ class ReactionComponentORM(BaseORM):
         Index("ix_reaction_component_optimization_id", "optimization_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "reaction_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["reaction_id"]
 
 
 class ReactionSpecificationORM(BaseORM):
@@ -84,12 +76,7 @@ class ReactionSpecificationORM(BaseORM):
         ),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(
-            exclude, "id", "keywords_hash", "singlepoint_specification_id", "optimization_specification_id"
-        )
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id", "keywords_hash", "singlepoint_specification_id", "optimization_specification_id"]
 
     @property
     def short_description(self) -> str:
@@ -126,10 +113,7 @@ class ReactionRecordORM(BaseRecordORM):
         "polymorphic_identity": "reaction",
     }
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "specification_id")
-        return BaseRecordORM.model_dict(self, exclude)
+    _qcportal_model_excludes = [*BaseRecordORM._qcportal_model_excludes, "specification_id"]
 
     @property
     def short_description(self) -> str:

--- a/qcfractal/qcfractal/components/record_db_models.py
+++ b/qcfractal/qcfractal/components/record_db_models.py
@@ -55,10 +55,11 @@ class RecordCommentORM(BaseORM):
 
     __table_args__ = (Index("ix_record_comment_record_id", "record_id"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        exclude = self.append_exclude(exclude, "user_id", "user")
+    _qcportal_model_excludes = ["user_id", "user"]
 
+    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         d = BaseORM.model_dict(self, exclude)
+
         d["username"] = self.user.username if self.user is not None else None
         return d
 
@@ -82,10 +83,7 @@ class RecordInfoBackupORM(BaseORM):
 
     __table_args__ = (Index("ix_record_info_backup_record_id", "record_id"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id", "record_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id", "record_id"]
 
 
 class OutputStoreORM(BaseORM):
@@ -105,14 +103,11 @@ class OutputStoreORM(BaseORM):
 
     __table_args__ = (UniqueConstraint("history_id", "output_type", name="ux_output_store_id_type"),)
 
+    _qcportal_model_excludes = ["id", "history_id", "compression_level"]
+
     def get_output(self) -> Any:
         return decompress(self.data, self.compression_type)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Fields not in model
-        exclude = self.append_exclude(exclude, "id", "history_id", "compression_level")
-
-        return BaseORM.model_dict(self, exclude)
 
 
 # Mark the storage of the data column as external
@@ -140,13 +135,10 @@ class NativeFileORM(BaseORM):
 
     __table_args__ = (UniqueConstraint("record_id", "name", name="ux_native_file_record_id_name"),)
 
+    _qcportal_model_excludes = ["id", "history_id", "compression_level"]
+
     def get_file(self) -> Any:
         return decompress(self.data, self.compression_type)
-
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id", "record_id", "compression_level")
-        return BaseORM.model_dict(self, exclude)
 
 
 # Mark the storage of the data column of native files as external
@@ -290,11 +282,11 @@ class BaseRecordORM(BaseORM):
 
     __mapper_args__ = {"polymorphic_on": "record_type"}
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # strip user/group ids
-        # info_backup is also never part of models
-        exclude = self.append_exclude(exclude, "owner_user_id", "owner_group_id", "info_backup")
+    # strip user/group ids
+    # info_backup is also never part of models
+    _qcportal_model_excludes = ["owner_user_id", "owner_group_id", "info_backup"]
 
+    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         d = BaseORM.model_dict(self, exclude)
 
         d["owner_user"] = self.owner_user.username if self.owner_user is not None else None

--- a/qcfractal/qcfractal/components/serverinfo/db_models.py
+++ b/qcfractal/qcfractal/components/serverinfo/db_models.py
@@ -62,10 +62,9 @@ class AccessLogORM(BaseORM):
         Index("ix_access_log_user_id", "user_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # strip user/group ids
-        exclude = self.append_exclude(exclude, "user_id")
+    _qcportal_model_excludes = ["user_id"]
 
+    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         d = BaseORM.model_dict(self, exclude)
         d["user"] = self.user.username if self.user is not None else None
         return d
@@ -103,10 +102,9 @@ class InternalErrorLogORM(BaseORM):
         Index("ix_internal_error_log_user_id", "user_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # strip user/group ids
-        exclude = self.append_exclude(exclude, "user_id")
+    _qcportal_model_excludes = ["user_id"]
 
+    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         d = BaseORM.model_dict(self, exclude)
         d["user"] = self.user.username if self.user is not None else None
         return d

--- a/qcfractal/qcfractal/components/serverinfo/test_access_socket.py
+++ b/qcfractal/qcfractal/components/serverinfo/test_access_socket.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -10,9 +9,6 @@ from qcarchivetesting.testing_classes import QCATestingSnowflake
 from qcfractal.testing_helpers import DummyJobProgress
 from qcportal.serverinfo.models import AccessLogQueryFilters
 from qcportal.utils import now_at_utc
-
-if TYPE_CHECKING:
-    pass
 
 # First part of the tuple is the ip address
 # second is the range, as stored in the MaxMind test JSON file

--- a/qcfractal/qcfractal/components/services/db_models.py
+++ b/qcfractal/qcfractal/components/services/db_models.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional, Iterable, Dict, Any
-
 from sqlalchemy import (
     Column,
     Integer,
@@ -42,10 +40,7 @@ class ServiceDependencyORM(BaseORM):
     # submitted but with different extras (position, etc)
     __table_args__ = (UniqueConstraint("service_id", "record_id", "extras", name="ux_service_dependency"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id", "service_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id", "service_id"]
 
 
 class ServiceQueueORM(BaseORM):

--- a/qcfractal/qcfractal/components/singlepoint/dataset_db_models.py
+++ b/qcfractal/qcfractal/components/singlepoint/dataset_db_models.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from sqlalchemy import JSON, Column, Integer, ForeignKey, String, ForeignKeyConstraint, UniqueConstraint, Index
+from sqlalchemy import JSON, Column, Integer, ForeignKey, String, ForeignKeyConstraint, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
@@ -10,9 +8,6 @@ from qcfractal.components.dataset_db_models import BaseDatasetORM
 from qcfractal.components.molecules.db_models import MoleculeORM
 from qcfractal.components.singlepoint.record_db_models import QCSpecificationORM, SinglepointRecordORM
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class SinglepointDatasetEntryORM(BaseORM):
@@ -39,10 +34,7 @@ class SinglepointDatasetEntryORM(BaseORM):
         Index("ix_singlepoint_dataset_entry_molecule_id", "molecule_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "molecule_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "molecule_id"]
 
 
 class SinglepointDatasetSpecificationORM(BaseORM):
@@ -61,10 +53,7 @@ class SinglepointDatasetSpecificationORM(BaseORM):
         Index("ix_singlepoint_dataset_specification_specification_id", "specification_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "specification_id"]
 
 
 class SinglepointDatasetRecordItemORM(BaseORM):
@@ -93,10 +82,7 @@ class SinglepointDatasetRecordItemORM(BaseORM):
         Index("ix_singlepoint_dataset_record_record_id", "record_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class SinglepointDatasetORM(BaseDatasetORM):

--- a/qcfractal/qcfractal/components/singlepoint/record_db_models.py
+++ b/qcfractal/qcfractal/components/singlepoint/record_db_models.py
@@ -26,7 +26,7 @@ from qcportal.compression import CompressionEnum, decompress
 from qcportal.singlepoint import SinglepointDriver
 
 if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
+    from typing import Dict, Optional
 
 
 class WavefunctionORM(BaseORM):
@@ -45,14 +45,11 @@ class WavefunctionORM(BaseORM):
 
     __table_args__ = (UniqueConstraint("record_id", name="ux_wavefunction_store_record_id"),)
 
+    _qcportal_model_excludes = ["id", "record_id", "compression_level"]
+
     def get_wavefunction(self) -> WavefunctionProperties:
         d = decompress(self.data, self.compression_type)
         return WavefunctionProperties(**d)
-
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id", "record_id", "compression_level")
-        return BaseORM.model_dict(self, exclude)
 
 
 class QCSpecificationORM(BaseORM):
@@ -89,10 +86,7 @@ class QCSpecificationORM(BaseORM):
         CheckConstraint("basis = LOWER(basis)", name="ck_qc_specification_basis_lower"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id", "keywords_hash")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id", "keywords_hash"]
 
     @property
     def required_programs(self) -> Dict[str, Optional[str]]:
@@ -129,10 +123,7 @@ class SinglepointRecordORM(BaseRecordORM):
         "polymorphic_identity": "singlepoint",
     }
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "specification_id")
-        return BaseRecordORM.model_dict(self, exclude)
+    _qcportal_model_excludes = [*BaseRecordORM._qcportal_model_excludes, "specification_id"]
 
     @property
     def required_programs(self) -> Dict[str, Optional[str]]:

--- a/qcfractal/qcfractal/components/test_record_client.py
+++ b/qcfractal/qcfractal/components/test_record_client.py
@@ -3,8 +3,6 @@ Tests the general record socket
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 from qcarchivetesting import test_users
@@ -25,9 +23,6 @@ from qcportal import PortalRequestError
 from qcportal.molecules import Molecule
 from qcportal.record_models import PriorityEnum, RecordStatusEnum
 from qcportal.utils import now_at_utc
-
-if TYPE_CHECKING:
-    pass
 
 
 def test_record_client_get(snowflake: QCATestingSnowflake):

--- a/qcfractal/qcfractal/components/test_record_client_waiting_reason.py
+++ b/qcfractal/qcfractal/components/test_record_client_waiting_reason.py
@@ -4,7 +4,6 @@ Tests the tasks socket (claiming & returning data)
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
 
 from qcarchivetesting.testing_classes import QCATestingSnowflake
 from qcfractal.components.optimization.testing_helpers import load_test_data as load_opt_test_data
@@ -14,9 +13,6 @@ from qcfractal.components.singlepoint.testing_helpers import (
 from qcfractal.components.torsiondrive.testing_helpers import load_test_data as load_td_test_data
 from qcportal.managers import ManagerName
 from qcportal.record_models import PriorityEnum
-
-if TYPE_CHECKING:
-    pass
 
 
 def test_record_client_waiting_reason(snowflake: QCATestingSnowflake):

--- a/qcfractal/qcfractal/components/torsiondrive/dataset_db_models.py
+++ b/qcfractal/qcfractal/components/torsiondrive/dataset_db_models.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from sqlalchemy import select, Column, Integer, ForeignKey, String, ForeignKeyConstraint, UniqueConstraint, Index
+from sqlalchemy import select, Column, Integer, ForeignKey, String, ForeignKeyConstraint, Index
 from sqlalchemy.dialects.postgresql import JSONB, array_agg
 from sqlalchemy.orm import relationship, column_property
 
@@ -13,9 +11,6 @@ from qcfractal.components.torsiondrive.record_db_models import (
     TorsiondriveSpecificationORM,
 )
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class TorsiondriveDatasetMoleculeORM(BaseORM):
@@ -76,11 +71,7 @@ class TorsiondriveDatasetEntryORM(BaseORM):
         Index("ix_torsiondrive_dataset_entry_name", "name"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "initial_molecules_assoc")
-        assert "initial_molecule_ids" not in BaseORM.model_dict(self, exclude)
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "initial_molecules_assoc", "initial_molecules_id"]
 
 
 class TorsiondriveDatasetSpecificationORM(BaseORM):
@@ -99,10 +90,7 @@ class TorsiondriveDatasetSpecificationORM(BaseORM):
         Index("ix_torsiondrive_dataset_specification_specification_id", "specification_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id", "specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id", "specification_id"]
 
 
 class TorsiondriveDatasetRecordItemORM(BaseORM):
@@ -131,10 +119,7 @@ class TorsiondriveDatasetRecordItemORM(BaseORM):
         Index("ix_torsiondrive_dataset_record_record_id", "record_id"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "dataset_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["dataset_id"]
 
 
 class TorsiondriveDatasetORM(BaseDatasetORM):

--- a/qcfractal/qcfractal/components/torsiondrive/record_db_models.py
+++ b/qcfractal/qcfractal/components/torsiondrive/record_db_models.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import select, Column, Integer, ForeignKey, String, UniqueConstraint, Index, CheckConstraint, event, DDL
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.orderinglist import ordering_list
@@ -14,9 +12,6 @@ from qcfractal.components.optimization.record_db_models import (
 )
 from qcfractal.components.record_db_models import BaseRecordORM
 from qcfractal.db_socket import BaseORM
-
-if TYPE_CHECKING:
-    from typing import Dict, Any, Optional, Iterable
 
 
 class TorsiondriveOptimizationORM(BaseORM):
@@ -39,10 +34,7 @@ class TorsiondriveOptimizationORM(BaseORM):
 
     __table_args__ = (Index("ix_torsiondrive_optimization_id", "optimization_id"),)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "torsiondrive_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["torsiondrive_id"]
 
 
 class TorsiondriveInitialMoleculeORM(BaseORM):
@@ -57,10 +49,7 @@ class TorsiondriveInitialMoleculeORM(BaseORM):
 
     molecule = relationship(MoleculeORM)
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "torsiondrive_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["torsiondrive_id"]
 
 
 class TorsiondriveSpecificationORM(BaseORM):
@@ -95,10 +84,7 @@ class TorsiondriveSpecificationORM(BaseORM):
         CheckConstraint("program = LOWER(program)", name="ck_torsiondrive_specification_program_lower"),
     )
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "id", "keywords_hash", "optimization_specification_id")
-        return BaseORM.model_dict(self, exclude)
+    _qcportal_model_excludes = ["id", "keywords_hash", "optimization_specification_id"]
 
     @property
     def short_description(self) -> str:
@@ -131,10 +117,7 @@ class TorsiondriveRecordORM(BaseRecordORM):
         "polymorphic_identity": "torsiondrive",
     }
 
-    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
-        # Remove fields not present in the model
-        exclude = self.append_exclude(exclude, "specification_id")
-        return BaseRecordORM.model_dict(self, exclude)
+    _qcportal_model_excludes = [*BaseRecordORM._qcportal_model_excludes, "specification_id"]
 
     @property
     def short_description(self) -> str:

--- a/qcfractal/qcfractal/db_socket/base_orm.py
+++ b/qcfractal/qcfractal/db_socket/base_orm.py
@@ -68,7 +68,7 @@ class BaseORM:
 
     def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         """
-        Converts the ORM to a dictionary that corresponds to the QCPortal pydantic model or type
+        Converts the ORM to a dictionary that corresponds to the QCPortal pydantic model
 
         All columns are included by default, but some can be removed using the exclude parameter.
         """
@@ -76,6 +76,12 @@ class BaseORM:
         d = self.__dict__.copy()
         d.pop("_sa_instance_state")
 
+        # remove typical model excludes
+        if hasattr(self, "_qcportal_model_excludes"):
+            for k in self._qcportal_model_excludes:
+                d.pop(k, None)
+
+        # remove any manually specified excludes
         if exclude is not None:
             for k in exclude:
                 d.pop(k, None)

--- a/qcfractal/qcfractal/testing_helpers.py
+++ b/qcfractal/qcfractal/testing_helpers.py
@@ -27,7 +27,6 @@ class DummyJobProgress:
 
     def __init__(self):
         self._runner_uuid = "1234-5678-9101-1213"
-        pass
 
     def update_progress(self, progress: int):
         pass

--- a/qcfractalcompute/qcfractalcompute/executors.py
+++ b/qcfractalcompute/qcfractalcompute/executors.py
@@ -183,6 +183,5 @@ def build_executor(executor_label: str, executor_config: ExecutorConfig) -> Pars
             self.tag_executor_map[tag] = ex.label
 
         self.executor_config_map[ex.label] = executor_config
-        pass
     else:
         raise ValueError("Unknown executor type: {}".format(executor_config.type))

--- a/qcportal/qcportal/reaction/record_models.py
+++ b/qcportal/qcportal/reaction/record_models.py
@@ -23,8 +23,6 @@ class ReactionKeywords(BaseModel):
         pass
         # extra = Extra.forbid
 
-    pass
-
 
 class ReactionSpecification(BaseModel):
     class Config:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Cleans up some ORM code so that fields that are excluded from qcportal models is handled more declaratively.
Also cleans up some useless `pass` statements

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fields that exist in the database but are excluded from QCPortal models is now handled more declaratively

## Status
- [X] Code base linted
- [X] Ready to go
