### PR TITLE
Better handling of passwords in init-db

### DIFF
--- a/qcarchivetesting/qcarchivetesting/config_files/gha_fractal_server.yaml
+++ b/qcarchivetesting/qcarchivetesting/config_files/gha_fractal_server.yaml
@@ -5,6 +5,8 @@ database:
   host: localhost
   logfile: qcfractal_postgres.log
   own: true
+  username: qcfractal
+  password: qcfractal1234
   port: 9876
 enable_security: false
 api:

--- a/qcarchivetesting/qcarchivetesting/config_files/qcf_basic.yaml
+++ b/qcarchivetesting/qcarchivetesting/config_files/qcf_basic.yaml
@@ -6,6 +6,8 @@ database:
   own: true
   port: 9987
   database_name: qcfractal_default
+  username: qcfractal
+  password: qcfractal1234
   logfile: qcfractal_postgres.log
 api:
   secret_key: THISISASECRETKEY 

--- a/qcarchivetesting/qcarchivetesting/migration_data/qcfractal_config_v0.15.8.yaml
+++ b/qcarchivetesting/qcarchivetesting/migration_data/qcfractal_config_v0.15.8.yaml
@@ -5,9 +5,9 @@ database:
   host: localhost
   logfile: qcfractal_postgres.log
   own: true
-  password: null
+  password: qcfractal1234
   port: 5444
-  username: null
+  username: qcfractal
 fractal:
   allow_read: true
   compress_response: true

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -137,8 +137,8 @@ class DatabaseConfig(ConfigBase):
         description="The port the database is running on. If own = True, a database will be started, binding to this port",
     )
     database_name: str = Field("qcfractal_default", description="The database name to connect to.")
-    username: Optional[str] = Field(None, description="The database username to connect with")
-    password: Optional[str] = Field(None, description="The database password to connect with")
+    username: str = Field(..., description="The database username to connect with")
+    password: str = Field(..., description="The database password to connect with")
     query: Dict[str, str] = Field({}, description="Extra connection query parameters at the end of the URL string")
 
     own: bool = Field(
@@ -561,8 +561,13 @@ def write_initial_configuration(file_path: str, full_config: bool = True):
     secret_key = secrets.token_urlsafe(32)
     jwt_secret_key = secrets.token_urlsafe(32)
 
+    db_config = {
+        "username": "qcfractal",
+        "password": secrets.token_urlsafe(32),
+    }
+
     default_config = FractalConfig(
-        base_folder=base_folder, api={"secret_key": secret_key, "jwt_secret_key": jwt_secret_key}
+        base_folder=base_folder, api={"secret_key": secret_key, "jwt_secret_key": jwt_secret_key}, database=db_config
     )
 
     default_config.database.port = find_open_port(5432)
@@ -580,7 +585,7 @@ def write_initial_configuration(file_path: str, full_config: bool = True):
             "service_frequency": True,
             "max_active_services": True,
             "heartbeat_frequency": True,
-            "database": {"own", "host", "port", "database_name", "base_folder"},
+            "database": {"own", "host", "port", "database_name", "base_folder", "username", "password"},
             "api": {"secret_key", "jwt_secret_key", "host", "port"},
         }
 

--- a/qcfractal/qcfractal/test_db_connection.py
+++ b/qcfractal/qcfractal/test_db_connection.py
@@ -21,8 +21,15 @@ from qcfractal.postgres_harness import PostgresHarness
             "testing_db_maint_1",
             {"connect_timeout": 10},
         ),
-        ("192.168.1.234", 6543, "test_user_1", None, "testing_db_2", "testing_db_maint_2", {"connect_timeout": 10}),
-        ("db.example.com", 9988, None, None, "testing_db_3", "testing_db_maint_3", {"connect_timeout": 10}),
+        (
+            "192.168.1.234",
+            6543,
+            "test_user_1",
+            "test_pass_2",
+            "testing_db_2",
+            "testing_db_maint_2",
+            {"connect_timeout": 10},
+        ),
         (
             "/var/run/postgresql",
             9876,
@@ -142,7 +149,7 @@ def test_db_connection_hosts(tmp_path_factory):
     pg_harness = PostgresHarness(db_config)
 
     # Change trust method so we can actually check passwords
-    pg_harness.initialize_postgres(auth_method="scram-sha-256")
+    pg_harness.initialize_postgres()
     pg_harness.create_database(create_tables=True)
     assert pg_harness.can_connect()
 
@@ -178,7 +185,7 @@ def test_db_connection_full_uri(tmp_path_factory):
     pg_harness = PostgresHarness(db_config)
 
     # Change trust method so we can actually check passwords
-    pg_harness.initialize_postgres(auth_method="scram-sha-256")
+    pg_harness.initialize_postgres()
     pg_harness.create_database(create_tables=True)
     assert pg_harness.can_connect()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Before, the database password was written to a temporary file to be read by init-db. This PR fixes that.

This PR also makes database passwords mandatory in the configuration file.

This is only really relevant if `own=True`. If you have an existing db initialized with the previous code, you will need to set the username to the username of your computer, and the password to any arbitrary string. Or backup/restore.

## Status
- [X] Code base linted
- [X] Ready to go
