### PR TITLE
Improve fetching speed by allowing for including more of records

### DIFF
--- a/qcarchivetesting/qcarchivetesting/testing_classes.py
+++ b/qcarchivetesting/qcarchivetesting/testing_classes.py
@@ -248,7 +248,7 @@ class QCATestingSnowflake(FractalSnowflake):
         """
         self._stop_job_runner()
 
-    def client(self, username=None, password=None, cache_dir=None) -> PortalClient:
+    def client(self, username=None, password=None, cache_dir=None, shared_memory_cache=False) -> PortalClient:
         """
         Obtain a client connected to this snowflake
 
@@ -260,6 +260,11 @@ class QCATestingSnowflake(FractalSnowflake):
             The password to use
         cache_dir
             Directory to store cache files in
+        shared_memory_cache
+            Whether to use a shared memory cache
+
+        Note: We generally don't want a shared memory cache for tests, so the default is False here
+        rather than True as in the main codebase
 
         Returns
         -------
@@ -267,7 +272,8 @@ class QCATestingSnowflake(FractalSnowflake):
             A PortalClient that is connected to this snowflake
         """
 
-        client = PortalClient(self.get_uri(), username=username, password=password, cache_dir=cache_dir)
+        client = PortalClient(self.get_uri(), username=username, password=password, cache_dir=cache_dir,
+                              shared_memory_cache=shared_memory_cache)
         client.encoding = self.encoding
         return client
 

--- a/qcfractal/qcfractal/components/gridoptimization/record_socket.py
+++ b/qcfractal/qcfractal/components/gridoptimization/record_socket.py
@@ -475,6 +475,25 @@ class GridoptimizationRecordSocket(BaseRecordSocket):
                 r = session.execute(stmt).scalar_one()
                 return InsertMetadata(existing_idx=[0]), r
 
+    def get(
+        self,
+        record_ids: Sequence[int],
+        include: Optional[Sequence[str]] = None,
+        exclude: Optional[Sequence[str]] = None,
+        missing_ok: bool = False,
+        *,
+        session: Optional[Session] = None,
+    ) -> List[Optional[Dict[str, Any]]]:
+        with self.root_socket.optional_session(session, True) as session:
+            return self.root_socket.records.get_base(
+                orm_type=self.record_orm,
+                record_ids=record_ids,
+                include=include,
+                exclude=exclude,
+                missing_ok=missing_ok,
+                session=session,
+            )
+
     def query(
         self,
         query_data: GridoptimizationQueryFilters,

--- a/qcfractal/qcfractal/components/gridoptimization/record_socket.py
+++ b/qcfractal/qcfractal/components/gridoptimization/record_socket.py
@@ -481,23 +481,6 @@ class GridoptimizationRecordSocket(BaseRecordSocket):
         *,
         session: Optional[Session] = None,
     ) -> List[int]:
-        """
-        Query gridoptimization records
-
-        Parameters
-        ----------
-        query_data
-            Fields/filters to query for
-        session
-            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
-            is used, it will be flushed (but not committed) before returning from this function.
-
-        Returns
-        -------
-        :
-            A list of record ids that were found in the database.
-        """
-
         and_query = []
         need_spspec_join = False
         need_optspec_join = False

--- a/qcfractal/qcfractal/components/manybody/record_socket.py
+++ b/qcfractal/qcfractal/components/manybody/record_socket.py
@@ -445,6 +445,25 @@ class ManybodyRecordSocket(BaseRecordSocket):
                 r = session.execute(stmt).scalar_one()
                 return InsertMetadata(existing_idx=[0]), r
 
+    def get(
+        self,
+        record_ids: Sequence[int],
+        include: Optional[Sequence[str]] = None,
+        exclude: Optional[Sequence[str]] = None,
+        missing_ok: bool = False,
+        *,
+        session: Optional[Session] = None,
+    ) -> List[Optional[Dict[str, Any]]]:
+        with self.root_socket.optional_session(session, True) as session:
+            return self.root_socket.records.get_base(
+                orm_type=self.record_orm,
+                record_ids=record_ids,
+                include=include,
+                exclude=exclude,
+                missing_ok=missing_ok,
+                session=session,
+            )
+
     def query(
         self,
         query_data: ManybodyQueryFilters,

--- a/qcfractal/qcfractal/components/manybody/record_socket.py
+++ b/qcfractal/qcfractal/components/manybody/record_socket.py
@@ -451,23 +451,6 @@ class ManybodyRecordSocket(BaseRecordSocket):
         *,
         session: Optional[Session] = None,
     ) -> List[int]:
-        """
-        Query manybody records
-
-        Parameters
-        ----------
-        query_data
-            Fields/filters to query for
-        session
-            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
-            is used, it will be flushed (but not committed) before returning from this function.
-
-        Returns
-        -------
-        :
-            A list of record ids that were found in the database.
-        """
-
         and_query = []
         need_spec_join = False
         need_qcspec_join = False

--- a/qcfractal/qcfractal/components/neb/record_socket.py
+++ b/qcfractal/qcfractal/components/neb/record_socket.py
@@ -527,6 +527,25 @@ class NEBRecordSocket(BaseRecordSocket):
                 r = session.execute(stmt).scalar_one()
                 return InsertMetadata(inserted_idx=[0]), r
 
+    def get(
+        self,
+        record_ids: Sequence[int],
+        include: Optional[Sequence[str]] = None,
+        exclude: Optional[Sequence[str]] = None,
+        missing_ok: bool = False,
+        *,
+        session: Optional[Session] = None,
+    ) -> List[Optional[Dict[str, Any]]]:
+        with self.root_socket.optional_session(session, True) as session:
+            return self.root_socket.records.get_base(
+                orm_type=self.record_orm,
+                record_ids=record_ids,
+                include=include,
+                exclude=exclude,
+                missing_ok=missing_ok,
+                session=session,
+            )
+
     def query(
         self,
         query_data: NEBQueryFilters,

--- a/qcfractal/qcfractal/components/neb/record_socket.py
+++ b/qcfractal/qcfractal/components/neb/record_socket.py
@@ -533,23 +533,6 @@ class NEBRecordSocket(BaseRecordSocket):
         *,
         session: Optional[Session] = None,
     ) -> List[int]:
-        """
-        Query neb records
-
-        Parameters
-        ----------
-        query_data
-            Fields/filters to query for
-        session
-            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
-            is used, it will be flushed (but not committed) before returning from this function.
-
-        Returns
-        -------
-        :
-            A list of record ids that were found in the database.
-        """
-
         and_query = []
         need_spspec_join = False
         need_initchain_join = False

--- a/qcfractal/qcfractal/components/optimization/record_db_models.py
+++ b/qcfractal/qcfractal/components/optimization/record_db_models.py
@@ -122,8 +122,10 @@ class OptimizationRecordORM(BaseRecordORM):
 
     def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         d = BaseRecordORM.model_dict(self, exclude)
+
+        # Models use ids for the trajectory, rather than the object we store
         if "trajectory" in d:
-            d["trajectory_ids_"] = [x["singlepoint_id"] for x in d.pop("trajectory")]
+            d["trajectory_ids"] = [x["singlepoint_id"] for x in d.pop("trajectory")]
 
         return d
 

--- a/qcfractal/qcfractal/components/optimization/record_socket.py
+++ b/qcfractal/qcfractal/components/optimization/record_socket.py
@@ -184,23 +184,6 @@ class OptimizationRecordSocket(BaseRecordSocket):
         *,
         session: Optional[Session] = None,
     ) -> List[int]:
-        """
-        Query optimization records
-
-        Parameters
-        ----------
-        query_data
-            Fields/filters to query for
-        session
-            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
-            is used, it will be flushed (but not committed) before returning from this function.
-
-        Returns
-        -------
-        :
-            A list of record ids that were found in the database.
-        """
-
         and_query = []
         need_spspec_join = False
         need_optspec_join = False

--- a/qcfractal/qcfractal/components/optimization/record_socket.py
+++ b/qcfractal/qcfractal/components/optimization/record_socket.py
@@ -178,6 +178,25 @@ class OptimizationRecordSocket(BaseRecordSocket):
                 r = session.execute(stmt).scalar_one()
                 return InsertMetadata(existing_idx=[0]), r
 
+    def get(
+        self,
+        record_ids: Sequence[int],
+        include: Optional[Sequence[str]] = None,
+        exclude: Optional[Sequence[str]] = None,
+        missing_ok: bool = False,
+        *,
+        session: Optional[Session] = None,
+    ) -> List[Optional[Dict[str, Any]]]:
+        with self.root_socket.optional_session(session, True) as session:
+            return self.root_socket.records.get_base(
+                orm_type=self.record_orm,
+                record_ids=record_ids,
+                include=include,
+                exclude=exclude,
+                missing_ok=missing_ok,
+                session=session,
+            )
+
     def query(
         self,
         query_data: OptimizationQueryFilters,

--- a/qcfractal/qcfractal/components/reaction/record_db_models.py
+++ b/qcfractal/qcfractal/components/reaction/record_db_models.py
@@ -28,7 +28,7 @@ class ReactionComponentORM(BaseORM):
     singlepoint_id = Column(Integer, ForeignKey(SinglepointRecordORM.id), nullable=True)
     optimization_id = Column(Integer, ForeignKey(OptimizationRecordORM.id), nullable=True)
 
-    molecule = relationship(MoleculeORM, lazy="selectin")
+    molecule = relationship(MoleculeORM)
     singlepoint_record = relationship(SinglepointRecordORM)
     optimization_record = relationship(OptimizationRecordORM)
 

--- a/qcfractal/qcfractal/components/reaction/record_socket.py
+++ b/qcfractal/qcfractal/components/reaction/record_socket.py
@@ -382,6 +382,25 @@ class ReactionRecordSocket(BaseRecordSocket):
             r = session.execute(stmt).scalar_one()
             return InsertMetadata(inserted_idx=[0]), r
 
+    def get(
+        self,
+        record_ids: Sequence[int],
+        include: Optional[Sequence[str]] = None,
+        exclude: Optional[Sequence[str]] = None,
+        missing_ok: bool = False,
+        *,
+        session: Optional[Session] = None,
+    ) -> List[Optional[Dict[str, Any]]]:
+        with self.root_socket.optional_session(session, True) as session:
+            return self.root_socket.records.get_base(
+                orm_type=self.record_orm,
+                record_ids=record_ids,
+                include=include,
+                exclude=exclude,
+                missing_ok=missing_ok,
+                session=session,
+            )
+
     def query(
         self,
         query_data: ReactionQueryFilters,

--- a/qcfractal/qcfractal/components/reaction/record_socket.py
+++ b/qcfractal/qcfractal/components/reaction/record_socket.py
@@ -388,23 +388,6 @@ class ReactionRecordSocket(BaseRecordSocket):
         *,
         session: Optional[Session] = None,
     ) -> List[int]:
-        """
-        Query reaction records
-
-        Parameters
-        ----------
-        query_data
-            Fields/filters to query for
-        session
-            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
-            is used, it will be flushed (but not committed) before returning from this function.
-
-        Returns
-        -------
-        :
-            A list of record ids that were found in the database.
-        """
-
         and_query = []
         need_qc_spec_join = False
         need_opt_spec_join = False

--- a/qcfractal/qcfractal/components/record_routes.py
+++ b/qcfractal/qcfractal/components/record_routes.py
@@ -73,7 +73,7 @@ def get_record_waiting_reason_v1(record_id: int):
 @wrap_route("READ")
 def get_records_v1(record_id: int, url_params: ProjURLParameters, record_type: Optional[str] = None):
     record_socket = storage_socket.records.get_socket(record_type)
-    return record_socket.get([record_id], url_params.include, url_params.exclude)
+    return record_socket.get([record_id], url_params.include, url_params.exclude)[0]
 
 
 @api_v1.route("/records/<string:record_type>/bulkGet", methods=["POST"])

--- a/qcfractal/qcfractal/components/record_socket.py
+++ b/qcfractal/qcfractal/components/record_socket.py
@@ -160,6 +160,31 @@ class BaseRecordSocket:
         with self.root_socket.optional_session(session, True) as session:
             return get_general(session, self.record_orm, self.record_orm.id, record_ids, include, exclude, missing_ok)
 
+    def query(
+        self,
+        query_data: RecordQueryFilters,
+        *,
+        session: Optional[Session] = None,
+    ) -> List[int]:
+        """
+        Query records of a particular type
+
+        Parameters
+        ----------
+        query_data
+            Fields/filters to query for
+        session
+            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
+            is used, it will be flushed (but not committed) before returning from this function.
+
+        Returns
+        -------
+        :
+            A list of record ids that were found in the database.
+        """
+
+        raise NotImplementedError(f"query function not implemented for {type(self)}! This is a developer error")
+
     def generate_task_specification(self, record_orm: BaseRecordORM) -> Dict[str, Any]:
         """
         Generate the actual QCSchema input and related fields for a task

--- a/qcfractal/qcfractal/components/singlepoint/record_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/record_socket.py
@@ -201,6 +201,25 @@ class SinglepointRecordSocket(BaseRecordSocket):
                 r = session.execute(stmt).scalar_one()
                 return InsertMetadata(existing_idx=[0]), r
 
+    def get(
+        self,
+        record_ids: Sequence[int],
+        include: Optional[Sequence[str]] = None,
+        exclude: Optional[Sequence[str]] = None,
+        missing_ok: bool = False,
+        *,
+        session: Optional[Session] = None,
+    ) -> List[Optional[Dict[str, Any]]]:
+        with self.root_socket.optional_session(session, True) as session:
+            return self.root_socket.records.get_base(
+                orm_type=self.record_orm,
+                record_ids=record_ids,
+                include=include,
+                exclude=exclude,
+                missing_ok=missing_ok,
+                session=session,
+            )
+
     def query(
         self,
         query_data: SinglepointQueryFilters,

--- a/qcfractal/qcfractal/components/singlepoint/record_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/record_socket.py
@@ -207,23 +207,6 @@ class SinglepointRecordSocket(BaseRecordSocket):
         *,
         session: Optional[Session] = None,
     ) -> List[int]:
-        """
-        Query singlepoint records
-
-        Parameters
-        ----------
-        query_data
-            Fields/filters to query for
-        session
-            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
-            is used, it will be flushed (but not committed) before returning from this function.
-
-        Returns
-        -------
-        :
-            A list of records that were found in the database.
-        """
-
         and_query = []
         need_join = False
 

--- a/qcfractal/qcfractal/components/singlepoint/record_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/record_socket.py
@@ -210,6 +210,13 @@ class SinglepointRecordSocket(BaseRecordSocket):
         *,
         session: Optional[Session] = None,
     ) -> List[Optional[Dict[str, Any]]]:
+        options = []
+        if include:
+            if "**" in include or "molecule" in include:
+                options.append(joinedload(SinglepointRecordORM.molecule))
+            if "**" in include or "wavefunction" in include:
+                options.append(joinedload(SinglepointRecordORM.wavefunction).undefer(WavefunctionORM.data))
+
         with self.root_socket.optional_session(session, True) as session:
             return self.root_socket.records.get_base(
                 orm_type=self.record_orm,
@@ -217,6 +224,7 @@ class SinglepointRecordSocket(BaseRecordSocket):
                 include=include,
                 exclude=exclude,
                 missing_ok=missing_ok,
+                additional_options=options,
                 session=session,
             )
 

--- a/qcfractal/qcfractal/components/singlepoint/testing_helpers.py
+++ b/qcfractal/qcfractal/components/singlepoint/testing_helpers.py
@@ -115,9 +115,6 @@ def run_test_data(
     with storage_socket.session_scope() as session:
         record = session.get(SinglepointRecordORM, record_id)
         assert record.status == end_status
-        print(time_0)
-        print(record.created_on)
-        print(time_1)
         assert time_0 < record.created_on < time_1
         assert time_1 < record.modified_on < time_2
         assert time_1 < record.compute_history[0].modified_on < time_2

--- a/qcfractal/qcfractal/components/torsiondrive/record_db_models.py
+++ b/qcfractal/qcfractal/components/torsiondrive/record_db_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import select, Column, Integer, ForeignKey, String, UniqueConstraint, Index, CheckConstraint, event, DDL
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.orderinglist import ordering_list
@@ -12,6 +14,9 @@ from qcfractal.components.optimization.record_db_models import (
 )
 from qcfractal.components.record_db_models import BaseRecordORM
 from qcfractal.db_socket import BaseORM
+
+if TYPE_CHECKING:
+    from typing import Dict, Any, Optional, Iterable
 
 
 class TorsiondriveOptimizationORM(BaseORM):
@@ -118,6 +123,18 @@ class TorsiondriveRecordORM(BaseRecordORM):
     }
 
     _qcportal_model_excludes = [*BaseRecordORM._qcportal_model_excludes, "specification_id"]
+
+    def model_dict(self, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
+        d = BaseRecordORM.model_dict(self, exclude)
+
+        # Return initial molecule or just the ids, depending on what we have
+        if "initial_molecules" in d:
+            init_mol = d.pop("initial_molecules")
+            d["initial_molecules_ids"] = [x["molecule_id"] for x in init_mol]
+            if "molecule" in init_mol[0]:
+                d["initial_molecules"] = [x["molecule"] for x in init_mol]
+
+        return d
 
     @property
     def short_description(self) -> str:

--- a/qcfractal/qcfractal/components/torsiondrive/record_socket.py
+++ b/qcfractal/qcfractal/components/torsiondrive/record_socket.py
@@ -398,23 +398,6 @@ class TorsiondriveRecordSocket(BaseRecordSocket):
         *,
         session: Optional[Session] = None,
     ) -> List[int]:
-        """
-        Query torsiondrive records
-
-        Parameters
-        ----------
-        query_data
-            Fields/filters to query for
-        session
-            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
-            is used, it will be flushed (but not committed) before returning from this function.
-
-        Returns
-        -------
-        :
-            A list of record ids that were found in the database.
-        """
-
         and_query = []
         need_spspec_join = False
         need_optspec_join = False

--- a/qcfractal/qcfractal/components/torsiondrive/record_socket.py
+++ b/qcfractal/qcfractal/components/torsiondrive/record_socket.py
@@ -392,6 +392,25 @@ class TorsiondriveRecordSocket(BaseRecordSocket):
                 r = session.execute(stmt).scalar_one()
                 return InsertMetadata(existing_idx=[0]), r
 
+    def get(
+        self,
+        record_ids: Sequence[int],
+        include: Optional[Sequence[str]] = None,
+        exclude: Optional[Sequence[str]] = None,
+        missing_ok: bool = False,
+        *,
+        session: Optional[Session] = None,
+    ) -> List[Optional[Dict[str, Any]]]:
+        with self.root_socket.optional_session(session, True) as session:
+            return self.root_socket.records.get_base(
+                orm_type=self.record_orm,
+                record_ids=record_ids,
+                include=include,
+                exclude=exclude,
+                missing_ok=missing_ok,
+                session=session,
+            )
+
     def query(
         self,
         query_data: TorsiondriveQueryFilters,

--- a/qcfractal/qcfractal/components/torsiondrive/record_socket.py
+++ b/qcfractal/qcfractal/components/torsiondrive/record_socket.py
@@ -15,12 +15,11 @@ try:
 except ImportError:
     from pydantic import BaseModel, Extra
 from sqlalchemy import select, func
-from sqlalchemy.dialects.postgresql import insert, array_agg, aggregate_order_by, DOUBLE_PRECISION, TEXT
+from sqlalchemy.dialects.postgresql import insert, array_agg, aggregate_order_by
 from sqlalchemy.orm import lazyload, selectinload, joinedload, defer, undefer
 
 from qcfractal.components.optimization.record_db_models import (
     OptimizationSpecificationORM,
-    OptimizationRecordORM,
 )
 from qcfractal.components.services.db_models import ServiceQueueORM, ServiceDependencyORM
 from qcfractal.components.singlepoint.record_db_models import QCSpecificationORM
@@ -416,6 +415,9 @@ class TorsiondriveRecordSocket(BaseRecordSocket):
             if "**" in include or "optimizations" in include:
                 options.append(selectinload(TorsiondriveRecordORM.optimizations))
 
+            if "**" in include or "minimum_optimizations" in include:
+                options.append(undefer(TorsiondriveRecordORM.minimum_optimizations))
+
         with self.root_socket.optional_session(session, True) as session:
             return self.root_socket.records.get_base(
                 orm_type=self.record_orm,
@@ -803,35 +805,8 @@ class TorsiondriveRecordSocket(BaseRecordSocket):
             optimization in the torsiondrive (representing the angles)
         """
 
-        # Kind of complicated, but this is relatively cross platform
-        # (with postgres, could do a DISTINCT ON)
-
-        # CTE with columns torsiondrive_id, key, min_energy
-        energy_cte = (
-            select(
-                TorsiondriveOptimizationORM.torsiondrive_id.label("torsiondrive_id"),
-                TorsiondriveOptimizationORM.key.label("key"),
-                func.min(OptimizationRecordORM.energies[-1].cast(TEXT).cast(DOUBLE_PRECISION)).label("min_energy"),
-            )
-            .join(OptimizationRecordORM)
-            .group_by("torsiondrive_id", "key")
-        ).cte()
-
-        # Select rows with matching minimum energies
-        # We order by the optimization id desc to handle the case where multiple records with same final energy
-        # Then, the dictionary comprehension at the end last of that energy (lowest id)
-        stmt = (
-            select(TorsiondriveOptimizationORM.key, TorsiondriveOptimizationORM.optimization_id)
-            .join(energy_cte, energy_cte.c.torsiondrive_id == TorsiondriveOptimizationORM.torsiondrive_id)
-            .join(TorsiondriveOptimizationORM.optimization_record)
-            .where(TorsiondriveOptimizationORM.torsiondrive_id == record_id)
-            .where(TorsiondriveOptimizationORM.key == energy_cte.c.key)
-            .where(OptimizationRecordORM.energies[-1].cast(TEXT).cast(DOUBLE_PRECISION) == energy_cte.c.min_energy)
-            .order_by(OptimizationRecordORM.id.desc())
-        )
+        stmt = select(TorsiondriveRecordORM.minimum_optimizations).where(TorsiondriveRecordORM.id == record_id)
 
         with self.root_socket.optional_session(session, True) as session:
-            r = session.execute(stmt).all()  # List of (key, id)
-
-            # If multiple records with the same energy are returned, then this will choose the last
-            return {x: y for x, y in r}
+            r = session.execute(stmt).scalar_one_or_none()  # List of (key, id)
+            return {} if r is None else r

--- a/qcfractal/qcfractal/db_socket/helpers.py
+++ b/qcfractal/qcfractal/db_socket/helpers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
-from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from sqlalchemy import tuple_, and_, or_, func, select, inspect
@@ -45,6 +45,30 @@ batchsize = 200
 logger = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass
+class _ProjectionDefaultInformation:
+    """
+    Information about the default columns and relationships for a given ORM type
+
+    This is used to memoize the results of the _get_default_attrs function
+    """
+
+    all_attrs: Any
+    columns: Set[str]
+    relationships: Set[str]
+
+    deferred_columns: Set[str]
+    lazy_relationships: Set[str]
+
+    default_columns: Set[str]
+    default_relationships: Set[str]
+
+
+# Cache for inspection information and projection options
+_query_defaults_cache: Dict[str, _ProjectionDefaultInformation] = {}
+_query_proj_cache = {}
+
+
 def get_count(session, stmt):
     """
     Returns a total count of an sql query statement
@@ -55,7 +79,57 @@ def get_count(session, stmt):
     return session.scalar(select(func.count()).select_from(stmt.subquery()))
 
 
-@lru_cache(maxsize=1000)
+def _get_default_attrs(orm_type: Type[_ORM_T]) -> _ProjectionDefaultInformation:
+    """
+    Obtain default attributes for an ORM type
+
+    This function returns information about the default columns and relationships for a given ORM type.
+    This information is used to determine what columns and relationships are loaded by default when
+    querying for ORM objects. This information is memoized.
+
+    Parameters
+    ----------
+    orm_type
+        The ORM type to inspect
+
+    Returns
+    -------
+    :
+        Information about the default columns and relationships for the given ORM type
+    """
+
+    key = orm_type.__name__
+    if key in _query_defaults_cache:
+        return _query_defaults_cache[key]
+
+    mapper = inspect(orm_type)
+
+    # We use mapper.mapper. This works for the usual ORM, as well as
+    # with_polymorphic objects
+    all_attrs = mapper.mapper.attrs
+    columns = set(mapper.mapper.column_attrs.keys())
+    relationships = set(mapper.mapper.relationships.keys())
+
+    deferred_columns = set(k for k, v in mapper.mapper.column_attrs.items() if v.deferred)
+    lazy_relationships = set(k for k, v in mapper.mapper.relationships.items() if v.lazy in lazy_opts)
+
+    default_columns = set(columns) - set(deferred_columns)
+    default_relationships = set(relationships) - set(lazy_relationships)
+
+    ret = _ProjectionDefaultInformation(
+        all_attrs=all_attrs,
+        columns=columns,
+        relationships=relationships,
+        deferred_columns=deferred_columns,
+        lazy_relationships=lazy_relationships,
+        default_columns=default_columns,
+        default_relationships=default_relationships,
+    )
+
+    _query_defaults_cache[key] = ret
+    return ret
+
+
 def _get_query_proj_options(
     orm_type: Type[_ORM_T], include: Optional[Tuple[str, ...]], exclude: Optional[Tuple[str, ...]]
 ) -> List[Any]:
@@ -77,42 +151,36 @@ def _get_query_proj_options(
     if exclude is not None:
         exclude_set = set(exclude)
 
-    mapper = inspect(orm_type)
+    # Get information about the defaults
+    defaults = _get_default_attrs(orm_type)
 
-    # We use mapper.mapper. This works for the usual ORM, as well as
-    # with_polymorphic objects
-    all_attrs = mapper.mapper.attrs
-    columns = set(mapper.mapper.column_attrs.keys())
-    relationships = set(mapper.mapper.relationships.keys())
-
-    lazy_relationships = set(k for k, v in mapper.mapper.relationships.items() if v.lazy in lazy_opts)
-    default_relationships = relationships - lazy_relationships
-
+    options = []
     if include_set is None and exclude_set:
         # no includes, some excludes
         # load only the non-excluded columns
         # skip loading excluded relationships
-        defer_columns = columns & exclude_set
-        noload_rels = default_relationships & exclude_set
+        defer_columns = defaults.default_columns & exclude_set
+        noload_rels = defaults.default_relationships & exclude_set
 
-        options = [lazyload(all_attrs[x]) for x in noload_rels]
-        options += [defer(all_attrs[x]) for x in defer_columns]
+        options += [lazyload(defaults.all_attrs[x]) for x in noload_rels]
+        options += [defer(defaults.all_attrs[x]) for x in defer_columns]
 
     elif include_set is not None and not exclude_set:
         # Include, but with no excludes
-        defer_columns = columns - include_set
-        noload_rels = default_relationships - include_set
+        # Remove any columns/relationships not specified in the includes
+        defer_columns = defaults.default_columns - include_set
+        noload_rels = defaults.default_relationships - include_set
 
-        options = [lazyload(all_attrs[x]) for x in noload_rels]
-        options += [defer(all_attrs[x]) for x in defer_columns]
+        options += [lazyload(defaults.all_attrs[x]) for x in noload_rels]
+        options += [defer(defaults.all_attrs[x]) for x in defer_columns]
 
     elif include_set is not None and exclude_set:
         # Both includes and excludes specified
-        defer_columns = (columns - include_set) | (columns & exclude_set)
-        noload_rels = (default_relationships - include_set) | (default_relationships & exclude_set)
+        defer_columns = (defaults.default_columns - include_set) | (defaults.default_columns & exclude_set)
+        noload_rels = (defaults.default_relationships - include_set) | (defaults.default_relationships & exclude_set)
 
-        options = [lazyload(all_attrs[x]) for x in noload_rels]
-        options += [defer(all_attrs[x]) for x in defer_columns]
+        options += [lazyload(defaults.all_attrs[x]) for x in noload_rels]
+        options += [defer(defaults.all_attrs[x]) for x in defer_columns]
 
     else:
         raise RuntimeError(
@@ -134,19 +202,21 @@ def get_query_proj_options(
     .options() function call (as part of a statement) that implements a projection. That is,
     the options will select/deselect columns and relationships that are specified as strings
     to the `include` and `exclude` arguments of this function.
-
-    If `restrict` is true, this function can only be used to remove columns/relationships from
-    the default. If it is false, the additional columns and relationships can be
-    loaded
     """
 
     # Wrap the include/exclude in tuples for memoization
     if include is not None:
-        include = tuple(include)
+        include = tuple(sorted(include))
     if exclude is not None:
-        exclude = tuple(exclude)
+        exclude = tuple(sorted(exclude))
 
-    return _get_query_proj_options(orm_type, include, exclude)
+    key = (orm_type.__name__, include, exclude)
+    if key in _query_proj_cache:
+        return _query_proj_cache[key]
+    else:
+        ret = _get_query_proj_options(orm_type, include, exclude)
+        _query_proj_cache[key] = ret
+        return ret
 
 
 def find_all_indices(lst: Sequence[_T], value: _T) -> Tuple[int, ...]:

--- a/qcportal/qcportal/__init__.py
+++ b/qcportal/qcportal/__init__.py
@@ -10,3 +10,6 @@ __version__ = version("qcportal")
 from .client import PortalClient
 from .client_base import PortalRequestError
 from .manager_client import ManagerClient
+
+# Some other helpful functions
+from .dataset_models import load_dataset_view, create_dataset_view

--- a/qcportal/qcportal/cache.py
+++ b/qcportal/qcportal/cache.py
@@ -670,7 +670,7 @@ def get_records_with_cache(
         existing_records += recs
 
     # Fetch all children as well
-    record_type.fetch_children_multi(existing_records, True)
+    record_type.fetch_children_multi(existing_records, include=include, force_fetch=force_fetch)
 
     # Return everything in the same order as the input
     all_recs = {r.id: r for r in existing_records}

--- a/qcportal/qcportal/cache.py
+++ b/qcportal/qcportal/cache.py
@@ -662,10 +662,9 @@ def get_records_with_cache(
 
         # Set up for the writeback
         for r in recs:
+            # Don't write to the cache yet. Let the writeback mechanism handle it
             r._record_cache = record_cache
-
-        # Don't write to the cache yet. Let the writeback mechanism handle it
-        # record_cache.update_records(recs)
+            r._cache_dirty = True
 
         existing_records += recs
 
@@ -676,7 +675,7 @@ def get_records_with_cache(
     all_recs = {r.id: r for r in existing_records}
     ret = [all_recs.get(rid, None) for rid in record_ids]
 
-    if None in ret:
+    if any(x is None for x in ret):
         missing_ids = set(record_ids) - set(all_recs.keys())
         raise RuntimeError(
             f"Not all records found either in the cache or on the server. Missing records: {missing_ids}"

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -551,13 +551,13 @@ class PortalClient(PortalClientBase):
         all_records = []
 
         for record_id_batch in chunk_iterable(record_ids, batch_size):
-            body = CommonBulkGetBody(ids=record_id_batch, missing_ok=missing_ok)
+            if include is not None:
+                # Always include the base stuff
+                include = list(include) + ["*"]
+
+            body = CommonBulkGetBody(ids=record_id_batch, include=include, missing_ok=missing_ok)
             record_data = self.make_request("post", "api/v1/records/bulkGet", List[Optional[Dict[str, Any]]], body=body)
             record_batch = records_from_dicts(record_data, self)
-
-            if include:
-                for r in record_batch:
-                    r._handle_includes(include)
 
             all_records.extend(record_batch)
 
@@ -609,7 +609,11 @@ class PortalClient(PortalClientBase):
         all_records = []
 
         for record_id_batch in chunk_iterable(record_ids, batch_size):
-            body = CommonBulkGetBody(ids=record_id_batch, missing_ok=missing_ok)
+            if include is not None:
+                # Always include the base stuff
+                include = list(include) + ["*"]
+
+            body = CommonBulkGetBody(ids=record_id_batch, include=include, missing_ok=missing_ok)
 
             record_data = self.make_request(
                 "post",
@@ -619,11 +623,6 @@ class PortalClient(PortalClientBase):
             )
 
             record_batch = [record_type(self, **r) if r is not None else None for r in record_data]
-
-            if include:
-                for r in record_batch:
-                    r._handle_includes(include)
-
             all_records.extend(record_batch)
 
         if is_single:

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -75,6 +75,8 @@ from .dataset_models import (
     DatasetDeleteParams,
     DatasetAddBody,
     dataset_from_dict,
+    load_dataset_view,
+    create_dataset_view,
 )
 from .internal_jobs import InternalJob, InternalJobQueryFilters, InternalJobQueryIterator, InternalJobStatusEnum
 from .managers import ManagerQueryFilters, ManagerQueryIterator, ComputeManager
@@ -269,6 +271,11 @@ class PortalClient(PortalClientBase):
             ds_cache.read_only = True
 
         return ds
+
+    def create_dataset_view(
+        self, dataset_id: int, file_path: str, include: Optional[Iterable[str]] = None, overwrite: bool = False
+    ):
+        return create_dataset_view(self, dataset_id, file_path, include, overwrite)
 
     def get_dataset_status_by_id(self, dataset_id: int) -> Dict[str, Dict[RecordStatusEnum, int]]:
         return self.make_request("get", f"api/v1/datasets/{dataset_id}/status", Dict[str, Dict[RecordStatusEnum, int]])

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union, Sequence, Iterable, TypeVar, Type
 
@@ -561,7 +562,7 @@ class PortalClient(PortalClientBase):
             endpoint = f"api/v1/records/{record_type_str}/bulkGet"
 
         max_batch_size = self.api_limits["get_records"]
-        initial_batch_size = max_batch_size // 4
+        initial_batch_size = math.ceil(max_batch_size // 10)
 
         def _download_chunk(id_chunk: List[int]):
             body = CommonBulkGetBody(ids=id_chunk, include=include, missing_ok=missing_ok)
@@ -666,6 +667,8 @@ class PortalClient(PortalClientBase):
         # is requested via include. So we always say recursive=True here, and it won't recursively download
         # children if that data is missing.
 
+        # We always force fetch here. Given that this record is not part of the cache, it shouldn't be using any
+        # Cache anyway. But the semantics of this function is that is always fetches everything
         if record_type is None:
             # Handle disparate record types
             record_groups = {}

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -674,9 +674,9 @@ class PortalClient(PortalClientBase):
                     record_groups.setdefault(r.record_type, [])
                     record_groups[r.record_type].append(r)
             for v in record_groups.values():
-                v[0].fetch_children_multi(v, True)
+                v[0].fetch_children_multi(v, include, force_fetch=True)
         else:
-            record_type.fetch_children_multi(all_records, True)
+            record_type.fetch_children_multi(all_records, include, force_fetch=True)
 
         if is_single:
             return all_records[0]

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -525,7 +525,8 @@ class PortalClient(PortalClientBase):
 
         Records will be returned in the same order as the record ids. This function always returns a list.
 
-        This function only fetches the top-level records - it does not fetch the children of the records.
+        This function only fetches the top-level records - it does not fetch the children of the records. It also
+        does not use caching at all.
 
         Parameters
         ----------
@@ -630,13 +631,15 @@ class PortalClient(PortalClientBase):
         include: Optional[Iterable[str]] = None,
     ) -> Union[Optional[_T], List[Optional[_T]]]:
         """
-        Obtain records of a particular type with the specified IDs.
+        Obtain records of a particular type with the specified IDs from the server.
 
         Records will be returned in the same order as the record ids.
 
         This function will fetch the children of the records if enough information
         is fetched of the parent record. This is handled by the various fetch_children_multi
         class functions of the record types.
+
+        This function does not use the cache.
 
         Parameters
         ----------
@@ -663,12 +666,8 @@ class PortalClient(PortalClientBase):
         record_ids = make_list(record_ids)
         all_records = self._fetch_records(record_type, record_ids, missing_ok, include)
 
-        # In general, fetching children should only happen if the metadata for the children
-        # is requested via include. So we always say recursive=True here, and it won't recursively download
-        # children if that data is missing.
-
         # We always force fetch here. Given that this record is not part of the cache, it shouldn't be using any
-        # Cache anyway. But the semantics of this function is that is always fetches everything
+        # cache anyway. But the semantics of this function is that is always fetches everything
         if record_type is None:
             # Handle disparate record types
             record_groups = {}

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -1105,7 +1105,7 @@ class PortalClient(PortalClientBase):
         }
 
         filter_data = SinglepointQueryFilters(**filter_dict)
-        return RecordQueryIterator[SinglepointRecord](self, filter_data, "singlepoint", include)
+        return RecordQueryIterator[SinglepointRecord](self, filter_data, SinglepointRecord, include)
 
     ##############################################################
     # Optimization calculations
@@ -1328,7 +1328,7 @@ class PortalClient(PortalClientBase):
         }
 
         filter_data = OptimizationQueryFilters(**filter_dict)
-        return RecordQueryIterator[OptimizationRecord](self, filter_data, "optimization", include)
+        return RecordQueryIterator[OptimizationRecord](self, filter_data, OptimizationRecord, include)
 
     ##############################################################
     # Torsiondrive calculations
@@ -1541,7 +1541,7 @@ class PortalClient(PortalClientBase):
         }
 
         filter_data = TorsiondriveQueryFilters(**filter_dict)
-        return RecordQueryIterator[TorsiondriveRecord](self, filter_data, "torsiondrive", include)
+        return RecordQueryIterator[TorsiondriveRecord](self, filter_data, TorsiondriveRecord, include)
 
     ##############################################################
     # Grid optimization calculations
@@ -1754,7 +1754,7 @@ class PortalClient(PortalClientBase):
         }
 
         filter_data = GridoptimizationQueryFilters(**filter_dict)
-        return RecordQueryIterator[GridoptimizationRecord](self, filter_data, "gridoptimization", include)
+        return RecordQueryIterator[GridoptimizationRecord](self, filter_data, GridoptimizationRecord, include)
 
     ##############################################################
     # Reactions
@@ -1975,7 +1975,7 @@ class PortalClient(PortalClientBase):
         }
 
         filter_data = ReactionQueryFilters(**filter_dict)
-        return RecordQueryIterator[ReactionRecord](self, filter_data, "reaction", include)
+        return RecordQueryIterator[ReactionRecord](self, filter_data, ReactionRecord, include)
 
     ##############################################################
     # Manybody calculations
@@ -2183,7 +2183,7 @@ class PortalClient(PortalClientBase):
         }
 
         filter_data = ManybodyQueryFilters(**filter_dict)
-        return RecordQueryIterator[ManybodyRecord](self, filter_data, "manybody", include)
+        return RecordQueryIterator[ManybodyRecord](self, filter_data, ManybodyRecord, include)
 
     ##############################################################
     # NEB
@@ -2397,7 +2397,7 @@ class PortalClient(PortalClientBase):
         }
 
         filter_data = NEBQueryFilters(**filter_dict)
-        return RecordQueryIterator[NEBRecord](self, filter_data, "neb", include)
+        return RecordQueryIterator[NEBRecord](self, filter_data, NEBRecord, include)
 
     ##############################################################
     # Managers

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -625,6 +625,11 @@ class PortalClient(PortalClientBase):
             record_batch = [record_type(self, **r) if r is not None else None for r in record_data]
             all_records.extend(record_batch)
 
+        # In general, fetching children should only happen if the metadata for the children
+        # is requested via include. So we always say True here, and it won't recursively download
+        # children if that data is missing.
+        record_type.fetch_children_multi(all_records, True)
+
         if is_single:
             return all_records[0]
         else:

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -122,6 +122,7 @@ class PortalClient(PortalClientBase):
         *,
         cache_dir: Optional[str] = None,
         cache_max_size: int = 0,
+        shared_memory_cache: bool = True,
     ) -> None:
         """
         Parameters
@@ -143,11 +144,15 @@ class PortalClient(PortalClientBase):
             Directory to store an internal cache of records and other data
         cache_max_size
             Maximum size of the cache directory
+        shared_memory_cache
+            If True (and cache_dir is not specified), the memory-backed cache will be marked as shared,
+            meaning that multiple instances of the PortalClient can share the same cache, as well as making the
+            cache shared among threads. Generally, this is what you want, but
         """
 
         PortalClientBase.__init__(self, address, username, password, verify, show_motd)
         self._logger = logging.getLogger("PortalClient")
-        self.cache = PortalCache(address, cache_dir, cache_max_size)
+        self.cache = PortalCache(address, cache_dir, cache_max_size, shared_memory_cache)
 
     def __repr__(self) -> str:
         """A short representation of the current PortalClient.

--- a/qcportal/qcportal/client_base.py
+++ b/qcportal/qcportal/client_base.py
@@ -128,6 +128,14 @@ class PortalClientBase:
         self.retry_backoff = 2
         self.retry_jitter_fraction = 0.05
 
+        # Processing/downloading in threads
+        # Number of threads to use when fetching from the server
+        self.n_download_threads = 2
+
+        # Target time for how long a request should take (in seconds)
+        # Chunk size will be adjusted to try to reach this target time
+        self.download_target_time = 0.50
+
         # If no 3rd party verification, quiet urllib
         if self._verify is False:
             from urllib3.exceptions import InsecureRequestWarning

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -36,7 +36,7 @@ from qcportal.metadata_models import DeleteMetadata
 from qcportal.metadata_models import InsertMetadata
 from qcportal.record_models import PriorityEnum, RecordStatusEnum, BaseRecord
 from qcportal.utils import make_list, chunk_iterable
-from qcportal.cache import DatasetCache, read_dataset_metadata
+from qcportal.cache import DatasetCache, read_dataset_metadata, get_records_with_cache
 
 if TYPE_CHECKING:
     from qcportal.client import PortalClient
@@ -862,7 +862,9 @@ class BaseDataset(BaseModel):
         )
 
         record_ids = [x[2] for x in record_info]
-        records = self._client._get_records_by_type(self._record_type, record_ids, include=include)
+
+        # This function always fetches, so force_fetch = True
+        records = get_records_with_cache(self._client, self._cache_data, self._record_type, record_ids, include, True)
 
         # Update the locally-stored records
         # zip(record_info, records) = ((entry_name, spec_name, record_id), record)

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -866,6 +866,13 @@ class BaseDataset(BaseModel):
         # This function always fetches, so force_fetch = True
         records = get_records_with_cache(self._client, self._cache_data, self._record_type, record_ids, include, True)
 
+        # TODO - kinda hacky? We don't want the records to write themselves back to the cache on
+        #        destruction, so detach them
+        # Update the records in bulk, then detach from the record_cache so they don't write back on destruction
+        self._cache_data.update_records(records)
+        for record in records:
+            record._record_cache = None
+
         # Update the locally-stored records
         # zip(record_info, records) = ((entry_name, spec_name, record_id), record)
         update_info = [(ename, sname, r) for (ename, sname, _), r in zip(record_info, records)]

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -823,15 +823,18 @@ class BaseDataset(BaseModel):
         specification_names: Iterable[str],
         status: Optional[Iterable[RecordStatusEnum]],
         include: Optional[Iterable[str]],
-    ) -> None:
+    ) -> List[Tuple[str, str, BaseRecord]]:
         """
-        Fetches record information from the remote server, storing it internally
+        Fetches records from the remote server
 
         This does not do any checking for existing records, but is used to actually
         request the data from the server.
 
         Note: This function does not do any batching w.r.t. server API limits. It is expected that is done
-        before this function is called.
+        before this function is called. This function also does not look up records in the cache, but does
+        attach the cache to the records.
+
+        Note: Records are not returned in any particular order
 
         Parameters
         ----------
@@ -843,10 +846,15 @@ class BaseDataset(BaseModel):
             Fetch only records with these statuses
         include
             Additional fields/data to include when fetch the entry
+
+        Returns
+        -------
+        :
+            List of tuples (entry_name, spec_name, record)
         """
 
         if not (entry_names and specification_names):
-            return
+            return []
 
         # First, we need the corresponding entries and specifications
         self.fetch_entries(entry_names)
@@ -864,19 +872,15 @@ class BaseDataset(BaseModel):
         record_ids = [x[2] for x in record_info]
 
         # This function always fetches, so force_fetch = True
+        # But records will be attached to thee cache
         records = get_records_with_cache(self._client, self._cache_data, self._record_type, record_ids, include, True)
 
-        # TODO - kinda hacky? We don't want the records to write themselves back to the cache on
-        #        destruction, so detach them
-        # Update the records in bulk, then detach from the record_cache so they don't write back on destruction
-        self._cache_data.update_records(records)
-        for record in records:
-            record._record_cache = None
-
-        # Update the locally-stored records
+        # Update the locally-stored metadata for these dataset records
         # zip(record_info, records) = ((entry_name, spec_name, record_id), record)
         update_info = [(ename, sname, r) for (ename, sname, _), r in zip(record_info, records)]
         self._cache_data.update_dataset_records(update_info)
+
+        return update_info
 
     def _internal_update_records(
         self,
@@ -884,12 +888,9 @@ class BaseDataset(BaseModel):
         specification_names: Iterable[str],
         status: Optional[Iterable[RecordStatusEnum]],
         include: Optional[Iterable[str]],
-    ):
+    ) -> List[Tuple[str, str, BaseRecord]]:
         """
-        Update local record information if it has been modified on the server
-
-        Note: This function does not do any batching w.r.t. server API limits. It is expected that is done
-        before this function is called.
+        Update local record information if the record has been modified on the server
 
         Parameters
         ----------
@@ -904,23 +905,20 @@ class BaseDataset(BaseModel):
         """
 
         if not (entry_names and specification_names):
-            return
-
-        # Only update records if the record in the local cache as one of the following statuses
-        updateable_statuses = (RecordStatusEnum.waiting, RecordStatusEnum.running, RecordStatusEnum.error)
+            return []
 
         # Returns list of tuple (entry name, spec_name, id, status, modified_on) of records
         # we have our local cache
-        updateable_record_info = self._cache_data.get_dataset_record_info(
-            entry_names, specification_names, updateable_statuses
-        )
+        updateable_record_info = self._cache_data.get_dataset_record_info(entry_names, specification_names, None)
+
         # print(f"UPDATEABLE RECORDS: {len(updateable_record_info)}")
         if not updateable_record_info:
-            return
+            return []
 
         batch_size = math.ceil(self._client.api_limits["get_records"] / 4)
-        record_modified_map: Dict[int, datetime] = {}  # record_id -> modified time
+        server_modified_time: Dict[int, datetime] = {}  # record_id -> modified time on server
 
+        # Find out which records have been updated on the server
         for record_info_batch in chunk_iterable(updateable_record_info, batch_size):
             record_id_batch = [x[2] for x in record_info_batch]
 
@@ -937,12 +935,12 @@ class BaseDataset(BaseModel):
             for sri in server_record_info:
                 # Only store if the status on the server matches what the caller wants
                 if status is None or sri["status"] in status:
-                    record_modified_map[sri["id"]] = pydantic.parse_obj_as(datetime, sri["modified_on"])
+                    server_modified_time[sri["id"]] = pydantic.parse_obj_as(datetime, sri["modified_on"])
 
         # Which ones need to be fully updated
         need_updating: Dict[str, List[str]] = {}  # key is specification, value is list of entry names
         for entry_name, spec_name, record_id, _, local_mtime in updateable_record_info:
-            server_mtime = record_modified_map.get(record_id, None)
+            server_mtime = server_modified_time.get(record_id, None)
 
             # Perhaps the record doesn't exist on the server anymore or something
             if server_mtime is None:
@@ -954,9 +952,15 @@ class BaseDataset(BaseModel):
 
         # Update from the server one spec at a time
         # print(f"Updated on server: {len(needs_updating)}")
+        updated_records = []
+
         for spec_name, entries_to_update in need_updating.items():
             for entries_batch in chunk_iterable(entries_to_update, batch_size):
-                self._internal_fetch_records(entries_batch, [spec_name], None, include)
+                # Updates dataset record metadata if needed
+                r = self._internal_fetch_records(entries_batch, [spec_name], None, include)
+                updated_records.extend(r)
+
+        return updated_records
 
     def fetch_records(
         self,
@@ -1014,27 +1018,44 @@ class BaseDataset(BaseModel):
         # Determine the number of entries in each batch
         # Assume there are many more entries than specifications, and that
         # everything has been submitted
-        # Divide by 4 to go easy on the server
-        batch_size: int = math.ceil(self._client.api_limits["get_records"] / 4)
+        batch_size: int = math.ceil(self._client.api_limits["get_records"])
+        n_batches = math.ceil(len(entry_names) / batch_size)
 
         # Do all entries for one spec. This simplifies things, especially with handling
         # existing or update-able records
         for spec_name in specification_names:
-            for entry_names_batch in chunk_iterable(entry_names, batch_size):
+            for entry_names_batch in tqdm(chunk_iterable(entry_names, batch_size), total=n_batches, disable=None):
+                records_batch = []
+
                 # Handle existing records that need to be updated
-                if fetch_updated and not force_refetch:
-                    self._internal_update_records(entry_names_batch, [spec_name], status, include)
-
                 if force_refetch:
-                    batch_tofetch = entry_names_batch
-                else:
-                    # Filter if they already exist in the local cache
-                    cached_records = self._cache_data.get_existing_dataset_records(entry_names_batch, [spec_name])
-                    cached_record_entries = [x[0] for x in cached_records]
-                    batch_tofetch = [x for x in entry_names_batch if x not in cached_record_entries]
+                    r = self._internal_fetch_records(entry_names_batch, [spec_name], status, include)
+                    records_batch.extend(r)
 
-                if batch_tofetch:
-                    self._internal_fetch_records(entry_names_batch, [spec_name], status, include)
+                else:
+                    missing_entries = entry_names_batch.copy()
+
+                    if fetch_updated:
+                        updated_records = self._internal_update_records(missing_entries, [spec_name], status, include)
+                        records_batch.extend(updated_records)
+
+                        # what wasn't updated
+                        updated_entries = [x for x, _, _ in updated_records]
+                        missing_entries = [e for e in entry_names_batch if e not in updated_entries]
+
+                    # Check if we have any cached records
+                    cached_records = self._cache_data.get_dataset_records(missing_entries, [spec_name])
+                    records_batch.extend(cached_records)
+
+                    # what we need to fetch from the server
+                    cached_entries = [x[0] for x in cached_records]
+                    missing_entries = [e for e in missing_entries if e not in cached_entries]
+
+                    fetched_records = self._internal_fetch_records(missing_entries, [spec_name], status, include)
+                    records_batch.extend(fetched_records)
+
+                # Write the record batch to the cache at once. Also marks the records as clean (no need to writeback)
+                self._cache_data.update_records([r for _, _, r in records_batch])
 
     def get_record(
         self,
@@ -1055,22 +1076,23 @@ class BaseDataset(BaseModel):
             fetch_updated = False
             force_refetch = False
 
+        record = None
         if force_refetch:
-            self._internal_fetch_records([entry_name], [specification_name], None, include)
+            records = self._internal_fetch_records([entry_name], [specification_name], None, include)
+            record = records[0][2]
         elif fetch_updated:
-            self._internal_update_records([entry_name], [specification_name], None, include)
+            records = self._internal_update_records([entry_name], [specification_name], None, include)
+            if records:
+                record = records[0][2]
 
-        record = self._cache_data.get_dataset_record(entry_name, specification_name)
+        if record is None:
+            # Attempt to get from cache
+            record = self._cache_data.get_dataset_record(entry_name, specification_name)
 
         if record is None and not self.is_view:
-            self.fetch_records(
-                entry_name,
-                specification_name,
-                include=include,
-                fetch_updated=fetch_updated,
-                force_refetch=force_refetch,
-            )
-            record = self._cache_data.get_dataset_record(entry_name, specification_name)
+            # not in cache
+            records = self._internal_fetch_records([entry_name], [specification_name], None, include)
+            record = records[0][2]
 
         if record is not None and self._client is not None:
             record.propagate_client(self._client)
@@ -1118,40 +1140,48 @@ class BaseDataset(BaseModel):
         if self.is_view:
             for spec_name in specification_names:
                 for entry_names_batch in chunk_iterable(entry_names, 125):
-                    record_data = self._cache_data.get_dataset_records(entry_names_batch, [spec_name])
+                    record_data = self._cache_data.get_dataset_records(entry_names_batch, [spec_name], status)
 
                     for e, s, r in record_data:
-                        if status is None or r.status in status:
-                            yield e, s, r
+                        yield e, s, r
         else:
-            # Smaller fetch limit for iteration (than in fetch_records)
-            batch_size: int = math.ceil(self._client.api_limits["get_records"] / 10)
+            batch_size: int = math.ceil(self._client.api_limits["get_records"])
 
             for spec_name in specification_names:
                 for entry_names_batch in chunk_iterable(entry_names, batch_size):
+                    records_batch = []
+
                     # Handle existing records that need to be updated
-                    if fetch_updated and not force_refetch:
-                        self._internal_update_records(entry_names_batch, [spec_name], status, include)
-
                     if force_refetch:
-                        batch_tofetch = entry_names_batch
+                        r = self._internal_fetch_records(entry_names_batch, [spec_name], status, include)
+                        records_batch.extend(r)
+
                     else:
-                        # Filter if they already exist in the local cache
-                        existing_records = self._cache_data.get_existing_dataset_records(entry_names_batch, [spec_name])
-                        existing_entries = [x[0] for x in existing_records]
-                        batch_tofetch = [x for x in entry_names_batch if x not in existing_entries]
+                        missing_entries = entry_names_batch.copy()
 
-                    if batch_tofetch:
-                        self._internal_fetch_records(batch_tofetch, [spec_name], status, include)
+                        if fetch_updated:
+                            updated_records = self._internal_update_records(
+                                missing_entries, [spec_name], status, include
+                            )
+                            records_batch.extend(updated_records)
 
-                    # Now lookup the just-fetched records and yield them
-                    record_data = self._cache_data.get_dataset_records(entry_names_batch, [spec_name])
+                            # what wasn't updated
+                            updated_entries = [x for x, _, _ in updated_records]
+                            missing_entries = [e for e in entry_names_batch if e not in updated_entries]
 
-                    if self._client is not None:
-                        for _, _, r in record_data:
-                            r.propagate_client(self._client)
+                        # Check if we have any cached records
+                        cached_records = self._cache_data.get_dataset_records(missing_entries, [spec_name])
+                        records_batch.extend(cached_records)
 
-                    for e, s, r in record_data:
+                        # what we need to fetch from the server
+                        cached_entries = [x[0] for x in cached_records]
+                        missing_entries = [e for e in missing_entries if e not in cached_entries]
+
+                        fetched_records = self._internal_fetch_records(missing_entries, [spec_name], status, include)
+                        records_batch.extend(fetched_records)
+
+                    # Let the writeback mechanism handle writing to the cache
+                    for e, s, r in records_batch:
                         if status is None or r.status in status:
                             yield e, s, r
 
@@ -1179,6 +1209,10 @@ class BaseDataset(BaseModel):
             None,
             body=body,
         )
+
+        if delete_records:
+            record_info = self._cache_data.get_dataset_records(entry_names, specification_names)
+            self._cache_data.delete_records([r.id for _, _, r in record_info])
 
         self._cache_data.delete_dataset_records(entry_names, specification_names)
 
@@ -1215,8 +1249,6 @@ class BaseDataset(BaseModel):
             body=body,
         )
 
-        self._cache_data.delete_dataset_records(entry_names, specification_names)
-
         if refetch_records:
             self.fetch_records(entry_names, specification_names, force_refetch=True)
 
@@ -1247,8 +1279,6 @@ class BaseDataset(BaseModel):
             None,
             body=body,
         )
-
-        self._cache_data.delete_dataset_records(entry_names, specification_names)
 
         if refetch_records:
             self.fetch_records(entry_names, specification_names, force_refetch=True)
@@ -1281,8 +1311,6 @@ class BaseDataset(BaseModel):
             body=body,
         )
 
-        self._cache_data.delete_dataset_records(entry_names, specification_names)
-
         if refetch_records:
             self.fetch_records(entry_names, specification_names, force_refetch=True)
 
@@ -1313,8 +1341,6 @@ class BaseDataset(BaseModel):
             None,
             body=body,
         )
-
-        self._cache_data.delete_dataset_records(entry_names, specification_names)
 
         if refetch_records:
             self.fetch_records(entry_names, specification_names, force_refetch=True)
@@ -1347,8 +1373,6 @@ class BaseDataset(BaseModel):
             body=body,
         )
 
-        self._cache_data.delete_dataset_records(entry_names, specification_names)
-
         if refetch_records:
             self.fetch_records(entry_names, specification_names, force_refetch=True)
 
@@ -1379,8 +1403,6 @@ class BaseDataset(BaseModel):
             None,
             body=body,
         )
-
-        self._cache_data.delete_dataset_records(entry_names, specification_names)
 
         if refetch_records:
             self.fetch_records(entry_names, specification_names, force_refetch=True)

--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -501,9 +501,12 @@ def run_dataset_model_modify_records(ds, test_entries, test_spec):
     assert rec2.status == RecordStatusEnum.waiting
 
     # Single record
+    print("cancelling")
     ds.cancel_records(entry_name, spec_name)
     rec = ds.get_record(entry_name, spec_name)
     rec2 = ds.get_record(entry_name_2, spec_name)
+    print(rec)
+    print(rec2)
     assert rec.status == RecordStatusEnum.cancelled
     assert rec2.status == RecordStatusEnum.waiting
 

--- a/qcportal/qcportal/gridoptimization/record_models.py
+++ b/qcportal/qcportal/gridoptimization/record_models.py
@@ -225,7 +225,7 @@ class GridoptimizationRecord(BaseRecord):
 
         include = ["**"] if recursive else None
         opt_ids = list(opt_ids)
-        opt_records = get_records_with_cache(client, record_cache, opt_ids, OptimizationRecord, include=include)
+        opt_records = get_records_with_cache(client, record_cache, OptimizationRecord, opt_ids, include=include)
         opt_map = {x.id: x for x in opt_records}
 
         for r in records:

--- a/qcportal/qcportal/gridoptimization/record_models.py
+++ b/qcportal/qcportal/gridoptimization/record_models.py
@@ -244,19 +244,6 @@ class GridoptimizationRecord(BaseRecord):
 
         self.propagate_client(self._client)
 
-    def _handle_includes(self, includes: Optional[Iterable[str]]):
-        if includes is None:
-            return
-
-        BaseRecord._handle_includes(self, includes)
-
-        if "initial_molecule" in includes:
-            self._fetch_initial_molecule()
-        if "starting_molecule" in includes:
-            self._fetch_starting_molecule()
-        if "optimizations" in includes:
-            self._fetch_optimizations()
-
     @property
     def initial_molecule(self) -> Molecule:
         if self.initial_molecule_ is None:

--- a/qcportal/qcportal/gridoptimization/record_models.py
+++ b/qcportal/qcportal/gridoptimization/record_models.py
@@ -212,7 +212,9 @@ class GridoptimizationRecord(BaseRecord):
                 opt.propagate_client(client)
 
     @classmethod
-    def _fetch_children_multi(cls, client, record_cache, records: Iterable[GridoptimizationRecord], recursive: bool):
+    def _fetch_children_multi(
+        cls, client, record_cache, records: Iterable[GridoptimizationRecord], recursive: bool, force_fetch: bool = False
+    ):
         # Should be checked by the calling function
         assert records
         assert all(isinstance(x, GridoptimizationRecord) for x in records)
@@ -225,7 +227,9 @@ class GridoptimizationRecord(BaseRecord):
 
         include = ["**"] if recursive else None
         opt_ids = list(opt_ids)
-        opt_records = get_records_with_cache(client, record_cache, OptimizationRecord, opt_ids, include=include)
+        opt_records = get_records_with_cache(
+            client, record_cache, OptimizationRecord, opt_ids, include=include, force_fetch=force_fetch
+        )
         opt_map = {x.id: x for x in opt_records}
 
         for r in records:
@@ -248,7 +252,6 @@ class GridoptimizationRecord(BaseRecord):
         self.starting_molecule_ = self._client.get_molecules([self.starting_molecule_id])[0]
 
     def _fetch_optimizations(self):
-        # Always fetch optimization metadata if we can
         if self.optimizations_ is None:
             self._assert_online()
             self.optimizations_ = self._client.make_request(

--- a/qcportal/qcportal/gridoptimization/record_models.py
+++ b/qcportal/qcportal/gridoptimization/record_models.py
@@ -190,11 +190,11 @@ class GridoptimizationRecord(BaseRecord):
     starting_molecule_id: Optional[int]
 
     ######################################################
-    # Fields not included when fetching the record
+    # Fields not always included when fetching the record
     ######################################################
-    initial_molecule_: Optional[Molecule] = None
-    starting_molecule_: Optional[Molecule] = None
-    optimizations_: Optional[List[GridoptimizationOptimization]] = None
+    initial_molecule_: Optional[Molecule] = Field(None, alias="initial_molecule")
+    starting_molecule_: Optional[Molecule] = Field(None, alias="starting_molecule")
+    optimizations_: Optional[List[GridoptimizationOptimization]] = Field(None, alias="optimizations")
 
     ########################################
     # Caches

--- a/qcportal/qcportal/gridoptimization/test_record_models.py
+++ b/qcportal/qcportal/gridoptimization/test_record_models.py
@@ -12,7 +12,7 @@ from qcportal.record_models import RecordStatusEnum
 if TYPE_CHECKING:
     from qcarchivetesting.testing_classes import QCATestingSnowflake
 
-all_includes = ["initial_molecule", "starting_molecule", "optimizations"]
+all_includes = ["initial_molecule", "starting_molecule", "optimizations", "final_molecule", "initial_molecule"]
 
 
 @pytest.mark.parametrize("includes", [None, ["**"], all_includes])

--- a/qcportal/qcportal/gridoptimization/test_record_models.py
+++ b/qcportal/qcportal/gridoptimization/test_record_models.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional, List
 import pytest
 
 from qcfractal.components.gridoptimization.testing_helpers import run_test_data, load_test_data
+from qcportal.gridoptimization import deserialize_key
 from qcportal.molecules import Molecule
 from qcportal.record_models import RecordStatusEnum
 
@@ -14,8 +15,8 @@ if TYPE_CHECKING:
 all_includes = ["initial_molecule", "starting_molecule", "optimizations"]
 
 
-@pytest.mark.parametrize("includes", [None, all_includes])
-def test_gridoptimizationrecord_model(snowflake: QCATestingSnowflake, includes: Optional[List[str]]):
+@pytest.mark.parametrize("includes", [None, ["**"], all_includes])
+def test_gridoptimization_record_model(snowflake: QCATestingSnowflake, includes: Optional[List[str]]):
     storage_socket = snowflake.get_storage_socket()
     snowflake_client = snowflake.client()
     activated_manager_name, _ = snowflake.activate_manager()
@@ -26,8 +27,18 @@ def test_gridoptimizationrecord_model(snowflake: QCATestingSnowflake, includes: 
     record = snowflake_client.get_gridoptimizations(rec_id, include=includes)
 
     if includes is not None:
-        record._client = None
+        assert record.initial_molecule_ is not None
+        assert record.optimizations_ is not None
+        record.propagate_client(None)
         assert record.offline
+
+        # children have all data fetched
+        assert all(x.initial_molecule_ is not None for x in record._optimizations_cache.values())
+        assert all(x.final_molecule_ is not None for x in record._optimizations_cache.values())
+    else:
+        assert record.initial_molecule_ is None
+        assert record.optimizations_ is None
+        assert record._optimizations_cache is None
 
     assert record.id == rec_id
     assert record.status == RecordStatusEnum.complete
@@ -42,3 +53,8 @@ def test_gridoptimizationrecord_model(snowflake: QCATestingSnowflake, includes: 
 
     opts = record.optimizations
     assert len(opts) == len(results)
+
+    # ids match
+    for opt_meta in record.optimizations_:
+        k = deserialize_key(opt_meta.key)
+        assert opts[k].id == opt_meta.optimization_id

--- a/qcportal/qcportal/manybody/__init__.py
+++ b/qcportal/qcportal/manybody/__init__.py
@@ -8,7 +8,7 @@ from .record_models import (
     BSSECorrectionEnum,
     ManybodyKeywords,
     ManybodySpecification,
-    ManybodyCluster,
+    ManybodyClusterMeta,
     ManybodyAddBody,
     ManybodyRecord,
     ManybodyQueryFilters,

--- a/qcportal/qcportal/manybody/record_models.py
+++ b/qcportal/qcportal/manybody/record_models.py
@@ -2,9 +2,9 @@ from enum import Enum
 from typing import List, Union, Optional, Dict, Any, Iterable
 
 try:
-    from pydantic.v1 import BaseModel, Extra, validator, constr, PrivateAttr
+    from pydantic.v1 import BaseModel, Extra, validator, constr, PrivateAttr, Field
 except ImportError:
-    from pydantic import BaseModel, Extra, validator, constr, PrivateAttr
+    from pydantic import BaseModel, Extra, validator, constr, PrivateAttr, Field
 from typing_extensions import Literal
 
 from qcportal.molecules import Molecule
@@ -78,9 +78,9 @@ class ManybodyRecord(BaseRecord):
     initial_molecule_id: int
 
     ######################################################
-    # Fields not included when fetching the record
+    # Fields not always included when fetching the record
     ######################################################
-    initial_molecule_: Optional[Molecule] = None
+    initial_molecule_: Optional[Molecule] = Field(None, alias="initial_molecule")
 
     ########################################
     # Caches

--- a/qcportal/qcportal/manybody/record_models.py
+++ b/qcportal/qcportal/manybody/record_models.py
@@ -117,7 +117,7 @@ class ManybodyRecord(BaseRecord):
 
         include = ["**"] if recursive else None
         sp_ids = list(sp_ids)
-        sp_recs = get_records_with_cache(client, record_cache, sp_ids, SinglepointRecord, include=include)
+        sp_recs = get_records_with_cache(client, record_cache, SinglepointRecord, sp_ids, include=include)
         sp_map = {x.id: x for x in sp_recs}
 
         for r in records:

--- a/qcportal/qcportal/manybody/record_models.py
+++ b/qcportal/qcportal/manybody/record_models.py
@@ -140,17 +140,6 @@ class ManybodyRecord(BaseRecord):
 
         self.propagate_client(self._client)
 
-    def _handle_includes(self, includes: Optional[Iterable[str]]):
-        if includes is None:
-            return
-
-        BaseRecord._handle_includes(self, includes)
-
-        if "initial_molecule" in includes:
-            self._fetch_initial_molecule()
-        if "clusters" in includes:
-            self._fetch_clusters()
-
     @property
     def initial_molecule(self) -> Molecule:
         if self.initial_molecule_ is None:

--- a/qcportal/qcportal/manybody/test_record_models.py
+++ b/qcportal/qcportal/manybody/test_record_models.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from qcarchivetesting.testing_classes import QCATestingSnowflake
 
 
-all_includes = ["initial_molecule", "clusters"]
+all_includes = ["initial_molecule", "clusters", "molecule", "comments"]
 
 
 @pytest.mark.parametrize("includes", [None, ["**"], all_includes])

--- a/qcportal/qcportal/neb/record_models.py
+++ b/qcportal/qcportal/neb/record_models.py
@@ -245,21 +245,6 @@ class NEBRecord(BaseRecord):
             Optional[Molecule],
         )
 
-    def _handle_includes(self, includes: Optional[Iterable[str]]):
-        if includes is None:
-            return
-
-        BaseRecord._handle_includes(self, includes)
-
-        if "initial_chain" in includes:
-            self._fetch_initial_chain()
-        if "singlepoints" in includes:
-            self._fetch_singlepoints()
-        if "optimizations" in includes:
-            self._fetch_optimizations()
-        if "result" in includes:
-            self._fetch_neb_result()
-
     @property
     def initial_chain(self) -> List[Molecule]:
         if self.initial_chain_ is None:

--- a/qcportal/qcportal/neb/record_models.py
+++ b/qcportal/qcportal/neb/record_models.py
@@ -130,14 +130,14 @@ class NEBRecord(BaseRecord):
     specification: NEBSpecification
 
     ######################################################
-    # Fields not included when fetching the record
+    # Fields not always included when fetching the record
     ######################################################
-    initial_chain_molecule_ids_: Optional[List[int]] = None
-    singlepoints_: Optional[List[NEBSinglepoint]] = None
-    optimizations_: Optional[Dict[str, NEBOptimization]] = None
-    ts_hessian_: Optional[SinglepointRecord] = None
-    neb_result_: Optional[Molecule] = None
-    initial_chain_: Optional[List[Molecule]] = None
+    initial_chain_molecule_ids_: Optional[List[int]] = Field(None, alias="initial_chain_molecule_ids")
+    singlepoints_: Optional[List[NEBSinglepoint]] = Field(None, alias="singlepoints")
+    optimizations_: Optional[Dict[str, NEBOptimization]] = Field(None, alias="optimizations")
+    ts_hessian_: Optional[SinglepointRecord] = Field(None, alias="ts_hessian")
+    neb_result_: Optional[Molecule] = Field(None, alias="neb_result")
+    initial_chain_: Optional[List[Molecule]] = Field(None, alias="initial_chain")
 
     ########################################
     # Caches

--- a/qcportal/qcportal/neb/record_models.py
+++ b/qcportal/qcportal/neb/record_models.py
@@ -180,8 +180,8 @@ class NEBRecord(BaseRecord):
         sp_ids = list(sp_ids)
         opt_ids = list(opt_ids)
 
-        sp_records = get_records_with_cache(client, record_cache, sp_ids, SinglepointRecord, include=include)
-        opt_records = get_records_with_cache(client, record_cache, opt_ids, OptimizationRecord, include=include)
+        sp_records = get_records_with_cache(client, record_cache, SinglepointRecord, sp_ids, include=include)
+        opt_records = get_records_with_cache(client, record_cache, OptimizationRecord, opt_ids, include=include)
 
         sp_map = {r.id: r for r in sp_records}
         opt_map = {r.id: r for r in opt_records}

--- a/qcportal/qcportal/neb/test_record_models.py
+++ b/qcportal/qcportal/neb/test_record_models.py
@@ -10,7 +10,7 @@ from qcportal.record_models import RecordStatusEnum
 if TYPE_CHECKING:
     from qcarchivetesting.testing_classes import QCATestingSnowflake
 
-all_includes = ["initial_chain", "singlepoints", "optimizations"]
+all_includes = ["initial_chain", "singlepoints", "optimizations", "molecule", "comments", "initial_molecule"]
 
 
 @pytest.mark.parametrize("includes", [None, ["**"], all_includes])

--- a/qcportal/qcportal/optimization/record_models.py
+++ b/qcportal/qcportal/optimization/record_models.py
@@ -80,7 +80,7 @@ class OptimizationRecord(BaseRecord):
 
         include = ["**"] if recursive else None
         sp_ids = list(sp_ids)
-        sp_records = get_records_with_cache(client, record_cache, sp_ids, SinglepointRecord, include=include)
+        sp_records = get_records_with_cache(client, record_cache, SinglepointRecord, sp_ids, include=include)
         sp_map = {r.id: r for r in sp_records}
 
         for r in records:

--- a/qcportal/qcportal/optimization/record_models.py
+++ b/qcportal/qcportal/optimization/record_models.py
@@ -99,19 +99,6 @@ class OptimizationRecord(BaseRecord):
         self._trajectory_records = self._get_child_records(self.trajectory_ids_, SinglepointRecord)
         self.propagate_client(self._client)
 
-    def _handle_includes(self, includes: Optional[Iterable[str]]):
-        if includes is None:
-            return
-
-        BaseRecord._handle_includes(self, includes)
-
-        if "initial_molecule" in includes:
-            self._fetch_initial_molecule()
-        if "final_molecule" in includes:
-            self._fetch_final_molecule()
-        if "trajectory" in includes:
-            self._fetch_trajectory()
-
     @property
     def initial_molecule(self) -> Molecule:
         if self.initial_molecule_ is None:

--- a/qcportal/qcportal/optimization/record_models.py
+++ b/qcportal/qcportal/optimization/record_models.py
@@ -51,11 +51,11 @@ class OptimizationRecord(BaseRecord):
     energies: Optional[List[float]]
 
     ######################################################
-    # Fields not included when fetching the record
+    # Fields not always included when fetching the record
     ######################################################
-    initial_molecule_: Optional[Molecule] = None
-    final_molecule_: Optional[Molecule] = None
-    trajectory_ids_: Optional[List[int]] = None
+    initial_molecule_: Optional[Molecule] = Field(None, alias="initial_molecule")
+    final_molecule_: Optional[Molecule] = Field(None, alias="final_molecule")
+    trajectory_ids_: Optional[List[int]] = Field(None, alias="trajectory")
 
     ########################################
     # Caches

--- a/qcportal/qcportal/optimization/record_models.py
+++ b/qcportal/qcportal/optimization/record_models.py
@@ -67,7 +67,9 @@ class OptimizationRecord(BaseRecord):
     _trajectory_records: Optional[List[SinglepointRecord]] = PrivateAttr(None)
 
     @classmethod
-    def _fetch_children_multi(cls, client, record_cache, records: Iterable[OptimizationRecord], recursive: bool):
+    def _fetch_children_multi(
+        cls, client, record_cache, records: Iterable[OptimizationRecord], recursive: bool, force_fetch: bool = False
+    ):
         # Should be checked by the calling function
         assert records
         assert all(isinstance(x, OptimizationRecord) for x in records)
@@ -80,7 +82,9 @@ class OptimizationRecord(BaseRecord):
 
         include = ["**"] if recursive else None
         sp_ids = list(sp_ids)
-        sp_records = get_records_with_cache(client, record_cache, SinglepointRecord, sp_ids, include=include)
+        sp_records = get_records_with_cache(
+            client, record_cache, SinglepointRecord, sp_ids, include=include, force_fetch=force_fetch
+        )
         sp_map = {r.id: r for r in sp_records}
 
         for r in records:

--- a/qcportal/qcportal/optimization/test_record_models.py
+++ b/qcportal/qcportal/optimization/test_record_models.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from qcarchivetesting.testing_classes import QCATestingSnowflake
 
 
-all_includes = ["initial_molecule", "final_molecule", "trajectory"]
+all_includes = ["initial_molecule", "final_molecule", "trajectory", "molecule"]
 
 
 @pytest.mark.parametrize("includes", [None, ["**"], all_includes])

--- a/qcportal/qcportal/optimization/test_record_models.py
+++ b/qcportal/qcportal/optimization/test_record_models.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 all_includes = ["initial_molecule", "final_molecule", "trajectory"]
 
 
-@pytest.mark.parametrize("includes", [None, all_includes])
-def test_optimizationrecord_model(snowflake: QCATestingSnowflake, includes: Optional[List[str]]):
+@pytest.mark.parametrize("includes", [None, ["**"], all_includes])
+def test_optimization_record_model(snowflake: QCATestingSnowflake, includes: Optional[List[str]]):
     storage_socket = snowflake.get_storage_socket()
     snowflake_client = snowflake.client()
     activated_manager_name, _ = snowflake.activate_manager()
@@ -27,8 +27,13 @@ def test_optimizationrecord_model(snowflake: QCATestingSnowflake, includes: Opti
     record = snowflake_client.get_optimizations(rec_id, include=includes)
 
     if includes is not None:
-        record._client = None
+        assert record.initial_molecule_ is not None
+        assert record.trajectory_ids_ is not None
+        record.propagate_client(None)
         assert record.offline
+    else:
+        assert record.initial_molecule_ is None
+        assert record.trajectory_ids_ is None
 
     assert record.id == rec_id
     assert record.status == RecordStatusEnum.complete
@@ -47,3 +52,8 @@ def test_optimizationrecord_model(snowflake: QCATestingSnowflake, includes: Opti
 
     traj_energy = [x.properties["return_energy"] for x in traj]
     assert traj_energy == record.energies
+
+    # Children have all their data fetched
+    if includes is not None:
+        assert all(x.molecule_ is not None for x in traj)
+    assert all(x.molecule is not None for x in traj)

--- a/qcportal/qcportal/reaction/__init__.py
+++ b/qcportal/qcportal/reaction/__init__.py
@@ -7,7 +7,7 @@ from .dataset_models import (
 from .record_models import (
     ReactionSpecification,
     ReactionKeywords,
-    ReactionComponent,
+    ReactionComponentMeta,
     ReactionAddBody,
     ReactionRecord,
     ReactionQueryFilters,

--- a/qcportal/qcportal/reaction/record_models.py
+++ b/qcportal/qcportal/reaction/record_models.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 from typing import List, Union, Optional, Tuple, Iterable
 
 try:
-    from pydantic.v1 import BaseModel, Extra, root_validator, constr, PrivateAttr
+    from pydantic.v1 import BaseModel, Extra, root_validator, constr, PrivateAttr, Field
 except ImportError:
-    from pydantic import BaseModel, Extra, root_validator, constr, PrivateAttr
+    from pydantic import BaseModel, Extra, root_validator, constr, PrivateAttr, Field
 from typing_extensions import Literal
 
 from qcportal.molecules import Molecule
+from qcportal.cache import get_records_with_cache
 from qcportal.record_models import BaseRecord, RecordAddBodyBase, RecordQueryFilters
 from ..optimization.record_models import OptimizationRecord, OptimizationSpecification
 from ..singlepoint.record_models import (
@@ -58,7 +61,7 @@ class ReactionQueryFilters(RecordQueryFilters):
     molecule_id: Optional[List[int]] = None
 
 
-class ReactionComponent(BaseModel):
+class ReactionComponentMeta(BaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -68,8 +71,11 @@ class ReactionComponent(BaseModel):
     optimization_id: Optional[int]
 
     molecule: Optional[Molecule]
-    singlepoint_record: Optional[SinglepointRecord]
-    optimization_record: Optional[OptimizationRecord]
+
+
+class ReactionComponent(ReactionComponentMeta):
+    singlepoint_record: Optional[SinglepointRecord] = None
+    optimization_record: Optional[SinglepointRecord] = None
 
 
 class ReactionRecord(BaseRecord):
@@ -77,6 +83,11 @@ class ReactionRecord(BaseRecord):
     specification: ReactionSpecification
 
     total_energy: Optional[float]
+
+    ######################################################
+    # Fields not always included when fetching the record
+    ######################################################
+    components_meta_: Optional[List[ReactionComponentMeta]] = Field(None, alias="components")
 
     ########################################
     # Caches
@@ -93,48 +104,65 @@ class ReactionRecord(BaseRecord):
                 if comp.optimization_record:
                     comp.optimization_record.propagate_client(self._client)
 
-    def fetch_all(self):
-        BaseRecord.fetch_all(self)
-        self._fetch_components()
+    @classmethod
+    def _fetch_children_multi(cls, client, record_cache, records: Iterable[ReactionRecord], recursive: bool):
+        # Should be checked by the calling function
+        assert records
+        assert all(isinstance(x, ReactionRecord) for x in records)
 
-        for comp in self._components:
-            if comp.singlepoint_record:
-                comp.singlepoint_record.fetch_all()
-            if comp.optimization_record:
-                comp.optimization_record.fetch_all()
+        # collect all singlepoint * optimization ids for all optimization
+        sp_ids = set()
+        opt_ids = set()
+
+        for r in records:
+            if r.components_meta_:
+                for cm in r.components_meta_:
+                    if cm.singlepoint_id is not None:
+                        sp_ids.add(cm.singlepoint_id)
+                    if cm.optimization_id is not None:
+                        opt_ids.add(cm.optimization_id)
+
+        include = ["**"] if recursive else None
+        sp_ids = list(sp_ids)
+        opt_ids = list(opt_ids)
+
+        sp_records = get_records_with_cache(client, record_cache, sp_ids, SinglepointRecord, include=include)
+        opt_records = get_records_with_cache(client, record_cache, opt_ids, OptimizationRecord, include=include)
+
+        sp_map = {r.id: r for r in sp_records}
+        opt_map = {r.id: r for r in opt_records}
+
+        for r in records:
+            if r.components_meta_ is None:
+                r._components = None
+            else:
+                r._components = []
+                for cm in r.components_meta_:
+                    rc = ReactionComponent(**cm.dict())
+
+                    if rc.singlepoint_id is not None:
+                        rc.singlepoint_record = sp_map[rc.singlepoint_id]
+                    if rc.optimization_id is not None:
+                        rc.optimization_record = opt_map[rc.optimization_id]
+
+                    r._components.append(rc)
+
+            r.propagate_client(r._client)
 
     def _fetch_components(self):
         self._assert_online()
 
-        if not self.offline or self._components is None:
+        if self.components_meta_ is None:
             self._assert_online()
-            self._components = self._client.make_request(
+
+            # Will include molecules
+            self.components_meta_ = self._client.make_request(
                 "get",
                 f"api/v1/records/reaction/{self.id}/components",
-                List[ReactionComponent],
+                List[ReactionComponentMeta],
             )
 
-            mol_ids = [c.molecule_id for c in self._components]
-            mols = self._client.get_molecules(mol_ids)
-            for c, mol in zip(self._components, mols):
-                assert mol.id == c.molecule_id
-                c.molecule = mol
-
-        # Fetch records from server or cache
-        sp_comp = [c for c in self._components if c.singlepoint_id is not None]
-        sp_ids = [c.singlepoint_id for c in sp_comp]
-        sp_recs = self._get_child_records(sp_ids, SinglepointRecord)
-        for c, rec in zip(sp_comp, sp_recs):
-            c.singlepoint_record = rec
-
-        opt_comp = [c for c in self._components if c.optimization_id is not None]
-        opt_ids = [c.optimization_id for c in opt_comp]
-        opt_recs = self._get_child_records(opt_ids, OptimizationRecord)
-        for c, rec in zip(opt_comp, opt_recs):
-            assert rec.initial_molecule_id == c.molecule_id
-            c.optimization_record = rec
-
-        self.propagate_client(self._client)
+        self.fetch_children(False)
 
     @property
     def components(self) -> List[ReactionComponent]:

--- a/qcportal/qcportal/reaction/record_models.py
+++ b/qcportal/qcportal/reaction/record_models.py
@@ -136,15 +136,6 @@ class ReactionRecord(BaseRecord):
 
         self.propagate_client(self._client)
 
-    def _handle_includes(self, includes: Optional[Iterable[str]]):
-        if includes is None:
-            return
-
-        BaseRecord._handle_includes(self, includes)
-
-        if "components" in includes:
-            self._fetch_components()
-
     @property
     def components(self) -> List[ReactionComponent]:
         if self._components is None:

--- a/qcportal/qcportal/reaction/record_models.py
+++ b/qcportal/qcportal/reaction/record_models.py
@@ -78,9 +78,6 @@ class ReactionRecord(BaseRecord):
 
     total_energy: Optional[float]
 
-    ######################################################
-    # Fields not included when fetching the record
-    ######################################################
     ########################################
     # Caches
     ########################################

--- a/qcportal/qcportal/reaction/record_models.py
+++ b/qcportal/qcportal/reaction/record_models.py
@@ -126,8 +126,8 @@ class ReactionRecord(BaseRecord):
         sp_ids = list(sp_ids)
         opt_ids = list(opt_ids)
 
-        sp_records = get_records_with_cache(client, record_cache, sp_ids, SinglepointRecord, include=include)
-        opt_records = get_records_with_cache(client, record_cache, opt_ids, OptimizationRecord, include=include)
+        sp_records = get_records_with_cache(client, record_cache, SinglepointRecord, sp_ids, include=include)
+        opt_records = get_records_with_cache(client, record_cache, OptimizationRecord, opt_ids, include=include)
 
         sp_map = {r.id: r for r in sp_records}
         opt_map = {r.id: r for r in opt_records}

--- a/qcportal/qcportal/reaction/record_models.py
+++ b/qcportal/qcportal/reaction/record_models.py
@@ -105,7 +105,9 @@ class ReactionRecord(BaseRecord):
                     comp.optimization_record.propagate_client(self._client)
 
     @classmethod
-    def _fetch_children_multi(cls, client, record_cache, records: Iterable[ReactionRecord], recursive: bool):
+    def _fetch_children_multi(
+        cls, client, record_cache, records: Iterable[ReactionRecord], recursive: bool, force_fetch: bool = False
+    ):
         # Should be checked by the calling function
         assert records
         assert all(isinstance(x, ReactionRecord) for x in records)
@@ -126,8 +128,12 @@ class ReactionRecord(BaseRecord):
         sp_ids = list(sp_ids)
         opt_ids = list(opt_ids)
 
-        sp_records = get_records_with_cache(client, record_cache, SinglepointRecord, sp_ids, include=include)
-        opt_records = get_records_with_cache(client, record_cache, OptimizationRecord, opt_ids, include=include)
+        sp_records = get_records_with_cache(
+            client, record_cache, SinglepointRecord, sp_ids, include=include, force_fetch=force_fetch
+        )
+        opt_records = get_records_with_cache(
+            client, record_cache, OptimizationRecord, opt_ids, include=include, force_fetch=force_fetch
+        )
 
         sp_map = {r.id: r for r in sp_records}
         opt_map = {r.id: r for r in opt_records}
@@ -150,8 +156,6 @@ class ReactionRecord(BaseRecord):
             r.propagate_client(r._client)
 
     def _fetch_components(self):
-        self._assert_online()
-
         if self.components_meta_ is None:
             self._assert_online()
 

--- a/qcportal/qcportal/reaction/test_record_models.py
+++ b/qcportal/qcportal/reaction/test_record_models.py
@@ -14,9 +14,9 @@ if TYPE_CHECKING:
 all_includes = ["components"]
 
 
-@pytest.mark.parametrize("includes", [None, all_includes])
+@pytest.mark.parametrize("includes", [None, ["**"], all_includes])
 @pytest.mark.parametrize("testfile", ["rxn_H2O_psi4_mp2_optsp", "rxn_H2O_psi4_mp2_opt", "rxn_H2O_psi4_b3lyp_sp"])
-def test_reactionrecord_model(snowflake: QCATestingSnowflake, includes: Optional[List[str]], testfile: str):
+def test_reaction_record_model(snowflake: QCATestingSnowflake, includes: Optional[List[str]], testfile: str):
     storage_socket = snowflake.get_storage_socket()
     snowflake_client = snowflake.client()
     activated_manager_name, _ = snowflake.activate_manager()
@@ -27,8 +27,25 @@ def test_reactionrecord_model(snowflake: QCATestingSnowflake, includes: Optional
     record = snowflake_client.get_reactions(rec_id, include=includes)
 
     if includes is not None:
-        record._client = None
+        assert record.components_meta_ is not None
+        assert record._components is not None
+        record.propagate_client(None)
         assert record.offline
+
+        # children have all data fetched
+        for c in record.components:
+            if c.singlepoint_id is not None:
+                assert c.singlepoint_record is not None
+                assert c.singlepoint_record.molecule_ is not None
+                assert c.singlepoint_record.comments_ is not None
+            if c.optimization_id is not None:
+                assert c.optimization_record is not None
+                assert c.optimization_record.initial_molecule_ is not None
+                assert c.optimization_record.final_molecule_ is not None
+                assert c.optimization_record.comments_ is not None
+    else:
+        assert record.components_meta_ is None
+        assert record._components is None
 
     assert record.id == rec_id
     assert record.status == RecordStatusEnum.complete

--- a/qcportal/qcportal/reaction/test_record_models.py
+++ b/qcportal/qcportal/reaction/test_record_models.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from qcarchivetesting.testing_classes import QCATestingSnowflake
 
 
-all_includes = ["components"]
+all_includes = ["components", "molecule", "comments", "initial_molecule", "final_molecule"]
 
 
 @pytest.mark.parametrize("includes", [None, ["**"], all_includes])

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -378,13 +378,13 @@ class BaseRecord(BaseModel):
     owner_group: Optional[str]
 
     ######################################################
-    # Fields not included when fetching the record
+    # Fields not always included when fetching the record
     ######################################################
-    compute_history_: Optional[List[ComputeHistory]] = None
-    task_: Optional[RecordTask] = None
-    service_: Optional[RecordService] = None
-    comments_: Optional[List[RecordComment]] = None
-    native_files_: Optional[Dict[str, NativeFile]] = None
+    compute_history_: Optional[List[ComputeHistory]] = Field(None, alias="compute_history")
+    task_: Optional[RecordTask] = Field(None, alias="task")
+    service_: Optional[RecordService] = Field(None, alias="service")
+    comments_: Optional[List[RecordComment]] = Field(None, alias="comments")
+    native_files_: Optional[Dict[str, NativeFile]] = Field(None, alias="native_files")
 
     # Private non-pydantic fields
     _client: Any = PrivateAttr(None)
@@ -420,7 +420,14 @@ class BaseRecord(BaseModel):
         cls._all_subclasses[record_type] = cls
 
     def __del__(self):
-        if self._record_cache is not None and self._record_cache_uid is not None and not self._record_cache.read_only:
+        # Sometimes this won't exist if there is an exception during construction
+        if (
+            hasattr(self, "_record_cache")
+            and hasattr(self, "_record_cache_uid")
+            and self._record_cache is not None
+            and self._record_cache_uid is not None
+            and not self._record_cache.read_only
+        ):
             self._record_cache.writeback_record(self._record_cache_uid, self)
 
         s = super()

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -749,7 +749,7 @@ class RecordQueryIterator(QueryIteratorBase[_Record_T]):
         self,
         client,
         query_filters: RecordQueryFilters,
-        record_type: Optional[str],
+        record_type: Type[_Record_T],
         include: Optional[Iterable[str]] = None,
     ):
         """
@@ -780,14 +780,16 @@ class RecordQueryIterator(QueryIteratorBase[_Record_T]):
                 body=self._query_filters,
             )
         else:
+            # Get the record type string. This is kind of ugly, but works.
+            record_type_str = self.record_type.__fields__["record_type"].default
             record_ids = self._client.make_request(
                 "post",
-                f"api/v1/records/{self.record_type}/query",
+                f"api/v1/records/{record_type_str}/query",
                 List[int],
                 body=self._query_filters,
             )
 
-        records: List[_Record_T] = self._client.get_records(record_ids, include=self.include)
+        records: List[_Record_T] = self._client._get_records_by_type(self.record_type, record_ids, include=self.include)
 
         return records
 

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -530,7 +530,7 @@ class BaseRecord(BaseModel):
         cache already, they may be missing those fields.
         """
 
-        return get_records_with_cache(self._client, self._record_cache, child_record_ids, child_record_type, include)
+        return get_records_with_cache(self._client, self._record_cache, child_record_type, child_record_ids, include)
 
     def _assert_online(self):
         """Raises an exception if this record does not have an associated client"""
@@ -750,14 +750,7 @@ class RecordQueryIterator(QueryIteratorBase[_Record_T]):
                 body=self._query_filters,
             )
 
-        if self.record_type is None:
-            records: List[BaseRecord] = self._client.get_records(record_ids, include=self.include)
-        else:
-            records: List[_Record_T] = self._client._get_records_by_type(
-                self.record_type, record_ids, include=self.include
-            )
-
-        return records
+        return self._client._get_records_by_type(self.record_type, record_ids, include=self.include)
 
 
 def record_from_dict(data: Dict[str, Any], client: Any = None) -> BaseRecord:

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from datetime import datetime
 from enum import Enum
 from typing import Optional, Dict, Any, List, Union, Iterable, Tuple, Type, Sequence, ClassVar, TypeVar
@@ -422,11 +423,16 @@ class BaseRecord(BaseModel):
 
     def __del__(self):
         # Sometimes this won't exist if there is an exception during construction
+
+        # TODO - we check sys.meta_path. Pydantic attempts an import of something, which is
+        #        not good if the interpreter is shutting down. This is a hack to avoid that.
+        #        Pydantic v2 may fix this
         if (
             hasattr(self, "_record_cache")
             and self._record_cache is not None
             and not self._record_cache.read_only
             and self._cache_dirty
+            and sys.meta_path is not None
         ):
             self.sync_to_cache(True)  # Don't really *have* to detach, but why not
 

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -612,24 +612,6 @@ class BaseRecord(BaseModel):
             return None
         return history[-1].get_output(output_type)
 
-    def _handle_includes(self, includes: Optional[Iterable[str]]):
-        """
-        Fetches information specified by some iterable of strings
-        """
-        if includes is None:
-            return
-
-        if "task" in includes:
-            self._fetch_task()
-        if "service" in includes:
-            self._fetch_task()
-        if "compute_history" in includes:
-            self._fetch_compute_history()
-        if "comments" in includes:
-            self._fetch_comments()
-        if "native_files" in includes:
-            self._fetch_native_files()
-
     @property
     def offline(self) -> bool:
         return self._client is None
@@ -805,11 +787,7 @@ class RecordQueryIterator(QueryIteratorBase[_Record_T]):
                 body=self._query_filters,
             )
 
-        records: List[_Record_T] = self._client.get_records(record_ids)
-
-        if self.include:
-            for r in records:
-                r._handle_includes(self.include)
+        records: List[_Record_T] = self._client.get_records(record_ids, include=self.include)
 
         return records
 

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -20,7 +20,7 @@ from qcportal.base_models import (
     ProjURLParameters,
 )
 
-from qcportal.cache import RecordCache
+from qcportal.cache import RecordCache, get_records_with_cache
 from qcportal.compression import CompressionEnum, decompress, get_compressed_ext
 
 _T = TypeVar("_T")
@@ -531,7 +531,7 @@ class BaseRecord(BaseModel):
 
     def _cache_child_records(self, record_ids: Iterable[int], record_type: Type[_Record_T]) -> None:
         """
-        Fetching child records and stores them in the cache
+        Fetch child records and stores them in the cache
 
         The cache will be checked for existing records
         """
@@ -549,7 +549,10 @@ class BaseRecord(BaseModel):
         self._record_cache.update_records(recs)
 
     def _get_child_records(
-        self, record_ids: Sequence[int], record_type: Type[_Record_T], include: Optional[Iterable[str]] = None
+        self,
+        child_record_ids: Sequence[int],
+        child_record_type: Type[_Record_T],
+        include: Optional[Iterable[str]] = None,
     ) -> List[_Record_T]:
         """
         Helper function for obtaining child records either from the cache or from the server
@@ -560,38 +563,7 @@ class BaseRecord(BaseModel):
         cache already, they may be missing those fields.
         """
 
-        if self._record_cache is None:
-            self._assert_online()
-            existing_records = []
-            records_tofetch = record_ids
-        else:
-            existing_records = self._record_cache.get_records(record_ids, record_type)
-            records_tofetch = set(record_ids) - {x.id for x in existing_records}
-
-        if self.offline and records_tofetch:
-            raise RuntimeError("Need to fetch some records, but not connected to a client")
-
-        if records_tofetch:
-            recs = self._client._get_records_by_type(record_type, list(records_tofetch), include=include)
-            if self._record_cache is not None:
-                uids = self._record_cache.update_records(recs)
-
-                for u, r in zip(uids, recs):
-                    r._record_cache = self._record_cache
-                    r._record_cache_uid = u
-
-            existing_records += recs
-
-        # Return everything in the same order as the input
-        all_recs = {r.id: r for r in existing_records}
-        ret = [all_recs.get(rid, None) for rid in record_ids]
-        if None in ret:
-            missing_ids = set(record_ids) - set(all_recs.keys())
-            raise RuntimeError(
-                f"Not all records found either in the cache or on the server. Missing records: {missing_ids}"
-            )
-
-        return ret
+        return get_records_with_cache(self._client, self._record_cache, child_record_ids, child_record_type, include)
 
     def _assert_online(self):
         """Raises an exception if this record does not have an associated client"""

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -447,7 +447,9 @@ class BaseRecord(BaseModel):
         return subcls
 
     @classmethod
-    def _fetch_children_multi(cls, client, record_cache, records: Iterable[BaseRecord], recursive: bool):
+    def _fetch_children_multi(
+        cls, client, record_cache, records: Iterable[BaseRecord], recursive: bool, force_fetch: bool = False
+    ):
         """
         Fetches all children of the given records recursively
 
@@ -459,7 +461,7 @@ class BaseRecord(BaseModel):
         pass
 
     @classmethod
-    def fetch_children_multi(cls, records: Iterable[Optional[BaseRecord]], recursive: bool):
+    def fetch_children_multi(cls, records: Iterable[Optional[BaseRecord]], recursive: bool, force_fetch: bool = False):
         """
         Fetches all children of the given records recursively
 
@@ -530,7 +532,9 @@ class BaseRecord(BaseModel):
         cache already, they may be missing those fields.
         """
 
-        return get_records_with_cache(self._client, self._record_cache, child_record_type, child_record_ids, include)
+        return get_records_with_cache(
+            self._client, self._record_cache, child_record_type, child_record_ids, include, force_fetch=False
+        )
 
     def _assert_online(self):
         """Raises an exception if this record does not have an associated client"""

--- a/qcportal/qcportal/serialization.py
+++ b/qcportal/qcportal/serialization.py
@@ -16,7 +16,7 @@ except ImportError:
 def _msgpack_encode(obj: Any) -> Any:
     if isinstance(obj, BaseModel):
         # Don't include unset fields in pydantic models
-        return obj.dict(exclude_unset=True)
+        return obj.dict(exclude_unset=True, by_alias=True)
 
     try:
         return pydantic_encoder(obj)
@@ -44,8 +44,9 @@ class _JSONEncoder(json.JSONEncoder):
             return {"_bytes_base64_": base64.b64encode(obj).decode("ascii")}
 
         # Now do anything with pydantic, excluding unset fields
+        # Also always use aliases when serializing
         if isinstance(obj, BaseModel):
-            return obj.dict(exclude_unset=True)
+            return obj.dict(exclude_unset=True, by_alias=True)
 
         # Let pydantic handle other things
         try:

--- a/qcportal/qcportal/singlepoint/record_models.py
+++ b/qcportal/qcportal/singlepoint/record_models.py
@@ -141,17 +141,6 @@ class SinglepointRecord(BaseRecord):
 
         self.propagate_client(self._client)
 
-    def _handle_includes(self, includes: Optional[Iterable[str]]):
-        if includes is None:
-            return
-
-        BaseRecord._handle_includes(self, includes)
-
-        if "molecule" in includes:
-            self._fetch_molecule()
-        if "wavefunction" in includes:
-            self._fetch_wavefunction()
-
     @property
     def return_result(self) -> Any:
         # Return result is stored in properties in QCFractal

--- a/qcportal/qcportal/singlepoint/record_models.py
+++ b/qcportal/qcportal/singlepoint/record_models.py
@@ -105,10 +105,10 @@ class SinglepointRecord(BaseRecord):
     molecule_id: int
 
     ######################################################
-    # Fields not included when fetching the record
+    # Fields not always included when fetching the record
     ######################################################
-    molecule_: Optional[Molecule] = None
-    wavefunction_: Optional[Wavefunction] = None
+    molecule_: Optional[Molecule] = Field(None, alias="molecule")
+    wavefunction_: Optional[Wavefunction] = Field(None, alias="wavefunction")
 
     def propagate_client(self, client):
         BaseRecord.propagate_client(self, client)

--- a/qcportal/qcportal/singlepoint/record_models.py
+++ b/qcportal/qcportal/singlepoint/record_models.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from enum import Enum
-from typing import Optional, Union, Any, List, Dict, Iterable, Tuple
+from typing import Optional, Union, Any, List, Dict, Tuple
 
 try:
     from pydantic.v1 import BaseModel, Field, constr, validator, Extra, PrivateAttr
@@ -67,7 +67,7 @@ class Wavefunction(BaseModel):
         extra = Extra.forbid
 
     compression_type: CompressionEnum
-    data_: Optional[bytes] = None
+    data_: Optional[bytes] = Field(None, alias="data")
 
     _data_url: Optional[str] = PrivateAttr(None)
     _client: Any = PrivateAttr(None)
@@ -115,16 +115,6 @@ class SinglepointRecord(BaseRecord):
 
         if self.wavefunction_ is not None:
             self.wavefunction_.propagate_client(self._client, self._base_url)
-
-    def fetch_all(self):
-        BaseRecord.fetch_all(self)
-        self._fetch_molecule()
-
-        if self.specification.protocols.wavefunction != WavefunctionProtocolEnum.none:
-            self._fetch_wavefunction()
-            self.wavefunction_._fetch_raw_data()
-        else:
-            self.wavefunction_ = None
 
     def _fetch_molecule(self):
         self._assert_online()

--- a/qcportal/qcportal/test_cache.py
+++ b/qcportal/qcportal/test_cache.py
@@ -5,7 +5,7 @@ import threading
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from qcportal.dataset_models import dataset_from_cache
+from qcportal.dataset_models import load_dataset_view
 from qcportal.record_models import RecordStatusEnum
 from qcportal.singlepoint import SinglepointDataset
 from qcportal.singlepoint.test_dataset_models import test_specs, test_entries
@@ -276,6 +276,6 @@ def test_dataset_cache_fromfile_view(snowflake: QCATestingSnowflake, tmp_path):
     del ds
     gc.collect()
 
-    ds2 = dataset_from_cache(cachefile_path)
+    ds2 = load_dataset_view(cachefile_path)
     assert ds2.is_view
     assert ds2.get_record(test_entries[0].name, "spec_1") is not None

--- a/qcportal/qcportal/test_cache.py
+++ b/qcportal/qcportal/test_cache.py
@@ -180,6 +180,9 @@ def test_dataset_cache_writeback(snowflake_client: PortalClient):
     assert r.molecule_ is None  # molecule not fetched
     r._fetch_molecule()
     assert r.molecule_ is not None  # molecule not fetched
+
+    # TODO: This is a hack to force a writeback. Remove when proper tracking of _cache_dirty is done in the records
+    r._cache_dirty = True
     del r  # should write back to the cache
     gc.collect()
 

--- a/qcportal/qcportal/torsiondrive/record_models.py
+++ b/qcportal/qcportal/torsiondrive/record_models.py
@@ -225,19 +225,6 @@ class TorsiondriveRecord(BaseRecord):
 
         self.propagate_client(self._client)
 
-    def _handle_includes(self, includes: Optional[Iterable[str]]):
-        if includes is None:
-            return
-
-        BaseRecord._handle_includes(self, includes)
-
-        if "initial_molecules" in includes:
-            self._fetch_initial_molecules()
-        if "minimum_optimizations" in includes and "optimizations" not in includes:
-            self._fetch_minimum_optimizations()
-        if "optimizations" in includes:
-            self._fetch_optimizations()
-
     @property
     def initial_molecules(self) -> List[Molecule]:
         if self.initial_molecules_ is None:

--- a/qcportal/qcportal/torsiondrive/record_models.py
+++ b/qcportal/qcportal/torsiondrive/record_models.py
@@ -163,7 +163,7 @@ class TorsiondriveRecord(BaseRecord):
 
         include = ["**"] if recursive else None
         opt_ids = list(opt_ids)
-        opt_records = get_records_with_cache(client, record_cache, opt_ids, OptimizationRecord, include=include)
+        opt_records = get_records_with_cache(client, record_cache, OptimizationRecord, opt_ids, include=include)
         opt_map = {x.id: x for x in opt_records}
 
         for r in records:

--- a/qcportal/qcportal/torsiondrive/record_models.py
+++ b/qcportal/qcportal/torsiondrive/record_models.py
@@ -130,11 +130,11 @@ class TorsiondriveRecord(BaseRecord):
     specification: TorsiondriveSpecification
 
     ######################################################
-    # Fields not included when fetching the record
+    # Fields not always included when fetching the record
     ######################################################
-    initial_molecules_ids_: Optional[List[int]] = None
-    optimizations_: Optional[List[TorsiondriveOptimization]] = None
-    initial_molecules_: Optional[List[Molecule]] = None
+    initial_molecules_ids_: Optional[List[int]] = Field(None, alias="initial_molecules_ids")
+    optimizations_: Optional[List[TorsiondriveOptimization]] = Field(None, alias="optimizations")
+    initial_molecules_: Optional[List[Molecule]] = Field(None, alias="initial_molecules")
 
     ########################################
     # Caches

--- a/qcportal/qcportal/torsiondrive/test_record_models.py
+++ b/qcportal/qcportal/torsiondrive/test_record_models.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from qcarchivetesting.testing_classes import QCATestingSnowflake
 
 
-all_includes = ["initial_molecules", "optimizations"]
+all_includes = ["initial_molecules", "optimizations", "initial_molecule", "final_molecule"]
 
 
 @pytest.mark.parametrize("includes", [None, ["**"], all_includes])

--- a/qcportal/qcportal/torsiondrive/test_record_models.py
+++ b/qcportal/qcportal/torsiondrive/test_record_models.py
@@ -6,6 +6,7 @@ import pytest
 
 from qcfractal.components.torsiondrive.testing_helpers import run_test_data, load_test_data
 from qcportal.record_models import RecordStatusEnum
+from qcportal.torsiondrive import deserialize_key
 
 if TYPE_CHECKING:
     from qcarchivetesting.testing_classes import QCATestingSnowflake
@@ -14,8 +15,8 @@ if TYPE_CHECKING:
 all_includes = ["initial_molecules", "optimizations"]
 
 
-@pytest.mark.parametrize("includes", [None, all_includes])
-def test_torsiondriverecord_model(snowflake: QCATestingSnowflake, includes: Optional[List[str]]):
+@pytest.mark.parametrize("includes", [None, ["**"], all_includes])
+def test_torsiondrive_record_model(snowflake: QCATestingSnowflake, includes: Optional[List[str]]):
     storage_socket = snowflake.get_storage_socket()
     snowflake_client = snowflake.client()
     activated_manager_name, _ = snowflake.activate_manager()
@@ -26,8 +27,19 @@ def test_torsiondriverecord_model(snowflake: QCATestingSnowflake, includes: Opti
     record = snowflake_client.get_torsiondrives(rec_id, include=includes)
 
     if includes is not None:
-        record._client = None
+        assert record.initial_molecules_ is not None
+        assert record.optimizations_ is not None
+        record.propagate_client(None)
         assert record.offline
+
+        # children have all data fetched
+        for opts in record._optimizations_cache.values():
+            assert all(x.initial_molecule_ is not None for x in opts)
+            assert all(x.final_molecule_ is not None for x in opts)
+    else:
+        assert record.initial_molecules_ is None
+        assert record.optimizations_ is None
+        assert record._optimizations_cache is None
 
     assert record.id == rec_id
     assert record.status == RecordStatusEnum.complete
@@ -54,3 +66,10 @@ def test_torsiondriverecord_model(snowflake: QCATestingSnowflake, includes: Opti
 
     # Did we get the same minimum optimizations?
     assert {k: v.id for k, v in min_opts_1.items()} == {k: v.id for k, v in min_opts_2.items()}
+
+    # Check that optimization keys/records match
+    idx = {key: 0 for key in opts_1.keys()}  # index of the list in each key
+    for optinfo in record.optimizations_:
+        k = deserialize_key(optinfo.key)
+        assert opts_1[k][idx[k]].id == optinfo.optimization_id
+        idx[k] += 1

--- a/qcportal/qcportal/utils.py
+++ b/qcportal/qcportal/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import concurrent.futures
 import datetime
 import io
 import itertools
@@ -9,7 +10,7 @@ import math
 import time
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from hashlib import sha256
-from typing import Optional, Union, Sequence, List, TypeVar, Any, Dict, Generator, Iterable
+from typing import Optional, Union, Sequence, List, TypeVar, Any, Dict, Generator, Iterable, Callable
 
 import numpy as np
 
@@ -86,6 +87,147 @@ def chunk_iterable_time(
 
         # Get the next chunk
         batch = list(itertools.islice(i, chunk_size))
+
+
+def process_chunk_iterable(
+    fn: Callable[[Iterable[_T]], Any],
+    it: Iterable[_T],
+    chunk_time: float,
+    max_chunk_size: int,
+    initial_chunk_size: int,
+    max_workers: int = 1,
+    *,
+    keep_order: bool = False,
+) -> Generator[List[_T], None, None]:
+    """
+    Process an iterable in chunks, trying to keep a constant time per chunk
+
+    This function keeps track of the time it takes to process each chunk and tries to keep the time per chunk
+    as close to 'chunk_time' as possible, increasing or decreasing the chunk size as needed (up to 'max_chunk_size')
+
+    The first chunk will be of size 'initial_chunk_size' (assuming there is enough elements in the iterable to fill it).
+
+    This function returns the results as chunks (lists) of the original iterable. If 'keep_order' is True, the results
+    will be returned in the same order as the original iterable. If 'keep_order' is False, the results will be returned
+    in the order they are completed.
+    """
+
+    # NOTE: You might think that we should spin up another thread to handle all the processing and submission
+    #       to the thread pool. However, if the user takes a long time processing the chunk (returned via yield) on
+    #       their end then this would effectively just process all the data and hold that in the cache. This might be
+    #       undesirable if the user is trying to process a large amount of data. Also, the effect is largely the same
+    #       in terms of timing.
+    #       So this function more or less tries to pre-process enough so that the user is never waiting, striking a
+    #       balance between downloading all the data and doing things completely serially.
+
+    if chunk_time <= 0.0:
+        raise ValueError("chunk_time must be > 0.0")
+    if max_chunk_size < 1:
+        raise ValueError("max_chunk_size must be >= 1")
+    if initial_chunk_size < 1 or initial_chunk_size > max_chunk_size:
+        raise ValueError("initial_chunk_size must be >= 1 and <= max_chunk_size")
+    if max_workers < 1:
+        raise ValueError("max_workers must be >= 1")
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+
+    # Get initial chunks to be submitted to the pool
+    i = iter(it)
+    chunks = [list(itertools.islice(i, initial_chunk_size)) for _ in range(max_workers)]
+
+    # Remove empty chunks
+    chunks = [b for b in chunks if b]
+
+    # Wrap the provided function so that we get timing and chunk id
+    def _process(chunk, chunk_id):
+        start = time.time()
+        ret = fn(chunk)
+        end = time.time()
+        return (end - start) / len(chunk), chunk_id, ret
+
+    # chunk id we should submit next
+    cur_chunk_idx = 0
+
+    # Current chunk id we are returning (if order is kept)
+    cur_ret_chunk_id = 0
+
+    # Dictionary keeping the results (indexed by chunk id)
+    results_cache = {}
+
+    # Submit the given function with the given chunks to the thread pool
+    futures = [pool.submit(_process, chunk, cur_chunk_idx + i) for i, chunk in enumerate(chunks)]
+    cur_chunk_idx += len(chunks)
+
+    while True:
+        if len(futures) == 0:
+            break
+
+        # Wait for any of the futures
+        done, not_done = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_COMPLETED)
+
+        # Get the result of the first completed future
+        average_per_element = 0.0
+
+        for future in done:
+            avg_time, chunk_idx, ret = future.result()
+            average_per_element += avg_time  # Average per element of the iterable
+            assert cur_chunk_idx not in results_cache
+            results_cache[chunk_idx] = ret
+
+        if len(done) != 0:
+            # compute the next chunk size
+            time_per_element = average_per_element / len(done)  # Average of the averages
+
+            # How many elements could we fit in the desired chunk_time
+            chunk_size = math.floor(int(chunk_time / time_per_element))
+
+            # Clamp to a valid size
+            chunk_size = max(1, min(chunk_size, max_chunk_size))
+
+            # next chunks
+            chunks = [list(itertools.islice(i, chunk_size)) for _ in range(len(done))]
+
+            # Remove empty chunks
+            chunks = [b for b in chunks if b]
+
+            # Submit to the thread pool
+            futures = list(not_done) + [
+                pool.submit(_process, chunk, cur_chunk_idx + i) for i, chunk in enumerate(chunks)
+            ]
+            cur_chunk_idx += len(chunks)
+
+        done_results = list(results_cache.keys())
+        if keep_order:
+            while cur_ret_chunk_id in done_results:
+                yield results_cache[cur_ret_chunk_id]
+                del results_cache[cur_ret_chunk_id]
+                cur_ret_chunk_id += 1
+        else:
+            for k in done_results:
+                yield results_cache[k]
+                del results_cache[k]
+
+    assert len(results_cache) == 0
+
+
+def process_iterable(
+    fn: Callable[[Iterable[_T]], Any],
+    it: Iterable[_T],
+    chunk_time: float,
+    max_chunk_size: int,
+    initial_chunk_size: int,
+    max_workers: int = 1,
+    *,
+    keep_order: bool = False,
+) -> Generator[List[_T], None, None]:
+    """
+    Similar to process_chunk_iterable, but returns individual elements ranther than chunks
+    """
+
+    for chunk in process_chunk_iterable(
+        fn, it, chunk_time, max_chunk_size, initial_chunk_size, max_workers, keep_order=keep_order
+    ):
+        yield from chunk
 
 
 def seconds_to_hms(seconds: Union[float, int]) -> str:


### PR DESCRIPTION
## Description

Right now, when records are fetched from the server, only the bare minimum is fetched, with the rest coming on-demand as you access fields of the record. This works in general, however if the user wants to download entire records (+ children), the result is a very large number of small requests.

This PR improves this. There are three main parts:

1. Being able to say `include=['**']`, which will result in the entire record being downloaded, including children

2. To handle fetching children, the children of multiple parent records are fetched together.  For example, singlepoint records from the trajectories of multiple optimization records are batched together.

3. A time-based chunking iterator to help prevent very large requests from choking the server. This also includes a thread pool for background fetching

This requires a few server side changes, so unfortunately this cannot be tested against the running production servers. I am planning on a release in early April, though.

## Changelog description
Improve fetching speed by allowing for including more of records

## Status
- [X] Implement new includes handling and child fetching
- [x] Time-based chunking iterator
- [x] Code base linted
- [x] Ready to go
