### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         encoding: ["application/json", "application/msgpack"]
         
     steps:

--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/full_tests_snowflake.yml
+++ b/.github/workflows/full_tests_snowflake.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         
     steps:
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

This PR drops Python 3.8, which is past its EOL, from testing.

## Status
- [ ] Code base linted
- [ ] Ready to go
