### PR TITLE
Add option for opt-in usage tracking for Parsl

### DIFF
--- a/qcfractalcompute/qcfractalcompute/compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/compute_manager.py
@@ -270,7 +270,10 @@ class ComputeManager:
         # Set up Parsl executors and DataFlowKernel
         ###########################################
         self.parsl_config = ParslConfig(
-            executors=[], initialize_logging=False, run_dir=self.manager_config.parsl_run_dir
+            executors=[],
+            initialize_logging=False,
+            run_dir=self.manager_config.parsl_run_dir,
+            usage_tracking=self.manager_config.parsl_usage_tracking,
         )
         self.dflow_kernel = DataFlowKernel(self.parsl_config)
 

--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -208,6 +208,7 @@ class FractalComputeConfig(BaseModel):
     )
 
     parsl_run_dir: str = "parsl_run_dir"
+    parsl_usage_tracking: int = 0
 
     server: FractalServerSettings = Field(...)
     environments: PackageEnvironmentSettings = PackageEnvironmentSettings()


### PR DESCRIPTION
## Description

Parsl contains an option to enable the Parsl team to collect statistics regarding Parsl usage. This collection and tracking is  is <ins>**opt-in**</ins>.

This PR adds an option to the manager config to set the usage data tracking level for data sent back to the Parsl team.

By default, the tracking is disabled (level = 0).

For more info about what is collected & the rationale for collection, see https://parsl.readthedocs.io/en/stable/userguide/usage_tracking.html

## Status
- [X] Code base linted
- [X] Ready to go
