### PR TITLE
Fix native_files fields return from server & ORM

### DIFF
--- a/qcfractal/qcfractal/components/record_db_models.py
+++ b/qcfractal/qcfractal/components/record_db_models.py
@@ -134,7 +134,7 @@ class NativeFileORM(BaseORM):
 
     __table_args__ = (UniqueConstraint("record_id", "name", name="ux_native_file_record_id_name"),)
 
-    _qcportal_model_excludes = ["id", "history_id", "compression_level"]
+    _qcportal_model_excludes = ["id", "record_id", "compression_level"]
 
     def get_file(self) -> Any:
         return decompress(self.data, self.compression_type)

--- a/qcportal/qcportal/test_record_models.py
+++ b/qcportal/qcportal/test_record_models.py
@@ -26,10 +26,10 @@ def test_base_record_model_common(snowflake: QCATestingSnowflake, includes: Opti
     snowflake_client = snowflake.client()
     activated_manager_name, _ = snowflake.activate_manager()
 
-    input_spec, _, result = load_sp_test_data("sp_psi4_benzene_energy_1")
+    input_spec, _, result = load_sp_test_data("sp_psi4_h2_b3lyp_nativefiles")
 
     time_0 = now_at_utc()
-    rec_id = run_sp_test_data(storage_socket, activated_manager_name, "sp_psi4_benzene_energy_1")
+    rec_id = run_sp_test_data(storage_socket, activated_manager_name, "sp_psi4_h2_b3lyp_nativefiles")
     time_1 = now_at_utc()
 
     snowflake_client.add_comment(rec_id, "This is a comment")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Fetching native files info from the server resulted in an error. `record_id` was being included in the data from the server/ORM, but it is not a valid field in the pydantic model.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fix native_files fields return from server & ORM

## Status
- [X] Code base linted
- [X] Ready to go
