### PR TITLE
Add internal job to delete old, finished internal jobs

### DIFF
--- a/qcfractal/qcfractal/components/serverinfo/socket.py
+++ b/qcfractal/qcfractal/components/serverinfo/socket.py
@@ -94,7 +94,7 @@ class ServerInfoSocket:
 
         with self.root_socket.optional_session(session) as session:
             self.root_socket.internal_jobs.add(
-                "delete_access_log",
+                "delete_old_access_log",
                 now_at_utc() + timedelta(seconds=delay),
                 "serverinfo.delete_old_access_logs",
                 {},

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -390,6 +390,7 @@ class FractalConfig(ConfigBase):
     internal_job_processes: int = Field(
         1, description="Number of processes for processing internal jobs and async requests"
     )
+    internal_job_keep: int = Field(0, description="Number of days of finished internal job logs to keep. 0 means keep all")
 
     # Homepage settings
     homepage_redirect_url: Optional[str] = Field(None, description="Redirect to this URL when going to the root path")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Ability to remove old, finished internal jobs

The internal job queue can end up with lots of completed and useless information, so it would be nice to be able to automatically clean that up.

## Changelog description
Add internal job to delete old access logs

## Status
- [X] Code base linted
- [X] Ready to go
