### PR TITLE
Better handling of queue tags (strict queue tags and case insensitivity) 

### DIFF
--- a/qcfractal/qcfractal/components/tasks/socket.py
+++ b/qcfractal/qcfractal/components/tasks/socket.py
@@ -249,6 +249,10 @@ class TaskSocket:
         # to claim absolutely everything. So double check here
         limit = calculate_limit(self._tasks_claim_limit, limit)
 
+        # Force given tags and programs to be lower case
+        tags = [tag.lower() for tag in tags]
+        programs = {key.lower(): [x.lower() for x in value] for key, value in programs.items()}
+
         with self.root_socket.optional_session(session) as session:
             stmt = select(ComputeManagerORM).where(ComputeManagerORM.name == manager_name)
             stmt = stmt.with_for_update(skip_locked=False)

--- a/qcfractal/qcfractal/components/tasks/test_socket_claim.py
+++ b/qcfractal/qcfractal/components/tasks/test_socket_claim.py
@@ -243,7 +243,8 @@ def test_task_socket_claim_tag(storage_socket: SQLAlchemySocket, session: Sessio
         recs.append(rec)
 
     # tag3 should be first, then tag1
-    tasks = storage_socket.tasks.claim_tasks(mname1.fullname, mprog1, ["tag3", "tag1"], 2)
+    # Change capitalization to test case insensitivity
+    tasks = storage_socket.tasks.claim_tasks(mname1.fullname, mprog1, ["Tag3", "Tag1"], 2)
     assert len(tasks) == 2
     assert tasks[0]["id"] == recs[3].task.id
     assert tasks[1]["id"] == recs[0].task.id
@@ -301,7 +302,9 @@ def test_task_socket_claim_tag_wildcard(storage_socket: SQLAlchemySocket, sessio
 
 def test_task_socket_claim_program(storage_socket: SQLAlchemySocket, session: Session):
     mname1 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-5678")
-    mprog1 = {"qcengine": ["unknown"], "psi4": ["unknown"], "geometric": ["v3.0"]}
+
+    # Managers should not send programs with uppercase characters, but be forgiving
+    mprog1 = {"QCengine": ["unknown"], "psi4": ["unknown"], "Geometric": ["V3.0"]}
     storage_socket.managers.activate(
         name_data=mname1,
         manager_version="v2.0",

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -338,6 +338,12 @@ class FractalConfig(ConfigBase):
         True,
         description="Allows unauthenticated read access to this instance. This does not extend to sensitive tables (such as user information)",
     )
+    strict_queue_tags: bool = Field(
+        False,
+        description="If True, disables wildcard behavior for queue tags. This disables managers from claiming all "
+        "tags if they specify a wildcard ('*') tag. Managers will still be able to claim tasks with an "
+        "explicit '*' tag if they specifiy the '*' queue tag in their config",
+    )
 
     # Logging and profiling
     logfile: Optional[str] = Field(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Some improvement to queue tags

* Fix bug where upper case tags in a manager config are ignored by the server (reported by @hjnpark)
* Add `strict_queue_tags` option. Enabling this option disables the wildcard-pulling behavior of manager ; managers that specify `'*'` as a queue tag will then only pull tasks marked with the `'*'` queue tag (requested by @peastman)

## Changelog description
Better handling of queue tags (strict queue tags and case insensitivity) 

## Status
- [X] Code base linted
- [X] Ready to go
