### PR TITLE
Fix missing client on cached dataset records

### DIFF
--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1045,6 +1045,9 @@ class BaseDataset(BaseModel):
 
                     # Check if we have any cached records
                     cached_records = self._cache_data.get_dataset_records(missing_entries, [spec_name])
+                    for _, _, cr in cached_records:
+                        cr.propagate_client(self._client)
+
                     records_batch.extend(cached_records)
 
                     # what we need to fetch from the server
@@ -1171,6 +1174,9 @@ class BaseDataset(BaseModel):
 
                         # Check if we have any cached records
                         cached_records = self._cache_data.get_dataset_records(missing_entries, [spec_name])
+                        for _, _, cr in cached_records:
+                            cr.propagate_client(self._client)
+
                         records_batch.extend(cached_records)
 
                         # what we need to fetch from the server


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Some dataset records, when fetched through the dataset's cache, would not have the client attached. This made it impossible to fetch additional pieces of the record one it had been cached.

## Changelog description
Fix missing client on cached dataset records

## Status
- [X] Code base linted
- [X] Ready to go
