### PR TITLE
Update "QCArchive in 15 minutes" tutorial to use `get_properties_df`

### DIFF
--- a/docs/source/quickstart/qca_15min.ipynb
+++ b/docs/source/quickstart/qca_15min.ipynb
@@ -205,7 +205,7 @@
     "Datasets are made up of many records of the same type of computation that can differ in molecule identity or other specification parameters.\n",
     "You can pull out iterate over records, see specifications, and compile values from records.\n",
     "\n",
-    "The cell below shows using the `compile_values` method to create a pandas dataframe containing the SCF total energy from each record."
+    "The cell below shows using the `get_properties_df` method to create a pandas dataframe containing the SCF total energy  and SCF iterations from each record."
    ]
   },
   {
@@ -215,10 +215,43 @@
    "outputs": [],
    "source": [
     "# use compile_values to make a dataframe\n",
-    "df = ds.compile_values(lambda record: record.properties['scf_total_energy'], \"scf_total_energy\")\n",
+    "df = ds.get_properties_df([\"scf_total_energy\", \"scf_iterations\"])\n",
     "\n",
     "# view the first 10 rows.\n",
     "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This dataframe is a multi-index dataframe with the top level index being the \"specification\" of our calculation.\n",
+    "For example, we can pull out just our results for `hf/sto-3g`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[\"hf/sto-3g\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`df[\"hf/sto-3g\"][\"scf_total_energy\"]` will give us the SCF total energy for all of the records in the dataset with the `hf/sto-3g` specification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[\"hf/sto-3g\"][\"scf_total_energy\"]"
    ]
   },
   {


### PR DESCRIPTION
## Description
This PR changes the function `compile_values` to the more user friendly `get_properties_df` in the overview tutorial.

## Changelog description
This PR changes the function `compile_values` to the more user friendly `get_properties_df` in the overview tutorial.

## Status
- [x] Code base linted
- [x] Ready to go
