### PR TITLE
Better handling of missing tags/programs from managers

### DIFF
--- a/qcfractalcompute/qcfractalcompute/compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/compute_manager.py
@@ -145,7 +145,10 @@ class ComputeManager:
         self.dflow_kernel = None
 
         # Set up the app manager
-        self.app_manager = AppManager(self.manager_config)
+        # A bit hacky, but the app_manager may already be set if
+        # we are running in a testing environment
+        if not hasattr(self, "app_manager"):
+            self.app_manager = AppManager(self.manager_config)
 
         self.executor_programs = {}
         for ex in self.manager_config.executors.keys():

--- a/qcfractalcompute/qcfractalcompute/compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/compute_manager.py
@@ -131,8 +131,14 @@ class ComputeManager:
         self._record_id_map: Dict[int, int] = {}
 
         self.all_queue_tags = []
-        for ex_config in config.executors.values():
+        for ex_label, ex_config in config.executors.items():
+            if len(ex_config.queue_tags) == 0:
+                raise ValueError(f"Executor {ex_label} has no queue tags")
+
             self.all_queue_tags.extend(ex_config.queue_tags)
+
+        # Merge queue tags, preserving order
+        self.all_queue_tags = list(dict.fromkeys(self.all_queue_tags))
 
         # These are more properly set up in the start() method
         self.parsl_config = None
@@ -140,9 +146,15 @@ class ComputeManager:
 
         # Set up the app manager
         self.app_manager = AppManager(self.manager_config)
-        self.executor_programs = {
-            ex: self.app_manager.all_program_info(ex) for ex in self.manager_config.executors.keys()
-        }
+
+        self.executor_programs = {}
+        for ex in self.manager_config.executors.keys():
+            ex_programs = self.app_manager.all_program_info(ex)
+            if len(ex_programs) == 0:
+                raise ValueError(f"Executor {ex} has no available programs")
+
+            self.executor_programs[ex] = ex_programs
+
         self.all_program_info = self.app_manager.all_program_info()
 
         self.logger.info("-" * 80)

--- a/qcfractalcompute/qcfractalcompute/test_compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/test_compute_manager.py
@@ -84,6 +84,56 @@ def test_manager_tags(snowflake: QCATestingSnowflake, tmp_path):
     assert set(managers[0]["tags"]) == {"tag1", "tag2", "tag3", "tag4", "*"}
 
 
+def test_manager_tags_missing(snowflake: QCATestingSnowflake, tmp_path):
+    compute_config = FractalComputeConfig(
+        base_folder=str(tmp_path),
+        cluster="testing_compute",
+        update_frequency=5,
+        server=FractalServerSettings(
+            fractal_uri=snowflake.get_uri(),
+            verify=False,
+        ),
+        executors={
+            "local": LocalExecutorConfig(
+                cores_per_worker=1,
+                memory_per_worker=1,
+                max_workers=1,
+                queue_tags=["tag1", "tag2", "*"],
+            ),
+            "local2": LocalExecutorConfig(cores_per_worker=1, memory_per_worker=1, max_workers=1, queue_tags=[]),
+        },
+    )
+
+    with pytest.raises(ValueError, match="local2 has no queue tags"):
+        ComputeManager(compute_config)
+
+
+def test_manager_tags_duplicate(snowflake: QCATestingSnowflake, tmp_path):
+    compute_config = FractalComputeConfig(
+        base_folder=str(tmp_path),
+        cluster="testing_compute",
+        update_frequency=5,
+        server=FractalServerSettings(
+            fractal_uri=snowflake.get_uri(),
+            verify=False,
+        ),
+        executors={
+            "local": LocalExecutorConfig(
+                cores_per_worker=1,
+                memory_per_worker=1,
+                max_workers=1,
+                queue_tags=["tag1", "tag2", "*"],
+            ),
+            "local2": LocalExecutorConfig(
+                cores_per_worker=1, memory_per_worker=1, max_workers=1, queue_tags=["tag2", "tag1"]
+            ),
+        },
+    )
+
+    compute = ComputeManager(compute_config)
+    assert compute.all_queue_tags == ["tag1", "tag2", "*"]
+
+
 @pytest.mark.filterwarnings("ignore:Exception in thread")
 def test_manager_claim_inactive(snowflake: QCATestingSnowflake):
     storage_socket = snowflake.get_storage_socket()

--- a/qcfractalcompute/qcfractalcompute/testing_helpers.py
+++ b/qcfractalcompute/qcfractalcompute/testing_helpers.py
@@ -21,6 +21,11 @@ from qcportal.all_results import AllResultTypes
 from qcportal.record_models import PriorityEnum, RecordTask
 
 
+class MockTestingAppManager:
+    def all_program_info(self, executor_label: Optional[str] = None) -> Dict[str, List[str]]:
+        return _activated_manager_programs
+
+
 class MockTestingComputeManager(ComputeManager):
     def __init__(self, qcf_config: FractalConfig, result_data: Dict[int, AllResultTypes]):
         self._qcf_config = qcf_config
@@ -57,10 +62,10 @@ class MockTestingComputeManager(ComputeManager):
                 )
             },
         )
-        ComputeManager.__init__(self, self._compute_config)
 
-        # overwrite the executor programs for testing
-        self.executor_programs = {"local": _activated_manager_programs}
+        # Set the app manager already
+        self.app_manager = MockTestingAppManager()
+        ComputeManager.__init__(self, self._compute_config)
 
         def cleanup(d):
             d.cleanup()

--- a/qcportal/qcportal/tasks/models.py
+++ b/qcportal/qcportal/tasks/models.py
@@ -1,9 +1,9 @@
 from typing import Dict, List
 
 try:
-    from pydantic.v1 import Field, BaseModel, constr, Extra
+    from pydantic.v1 import Field, BaseModel, constr, Extra, validator
 except ImportError:
-    from pydantic import Field, BaseModel, constr, Extra
+    from pydantic import Field, BaseModel, constr, Extra, validator
 
 from qcportal.base_models import RestModelBase
 from qcportal.managers import ManagerName
@@ -14,6 +14,23 @@ class TaskClaimBody(RestModelBase):
     programs: Dict[constr(to_lower=True), List[str]] = Field(..., description="Subset of programs to claim tasks for")
     tags: List[str] = Field(..., description="Subset of tags to claim tasks from")
     limit: int = Field(..., description="Limit on the number of tasks to claim")
+
+    @validator("tags")
+    def validate_tags(cls, v):
+        v = [x for x in v if len(x) > 0]
+
+        if len(v) == 0:
+            raise ValueError("'tags' field contains no non-zero-length tags")
+
+        return list(dict.fromkeys(v))  # remove duplicates, maintaining order (in python 3.6+)
+
+    @validator("programs")
+    def validate_programs(cls, v):
+        # Remove programs of zero length
+        v = {x: y for x, y in v.items() if len(x) > 0}
+        if len(v) == 0:
+            raise ValueError("'programs' field contains no non-zero-length programs")
+        return v
 
 
 class TaskReturnBody(RestModelBase):


### PR DESCRIPTION
## Description

Adds more checks for managers that have executors missing tags or programs. Fixes #807

Missing tags has been tested, but missing programs is hard to test.


## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fix issue with missing programs or tags with compute manager executors (Issue #807)

## Status
- [X] Code base linted
- [X] Ready to go
