### PR TITLE
Lazy-load pandas

### DIFF
--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -19,8 +19,6 @@ from typing import (
     Mapping,
 )
 
-import pandas as pd
-
 try:
     import pydantic.v1 as pydantic
     from pydantic.v1 import BaseModel, Extra, validator, PrivateAttr, Field
@@ -40,6 +38,7 @@ from qcportal.cache import DatasetCache, read_dataset_metadata, get_records_with
 
 if TYPE_CHECKING:
     from qcportal.client import PortalClient
+    from pandas import DataFrame
 
 
 class Citation(BaseModel):
@@ -1422,7 +1421,7 @@ class BaseDataset(BaseModel):
         entry_names: Optional[Union[str, Iterable[str]]] = None,
         specification_names: Optional[Union[str, Iterable[str]]] = None,
         unpack: bool = False,
-    ) -> pd.DataFrame:
+) -> "DataFrame":
         """
         Compile values from records into a pandas DataFrame.
 
@@ -1450,7 +1449,7 @@ class BaseDataset(BaseModel):
 
         Returns
         --------
-        pd.DataFrame
+        pandas.DataFrame
             A multi-index DataFrame where each row corresponds to an entry. Each column corresponds has a top level
             index as a specification, and a second level index as the appropriate value name.
             Values are extracted from records using 'value_call'.
@@ -1468,6 +1467,8 @@ class BaseDataset(BaseModel):
         to be distributed across columns in the resulting DataFrame. 'value_call' should always return the
         same number of values for each record if unpack is True.
         """
+        import pandas as pd
+
 
         def _data_generator(unpack=False):
             for entry_name, spec_name, record in self.iterate_records(
@@ -1511,7 +1512,7 @@ class BaseDataset(BaseModel):
         # Make specification top level index.
         return return_val.swaplevel(axis=1)
 
-    def get_properties_df(self, properties_list: Sequence[str]) -> pd.DataFrame:
+    def get_properties_df(self, properties_list: Sequence[str]) -> "DataFrame":
         """
         Retrieve a DataFrame populated with the specified properties from dataset records.
 
@@ -1528,7 +1529,7 @@ class BaseDataset(BaseModel):
 
         Returns:
         --------
-        pd.DataFrame
+        pandas.DataFrame
             A DataFrame populated with the specified properties for each record.
         """
 


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Currently, a little less than half of the time taken to import anything from QCPortal is spend dealing with Pandas. I think most use cases don't involve [its direct use](https://github.com/search?q=repo%3AMolSSI%2FQCFractal%20import%20pandas&type=code), so it can be loaded later when needed. This improvement should propagate to downstream packages which want to i.e. use `PortalClient` or build off of record models but don't need Pandas.

Before:

```shell
$ hyperfine \                                                                    14:31:18  ☁  4ebcd88f ☀
    'python -c "from qcportal import PortalClient"' \
    --prepare \
    'python -c "from qcportal import PortalClient"'
Benchmark 1: python -c "from qcportal import PortalClient"
  Time (mean ± σ):     621.8 ms ±  10.0 ms    [User: 514.2 ms, System: 96.5 ms]
  Range (min … max):   608.4 ms … 642.9 ms    10 runs

```

```shell
$ python -X importtime -c "from qcportal import PortalClient" 2> tuna.log && tuna tuna.log
```

![image](https://github.com/user-attachments/assets/a3ac0112-176b-413b-9eb6-a137259f97ac)

With these changes:

```shell
$ fc                                                                     14:27:45  ☁  lazy-load-pandas ☀
hyperfine \
    'python -c "from qcportal import PortalClient"' \
    --prepare \
    'python -c "from qcportal import PortalClient"'
Benchmark 1: python -c "from qcportal import PortalClient"
  Time (mean ± σ):     375.1 ms ±   7.5 ms    [User: 318.7 ms, System: 50.1 ms]
  Range (min … max):   368.1 ms … 394.3 ms    10 runs
```
## Status
- [ ] Code base linted
- [ ] Ready to go
