### PR TITLE
Pin pyjwt & enable invalid subject handling

### DIFF
--- a/qcarchivetesting/conda-envs/fulltest_qcportal.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_qcportal.yaml
@@ -16,7 +16,7 @@ dependencies:
   - tabulate
   - tqdm
   - pandas
-  - pyjwt
+  - pyjwt>=2.10.0
   - packaging
   - typing_extensions
   - python-dateutil

--- a/qcarchivetesting/conda-envs/fulltest_server.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_server.yaml
@@ -20,7 +20,7 @@ dependencies:
   - tabulate
   - tqdm
   - pandas
-  - pyjwt
+  - pyjwt>=2.10.0
   - packaging
   - typing_extensions
   - python-dateutil

--- a/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
@@ -20,7 +20,7 @@ dependencies:
   - tabulate
   - tqdm
   - pandas
-  - pyjwt
+  - pyjwt>=2.10.0
   - packaging
   - typing_extensions
   - python-dateutil

--- a/qcarchivetesting/conda-envs/fulltest_worker.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_worker.yaml
@@ -19,7 +19,7 @@ dependencies:
   - tabulate
   - tqdm
   - pandas
-  - pyjwt
+  - pyjwt>=2.10.0
   - packaging
   - typing_extensions
   - python-dateutil

--- a/qcfractal/qcfractal/flask_app/handlers.py
+++ b/qcfractal/qcfractal/flask_app/handlers.py
@@ -10,6 +10,7 @@ from flask_jwt_extended import (
     set_access_cookies,
     get_jwt_request_location,
 )
+from jwt.exceptions import InvalidSubjectError
 from werkzeug.exceptions import InternalServerError, HTTPException
 
 from qcfractal.flask_app import storage_socket
@@ -172,3 +173,10 @@ def handle_auth_error(error):
 def handle_compute_manager_error(error: ComputeManagerError):
     # Handle compute manager errors
     return jsonify(msg=str(error)), 400
+
+
+@home_v1.app_errorhandler(InvalidSubjectError)
+def handle_old_tokens(error):
+    # Handle old tokens that have integers as the subject
+    # Just say they have been expired, and you need to login again
+    return jsonify(msg="Token has expired"), 401

--- a/qcportal/pyproject.toml
+++ b/qcportal/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "tabulate",
     "tqdm",
     "pandas",
-    "pyjwt",
+    "pyjwt>=2.10",
     "packaging",
     "typing_extensions",
     "python-dateutil",


### PR DESCRIPTION
## Description

An update to pyjwt enforces the standard that subjects of the JWT are strings. We use integers (ids).

So the fix:
1. Move to using strings (just stringified int)
2. Add a handler to return that the token is expired if the validation in pyjwt fails with InvalidSubjectError.
3. That exception only exists in pyjwt 2.10.0 and above, so pin that version.

Only affects servers, not clients. Upgrading a server should be transparent to clients.

## Status
- [X] Code base linted
- [X] Ready to go
