### PR TITLE
Add qcportal as dependency to qcfractal

### DIFF
--- a/qcfractal/pyproject.toml
+++ b/qcfractal/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "sqlalchemy >=2.0",
     "alembic",
     "psycopg2",
+    "qcportal",
 ]
 
 


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
Adds QCElemental as a dependency for QCFractal in `pyproject.toml`. Don't know how this was missed, but doesn't really affect much (installing QCFractal, without services, via pip is probably very rare)

## Status
- [X] Code base linted
- [X] Ready to go
