### PR TITLE
Fix type of results in ServiceSubtaskRecord

### DIFF
--- a/qcportal/qcportal/services/models.py
+++ b/qcportal/qcportal/services/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 from typing_extensions import Literal
 
@@ -13,4 +13,4 @@ class ServiceSubtaskRecord(BaseRecord):
     required_programs: Dict[str, Any]
     function: str
     function_kwargs: Dict[str, Any]
-    results: Optional[Dict[str, Any]]
+    results: Any


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
The results from `ServiceSubtaskRecord`s can be a list as well. So relax the type in pydantic

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fix type of results in ServiceSubtaskRecord

## Status
- [X] Code base linted
- [X] Ready to go
