### PR TITLE
Fix database constraint violation when program version strings contain uppercase characters

### DIFF
--- a/qcfractal/qcfractal/components/managers/socket.py
+++ b/qcfractal/qcfractal/components/managers/socket.py
@@ -96,7 +96,9 @@ class ManagerSocket:
 
         # Strip out empty tags and programs
         tags = [x.lower() for x in tags if len(x) > 0]
-        programs = {k.lower(): v for k, v in programs.items() if len(k) > 0}
+
+        # Some version strings can contain uppercase characters
+        programs = {k.lower(): [v.lower() for v in vlst] for k, vlst in programs.items() if len(k) > 0}
 
         if len(tags) == 0:
             raise ComputeManagerError("Manager does not have any tags assigned. Use '*' to match all tags")

--- a/qcfractal/qcfractal/components/managers/test_manager_client.py
+++ b/qcfractal/qcfractal/components/managers/test_manager_client.py
@@ -77,13 +77,18 @@ def test_manager_mclient_activate_normalize(snowflake: QCATestingSnowflake):
 
     mclient1.activate(
         manager_version="v2.0",
-        programs={"qcengine": ["unknown"], "program1": ["v3.0"], "PROgRam2": ["v4.0"]},
+        programs={"qcengine": ["unknown"], "program1": ["v3.0"], "PROgRam2": ["v4.0"], "PROGRAM4": ["v5.0-AB"]},
         tags=["tag1", "taG3", "tAg2", "TAG3", "TAG1"],
     )
 
     manager = client.get_managers(mname1.fullname)
     assert manager.tags == ["tag1", "tag3", "tag2"]
-    assert manager.programs == {"qcengine": ["unknown"], "program1": ["v3.0"], "program2": ["v4.0"]}
+    assert manager.programs == {
+        "qcengine": ["unknown"],
+        "program1": ["v3.0"],
+        "program2": ["v4.0"],
+        "program4": ["v5.0-ab"],
+    }
 
 
 def test_manager_mclient_activate_notags(snowflake: QCATestingSnowflake):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Some program version strings can contain uppercase characters, which causes a database constraint violation.
This adds normalization for that case (+ a test)



## Changelog description
Fix database constraint violation when program version strings contain uppercase characters

## Status
- [X] Code base linted
- [X] Ready to go
