### PR TITLE
Fixes some cache issues in v0.54

### DIFF
--- a/qcarchivetesting/qcarchivetesting/testing_classes.py
+++ b/qcarchivetesting/qcarchivetesting/testing_classes.py
@@ -248,7 +248,7 @@ class QCATestingSnowflake(FractalSnowflake):
         """
         self._stop_job_runner()
 
-    def client(self, username=None, password=None, cache_dir=None, shared_memory_cache=False) -> PortalClient:
+    def client(self, username=None, password=None, cache_dir=None) -> PortalClient:
         """
         Obtain a client connected to this snowflake
 
@@ -260,11 +260,6 @@ class QCATestingSnowflake(FractalSnowflake):
             The password to use
         cache_dir
             Directory to store cache files in
-        shared_memory_cache
-            Whether to use a shared memory cache
-
-        Note: We generally don't want a shared memory cache for tests, so the default is False here
-        rather than True as in the main codebase
 
         Returns
         -------
@@ -272,8 +267,7 @@ class QCATestingSnowflake(FractalSnowflake):
             A PortalClient that is connected to this snowflake
         """
 
-        client = PortalClient(self.get_uri(), username=username, password=password, cache_dir=cache_dir,
-                              shared_memory_cache=shared_memory_cache)
+        client = PortalClient(self.get_uri(), username=username, password=password, cache_dir=cache_dir)
         client.encoding = self.encoding
         return client
 

--- a/qcportal/qcportal/cache.py
+++ b/qcportal/qcportal/cache.py
@@ -676,6 +676,9 @@ def get_records_with_cache(
         existing_records = record_cache.get_records(record_ids, record_type)
         records_tofetch = set(record_ids) - {x.id for x in existing_records}
 
+        for r in existing_records:
+            r.propagate_client(client)
+
     if records_tofetch:
         if client is None:
             raise RuntimeError("Need to fetch some records, but not connected to a client")

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -125,7 +125,7 @@ class PortalClient(PortalClientBase):
         *,
         cache_dir: Optional[str] = None,
         cache_max_size: int = 0,
-        shared_memory_cache: bool = True,
+        memory_cache_key: Optional[str] = None,
     ) -> None:
         """
         Parameters
@@ -147,15 +147,15 @@ class PortalClient(PortalClientBase):
             Directory to store an internal cache of records and other data
         cache_max_size
             Maximum size of the cache directory
-        shared_memory_cache
-            If True (and cache_dir is not specified), the memory-backed cache will be marked as shared,
-            meaning that multiple instances of the PortalClient can share the same cache, as well as making the
-            cache shared among threads. Generally, this is what you want, but
+        memory_cache_key
+            If set, all clients with the same memory_cache_key will share an in-memory cache. If not specified,
+            a unique one will be generated, meaning this client will not share a memory-based cache with any
+            other clients. Not used if cache_dir is set.
         """
 
         PortalClientBase.__init__(self, address, username, password, verify, show_motd)
         self._logger = logging.getLogger("PortalClient")
-        self.cache = PortalCache(address, cache_dir, cache_max_size, shared_memory_cache)
+        self.cache = PortalCache(address, cache_dir, cache_max_size, memory_cache_key)
 
     def __repr__(self) -> str:
         """A short representation of the current PortalClient.

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -525,10 +525,10 @@ class BaseDataset(BaseModel):
     @property
     def specification_names(self) -> List[str]:
         if not self._specification_names:
-            self._specification_names = self._cache_data.get_specification_names()
-
-        if not self._specification_names and not self.is_view:
-            self.fetch_specification_names()
+            if self.is_view:
+                self._specification_names = self._cache_data.get_specification_names()
+            else:
+                self.fetch_specification_names()
 
         return self._specification_names
 
@@ -769,10 +769,10 @@ class BaseDataset(BaseModel):
     @property
     def entry_names(self) -> List[str]:
         if not self._entry_names:
-            self._entry_names = self._cache_data.get_entry_names()
-
-        if not self._entry_names and not self.is_view:
-            self.fetch_entry_names()
+            if self.is_view:
+                self._entry_names = self._cache_data.get_entry_names()
+            else:
+                self.fetch_entry_names()
 
         return self._entry_names
 

--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -270,6 +270,7 @@ def run_dataset_model_rename_spec(snowflake_client, ds, test_entries, test_specs
 
     assert set(spec_names) == {"spec_2", "spec_1_new"}
     assert set(ds.specifications.keys()) == {"spec_2", "spec_1_new"}
+    assert set(ds.specification_names) == {"spec_2", "spec_1_new"}
     assert set(ds._specification_names) == {"spec_2", "spec_1_new"}
     assert set(ds._cache_data.get_specification_names()) == {"spec_2", "spec_1_new"}
     assert ds._cache_data.get_specification("spec_1_new").name == "spec_1_new"

--- a/qcportal/qcportal/test_cache.py
+++ b/qcportal/qcportal/test_cache.py
@@ -131,9 +131,7 @@ def test_dataset_cache_update(snowflake_client: PortalClient):
 
 
 def test_dataset_cache_multithread(snowflake: QCATestingSnowflake):
-    # Use shared memory cache
-    # This is the default for a regular client, but a testing snowflake uses :memory:
-    snowflake_client: PortalClient = snowflake.client(shared_memory_cache=True)
+    snowflake_client: PortalClient = snowflake.client()
 
     ds: SinglepointDataset = snowflake_client.add_dataset("singlepoint", "Test dataset")
 

--- a/qcportal/qcportal/torsiondrive/record_models.py
+++ b/qcportal/qcportal/torsiondrive/record_models.py
@@ -174,9 +174,6 @@ class TorsiondriveRecord(BaseRecord):
             if r.minimum_optimizations_ and do_minopt:
                 opt_ids.update(r.minimum_optimizations_.values())
 
-        if not opt_ids:
-            return
-
         opt_ids = list(opt_ids)
         opt_records = get_records_with_cache(
             client, record_cache, OptimizationRecord, opt_ids, include=include, force_fetch=force_fetch


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
The idea of memory-backed caches that are shared between clients was a little half-baked. In general, that is not expected, and can cause issues with tests (see https://github.com/openforcefield/openff-qcsubmit/issues/275). This makes that kind of shared cache opt-in.

Not that there is still some idea of sharing the cache withing a particular client due to multi-threading. But now, unless specified, constructing a new client will result in a separate cache.

Also fixes an issue where, if some records were in cache and some not, an exception was raised due to client mismatches between records.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fixes issues related to shared caching. Shared in-memory caches are now opt-in

## Status
- [X] Code base linted
- [X] Ready to go
