### PR TITLE
Pin APSW to a relatively recent version

### DIFF
--- a/qcarchivetesting/conda-envs/fulltest_qcportal.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_qcportal.yaml
@@ -11,7 +11,7 @@ dependencies:
   - pyyaml
   - pydantic
   - zstandard
-  - apsw
+  - apsw>=3.42
   - qcelemental<0.70a0
   - tabulate
   - tqdm

--- a/qcarchivetesting/conda-envs/fulltest_server.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_server.yaml
@@ -15,7 +15,7 @@ dependencies:
   - pyyaml
   - pydantic
   - zstandard
-  - apsw
+  - apsw>=3.42
   - qcelemental<0.70a0
   - tabulate
   - tqdm

--- a/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
@@ -15,7 +15,7 @@ dependencies:
   - pyyaml
   - pydantic
   - zstandard
-  - apsw
+  - apsw>=3.42
   - qcelemental<0.70a0
   - tabulate
   - tqdm

--- a/qcarchivetesting/conda-envs/fulltest_worker.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_worker.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pyyaml
   - pydantic
   - zstandard
-  - apsw
+  - apsw>=3.42
   - qcelemental<0.70a0
   - tabulate
   - tqdm

--- a/qcportal/pyproject.toml
+++ b/qcportal/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyyaml",
     "pydantic",
     "zstandard",
-    "apsw",
+    "apsw>=3.42",
     "qcelemental<0.70a0",
     "tabulate",
     "tqdm",


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

We require APSW v3.42 or newer because we use `pragma` to enable foreign key features in sqlite.

See https://github.com/conda-forge/qcfractal-feedstock/issues/51

## Status
- [X] Code base linted
- [X] Ready to go
