### PR TITLE
Lazy load zstandard

### DIFF
--- a/qcportal/qcportal/cache.py
+++ b/qcportal/qcportal/cache.py
@@ -20,7 +20,6 @@ try:
 except ImportError:
     import pydantic
     from pydantic import BaseModel, Extra, validator, PrivateAttr, Field
-import zstandard
 
 from .serialization import serialize, deserialize
 
@@ -35,12 +34,16 @@ _query_chunk_size = 125
 
 
 def compress_for_cache(data: Any) -> sqlite3.Binary:
+    import zstandard
+
     serialized_data = serialize(data, "msgpack")
     compressed_data = zstandard.compress(serialized_data, level=1)
     return sqlite3.Binary(compressed_data)
 
 
 def decompress_from_cache(data: sqlite3.Binary, value_type) -> Any:
+    import zstandard
+
     decompressed_data = zstandard.decompress(bytes(data))
     deserialized_data = deserialize(decompressed_data, "msgpack")
     return pydantic.parse_obj_as(value_type, deserialized_data)

--- a/qcportal/qcportal/compression.py
+++ b/qcportal/qcportal/compression.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Optional, Tuple, Any
 
 import msgpack
-import zstandard
 
 
 class CompressionEnum(str, Enum):
@@ -60,6 +59,8 @@ def compress(
     # ZStandard compression
     # By default, use level = 6 for larger data (>15MB or so)
     elif compression_type == CompressionEnum.zstd:
+        import zstandard
+
         if compression_level is None:
             if len(data) > 15 * 1048576:
                 compression_level = 6


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

This PR defers `import zstandard` until it's needed. Some [weird packaging issues](https://github.com/conda-forge/qcfractal-feedstock/issues/43) cause a conflict that prevents any QCPortal import. I'm not sure when these compression/caching modules are used, i.e. by common user operations or only by admins. If they're ever not needed, this avoids an unnecessary crash.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Lazy load `zstandard`

## Status
- [x] Code base linted
- [x] Ready to go
