### PR TITLE
Managers claiming/returning should be marked as modified

### DIFF
--- a/qcfractal/qcfractal/components/tasks/socket.py
+++ b/qcfractal/qcfractal/components/tasks/socket.py
@@ -190,6 +190,9 @@ class TaskSocket:
             manager.failures += len(tasks_failures)
             manager.rejected += len(tasks_rejected)
 
+            # Mark that we have heard from the manager
+            manager.modified_on = now_at_utc()
+
             # Automatically reset ones that should be reset
             if self.root_socket.qcf_config.auto_reset.enabled and to_be_reset:
                 self._logger.info(f"Auto resetting {len(to_be_reset)} records")
@@ -340,6 +343,9 @@ class TaskSocket:
                 session.flush()
 
             manager.claimed += len(found)
+
+            # Mark that we have heard from the manager
+            manager.modified_on = now_at_utc()
 
             self._logger.info(f"Manager {manager_name} has claimed {len(found)} new tasks")
 


### PR DESCRIPTION
## Description

When a manager claims or returns tasks, that should count towards the server as having heard from the manager (for heartbeat purposes). Without this, a manager could get stuck returning or claiming lots of data, but then be marked as inactive by the server since the heartbeat mechanism has been block by the other actions.

This is a bit of a bandaid. The next iteration of the manager should probably use a separate threads for heartbeat and updates, which would also help.

Hopefully helps with #850 

## Status
- [X] Code base linted
- [X] Ready to go
