### PR TITLE
Add property to get errored child records

### DIFF
--- a/qcfractal/qcfractal/components/record_routes.py
+++ b/qcfractal/qcfractal/components/record_routes.py
@@ -204,3 +204,10 @@ def get_record_native_file_data_v1(record_id: int, name: str, record_type: Optio
 def get_record_children_status_v1(record_id: int, record_type: Optional[str] = None):
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_children_status(record_id)
+
+
+@api_v1.route("/records/<string:record_type>/<int:record_id>/children_errors", methods=["GET"])
+@wrap_route("READ")
+def get_record_children_errors_v1(record_id: int, record_type: Optional[str] = None):
+    record_socket = storage_socket.records.get_socket(record_type)
+    return record_socket.get_children_errors(record_id)

--- a/qcfractal/qcfractal/components/services/test_client.py
+++ b/qcfractal/qcfractal/components/services/test_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from qcelemental.models import FailedOperation
+
+from qcfractal.components.torsiondrive.testing_helpers import (
+    submit_test_data as submit_td_test_data,
+    generate_task_key as generate_td_task_key,
+)
+from qcfractal.testing_helpers import run_service
+from qcportal.record_models import RecordStatusEnum, PriorityEnum
+from qcportal.utils import now_at_utc
+
+if TYPE_CHECKING:
+    from qcarchivetesting.testing_classes import QCATestingSnowflake
+
+
+def test_service_client_error(snowflake: QCATestingSnowflake):
+    storage_socket = snowflake.get_storage_socket()
+    activated_manager_name, _ = snowflake.activate_manager()
+    client = snowflake.client()
+
+    id_1, result_data_1 = submit_td_test_data(storage_socket, "td_H2O2_mopac_pm6", "test_tag", PriorityEnum.low)
+
+    # Inject a failed computation
+    failed_key = list(result_data_1.keys())[1]
+    result_data_1[failed_key] = FailedOperation(
+        error={"error_type": "test_error", "error_message": "this is just a test error"},
+    )
+
+    time_0 = now_at_utc()
+    finished, n_optimizations = run_service(
+        storage_socket, activated_manager_name, id_1, generate_td_task_key, result_data_1, 20
+    )
+    time_1 = now_at_utc()
+
+    rec = client.get_torsiondrives(id_1)
+    assert rec.status == RecordStatusEnum.error
+
+    err_opts = []
+    for optlist in rec.optimizations.values():
+        err_opts.extend(opt for opt in optlist if opt.status == RecordStatusEnum.error)
+    assert len(err_opts) == 1
+
+    assert rec.children_status[RecordStatusEnum.error] == 1
+    assert len(rec.children_errors) == 1
+
+    assert rec.children_errors[0].status == RecordStatusEnum.error
+    assert rec.children_errors[0].id == err_opts[0].id
+    assert rec.children_errors[0].error["error_type"] == "test_error"
+    assert rec.children_errors[0].error["error_message"] == "this is just a test error"

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -612,7 +612,7 @@ class BaseRecord(BaseModel):
 
     @property
     def children_status(self) -> Dict[RecordStatusEnum, int]:
-        """Returns a dicionary of the status of all children of this record"""
+        """Returns a dictionary of the status of all children of this record"""
         self._assert_online()
 
         return self._client.make_request(
@@ -620,6 +620,19 @@ class BaseRecord(BaseModel):
             f"{self._base_url}/children_status",
             Dict[RecordStatusEnum, int],
         )
+
+    @property
+    def children_errors(self) -> List[BaseRecord]:
+        """Returns errored child records"""
+        self._assert_online()
+
+        error_ids = self._client.make_request(
+            "get",
+            f"{self._base_url}/children_errors",
+            List[int],
+        )
+
+        return self._client._get_records_by_type(None, error_ids)
 
     @property
     def compute_history(self) -> List[ComputeHistory]:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This adds a property to records that gets information about errored children. This allows for a user to quickly get the child records of a service that caused the overall service to be errored.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Add property to get errored child records

## Status
- [X] Code base linted
- [X] Ready to go
