### PR TITLE
Replace sqlite3 with apsw

### DIFF
--- a/qcarchivetesting/conda-envs/fulltest_qcportal.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_qcportal.yaml
@@ -11,6 +11,7 @@ dependencies:
   - pyyaml
   - pydantic
   - zstandard
+  - apsw
   - qcelemental
   - tabulate
   - tqdm

--- a/qcarchivetesting/conda-envs/fulltest_server.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_server.yaml
@@ -15,6 +15,7 @@ dependencies:
   - pyyaml
   - pydantic
   - zstandard
+  - apsw
   - qcelemental
   - tabulate
   - tqdm

--- a/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
@@ -16,6 +16,7 @@ dependencies:
   - pyyaml
   - pydantic
   - zstandard
+  - apsw
   - qcelemental
   - tabulate
   - tqdm

--- a/qcarchivetesting/conda-envs/fulltest_worker.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_worker.yaml
@@ -15,6 +15,7 @@ dependencies:
   - pyyaml
   - pydantic
   - zstandard
+  - apsw
   - qcelemental
   - tabulate
   - tqdm

--- a/qcportal/pyproject.toml
+++ b/qcportal/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pyyaml",
     "pydantic",
     "zstandard",
+    "apsw",
     "qcelemental",
     "tabulate",
     "tqdm",

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -147,15 +147,11 @@ class PortalClient(PortalClientBase):
             Directory to store an internal cache of records and other data
         cache_max_size
             Maximum size of the cache directory
-        memory_cache_key
-            If set, all clients with the same memory_cache_key will share an in-memory cache. If not specified,
-            a unique one will be generated, meaning this client will not share a memory-based cache with any
-            other clients. Not used if cache_dir is set.
         """
 
         PortalClientBase.__init__(self, address, username, password, verify, show_motd)
         self._logger = logging.getLogger("PortalClient")
-        self.cache = PortalCache(address, cache_dir, cache_max_size, memory_cache_key)
+        self.cache = PortalCache(address, cache_dir, cache_max_size)
 
     def __repr__(self) -> str:
         """A short representation of the current PortalClient.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Replaces the use of sqlite3 from the python standard library with APSW (https://github.com/rogerbinns/apsw, https://rogerbinns.github.io/apsw/index.html)

APSW is a lightweight wrapper around sqlite that allows for more features compared to the python standard library (which is constrained by the DB API).

In particular, APSW allows for multi-threaded access to connections, which means I can remove some kinda hacky thread-local stuff. And since I can remove that, I don't need to use the memdb vfs, which seems constrained in the size of the db (whereas `:memory:` seems unconstrained). So that should prevent things like #820 

It also allows for some more advanced features that I may use in the future.

## Changelog description
Replace use of Python sqlite3 with APSW

## Status
- [X] Code base linted
- [X] Ready to go
