### PR TITLE
Adding entry attribute modification.

### DIFF
--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -266,11 +266,13 @@ def rename_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dic
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.rename_entries(dataset_id, body_data)
 
+
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/entries/modify", methods=["PATCH"])
 @wrap_route("WRITE")
 def modify_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dict[str, Dict[str, Any]]):
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.modify_entries(dataset_id, body_data)
+
 
 #########################
 # Records

--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Any
 
 from flask import current_app, g
 
@@ -266,6 +266,11 @@ def rename_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dic
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.rename_entries(dataset_id, body_data)
 
+@api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/entries/modify", methods=["PATCH"])
+@wrap_route("WRITE")
+def modify_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dict[str, Dict[str, Any]]):
+    ds_socket = storage_socket.datasets.get_socket(dataset_type)
+    return ds_socket.modify_entries(dataset_id, body_data)
 
 #########################
 # Records

--- a/qcfractal/qcfractal/components/dataset_socket.py
+++ b/qcfractal/qcfractal/components/dataset_socket.py
@@ -983,6 +983,33 @@ class BaseDatasetSocket:
             for entry in entries:
                 entry.name = entry_name_map[entry.name]
 
+    def modify_entries(self, dataset_id: int, entry_name_map: Dict[str, Dict[str, Any]], *, session: Optional[Session] = None):
+        """
+        Modify the attributes of the entries in a dataset
+
+        The entry_name_map maps the name of the entry to the new attribute data.
+
+        Parameters
+        ----------
+        dataset_id
+            ID of a dataset
+        entry_name_map
+            Mapping of entry names to attributes.
+        session
+            An existing SQLAlchemy session to use. If None, one will be created. If an existing session
+            is used, it will be flushed (but not committed) before returning from this function.
+        """
+        stmt = select(self.entry_orm)
+        stmt = stmt.where(self.entry_orm.dataset_id == dataset_id)
+        stmt = stmt.where(self.entry_orm.name.in_(entry_name_map.keys()))
+        stmt = stmt.options(load_only(self.entry_orm.name))
+
+        with self.root_socket.optional_session(session) as session:
+            entries = session.execute(stmt).scalars().all()
+
+            for entry in entries:
+                entry.attributes = entry_name_map[entry.name]
+
     def fetch_records(
         self,
         dataset_id: int,

--- a/qcfractal/qcfractal/components/dataset_socket.py
+++ b/qcfractal/qcfractal/components/dataset_socket.py
@@ -983,7 +983,9 @@ class BaseDatasetSocket:
             for entry in entries:
                 entry.name = entry_name_map[entry.name]
 
-    def modify_entries(self, dataset_id: int, entry_name_map: Dict[str, Dict[str, Any]], *, session: Optional[Session] = None):
+    def modify_entries(
+        self, dataset_id: int, entry_name_map: Dict[str, Dict[str, Any]], *, session: Optional[Session] = None
+    ):
         """
         Modify the attributes of the entries in a dataset
 

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -793,6 +793,17 @@ class BaseDataset(BaseModel):
         for old_name, new_name in name_map.items():
             self._cache_data.rename_entry(old_name, new_name)
 
+    def modify_entries(self, name_map: Dict[str, Dict[str, Any]]):
+        self.assert_is_not_view()
+        self.assert_online()
+
+        self._client.make_request(
+            "patch", f"api/v1/datasets/{self.dataset_type}/{self.id}/entries/modify", None, body=name_map
+        )
+        
+        # Sync local cache with updated server.
+        self.fetch_entries(entry_names, force_refetch=True)
+
     def delete_entries(self, names: Union[str, Iterable[str]], delete_records: bool = False) -> DeleteMetadata:
         self.assert_is_not_view()
         self.assert_online()

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -800,7 +800,7 @@ class BaseDataset(BaseModel):
         self._client.make_request(
             "patch", f"api/v1/datasets/{self.dataset_type}/{self.id}/entries/modify", None, body=name_map
         )
-        
+
         # Sync local cache with updated server.
         self.fetch_entries(entry_names, force_refetch=True)
 

--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -138,6 +138,28 @@ def run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_spec
     assert ds._cache_data.get_dataset_record(entry_name_3, "spec_1").id == ent_rec_map[entry_name_3].id
 
 
+def run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs):
+    ds.add_specification("spec_1", test_specs[0])
+    ds.add_entries(test_entries)
+    ds.submit()
+    ds.fetch_entries()
+
+    ent_rec_map = {entry_name: record for entry_name, _, record in ds.iterate_records()}
+    assert len(ent_rec_map) == 3
+
+    entry_name_1 = test_entries[0].name
+    entry_name_2 = test_entries[1].name
+    entry_name_3 = test_entries[2].name
+
+    #ds.rename_entries({entry_name_1: entry_name_1 + "new", entry_name_2: entry_name_2 + "new"})
+    ds.modify_entries({entry_name_1: {"test_attr_1": "val", "test_attr_2": 5}})
+
+    assert set(ds._cache_data.get_entry().attributes == {entry_name_1: {"test_attr_1": "val", "test_attr_2": 5}})
+    #assert set(ds.entry_names) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
+    #assert set(ds._entry_names) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
+    #assert set(ds._cache_data.get_entry_names()) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
+
+
 def run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs):
     ds.add_specification("spec_1", test_specs[0])
     ds.add_entries(test_entries)

--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -151,13 +151,9 @@ def run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_sp
     entry_name_2 = test_entries[1].name
     entry_name_3 = test_entries[2].name
 
-    # ds.rename_entries({entry_name_1: entry_name_1 + "new", entry_name_2: entry_name_2 + "new"})
     ds.modify_entries({entry_name_1: {"test_attr_1": "val", "test_attr_2": 5}})
 
     assert set(ds._cache_data.get_entry().attributes == {entry_name_1: {"test_attr_1": "val", "test_attr_2": 5}})
-    # assert set(ds.entry_names) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
-    # assert set(ds._entry_names) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
-    # assert set(ds._cache_data.get_entry_names()) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
 
 
 def run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs):

--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -151,13 +151,13 @@ def run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_sp
     entry_name_2 = test_entries[1].name
     entry_name_3 = test_entries[2].name
 
-    #ds.rename_entries({entry_name_1: entry_name_1 + "new", entry_name_2: entry_name_2 + "new"})
+    # ds.rename_entries({entry_name_1: entry_name_1 + "new", entry_name_2: entry_name_2 + "new"})
     ds.modify_entries({entry_name_1: {"test_attr_1": "val", "test_attr_2": 5}})
 
     assert set(ds._cache_data.get_entry().attributes == {entry_name_1: {"test_attr_1": "val", "test_attr_2": 5}})
-    #assert set(ds.entry_names) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
-    #assert set(ds._entry_names) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
-    #assert set(ds._cache_data.get_entry_names()) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
+    # assert set(ds.entry_names) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
+    # assert set(ds._entry_names) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
+    # assert set(ds._cache_data.get_entry_names()) == {entry_name_1 + "new", entry_name_2 + "new", entry_name_3}
 
 
 def run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs):

--- a/qcportal/qcportal/gridoptimization/test_dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/test_dataset_models.py
@@ -125,6 +125,7 @@ def test_gridoptimization_dataset_model_rename_entry(snowflake_client: PortalCli
     ds = snowflake_client.add_dataset("gridoptimization", "Test dataset")
     ds_helpers.run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_specs)
 
+
 def test_gridoptimization_dataset_model_modify_entries(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("gridoptimization", "Test dataset")
     ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)

--- a/qcportal/qcportal/gridoptimization/test_dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/test_dataset_models.py
@@ -125,6 +125,10 @@ def test_gridoptimization_dataset_model_rename_entry(snowflake_client: PortalCli
     ds = snowflake_client.add_dataset("gridoptimization", "Test dataset")
     ds_helpers.run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_specs)
 
+def test_gridoptimization_dataset_model_modify_entries(snowflake_client: PortalClient):
+    ds = snowflake_client.add_dataset("gridoptimization", "Test dataset")
+    ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)
+
 
 def test_gridoptimization_dataset_model_delete_entry(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("gridoptimization", "Test dataset")

--- a/qcportal/qcportal/manybody/test_dataset_models.py
+++ b/qcportal/qcportal/manybody/test_dataset_models.py
@@ -82,6 +82,11 @@ def test_manybody_dataset_model_rename_entry(snowflake_client: PortalClient):
     ds_helpers.run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_specs)
 
 
+def test_manybody_dataset_model_modify_entries(snowflake_client: PortalClient):
+    ds = snowflake_client.add_dataset("manybody", "Test dataset")
+    ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)
+
+
 def test_manybody_dataset_model_delete_entry(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("manybody", "Test dataset")
     ds_helpers.run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs)

--- a/qcportal/qcportal/neb/test_dataset_models.py
+++ b/qcportal/qcportal/neb/test_dataset_models.py
@@ -128,6 +128,11 @@ def test_neb_dataset_model_rename_entry(snowflake_client: PortalClient):
     ds_helpers.run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_specs)
 
 
+def test_neb_dataset_model_modify_entries(snowflake_client: PortalClient):
+    ds = snowflake_client.add_dataset("neb", "Test dataset")
+    ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)
+
+
 def test_neb_dataset_model_delete_entry(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("neb", "Test dataset")
     ds_helpers.run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs)

--- a/qcportal/qcportal/optimization/test_dataset_models.py
+++ b/qcportal/qcportal/optimization/test_dataset_models.py
@@ -84,6 +84,11 @@ def test_optimization_dataset_model_rename_entry(snowflake_client: PortalClient)
     ds_helpers.run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_specs)
 
 
+def test_optimization_dataset_model_modify_entries(snowflake_client: PortalClient):
+    ds = snowflake_client.add_dataset("optimization", "Test dataset")
+    ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)
+
+
 def test_optimization_dataset_model_delete_entry(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("optimization", "Test dataset")
     ds_helpers.run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs)

--- a/qcportal/qcportal/reaction/test_dataset_models.py
+++ b/qcportal/qcportal/reaction/test_dataset_models.py
@@ -107,7 +107,7 @@ def test_reaction_dataset_model_rename_entry(snowflake_client: PortalClient):
 def test_reaction_dataset_model_modify_entries(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("reaction", "Test dataset")
     ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)
-    
+
 
 def test_reaction_dataset_model_delete_entry(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("reaction", "Test dataset")

--- a/qcportal/qcportal/reaction/test_dataset_models.py
+++ b/qcportal/qcportal/reaction/test_dataset_models.py
@@ -104,6 +104,11 @@ def test_reaction_dataset_model_rename_entry(snowflake_client: PortalClient):
     ds_helpers.run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_specs)
 
 
+def test_reaction_dataset_model_modify_entries(snowflake_client: PortalClient):
+    ds = snowflake_client.add_dataset("reaction", "Test dataset")
+    ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)
+    
+
 def test_reaction_dataset_model_delete_entry(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("reaction", "Test dataset")
     ds_helpers.run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs)

--- a/qcportal/qcportal/singlepoint/test_dataset_models.py
+++ b/qcportal/qcportal/singlepoint/test_dataset_models.py
@@ -69,6 +69,11 @@ def test_singlepoint_dataset_model_rename_entry(snowflake_client: PortalClient):
     ds_helpers.run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_specs)
 
 
+def test_singlepoint_dataset_model_modify_entries(snowflake_client: PortalClient):
+    ds = snowflake_client.add_dataset("singlepoint", "Test dataset")
+    ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)
+
+
 def test_singlepoint_dataset_model_delete_entry(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("singlepoint", "Test dataset")
     ds_helpers.run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs)

--- a/qcportal/qcportal/torsiondrive/test_dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/test_dataset_models.py
@@ -131,6 +131,11 @@ def test_torsiondrive_dataset_model_rename_entry(snowflake_client: PortalClient)
     ds_helpers.run_dataset_model_rename_entry(snowflake_client, ds, test_entries, test_specs)
 
 
+def test_torsiondrive_dataset_model_modify_entries(snowflake_client: PortalClient):
+    ds = snowflake_client.add_dataset("torsiondrive", "Test dataset")
+    ds_helpers.run_dataset_model_modify_entries(snowflake_client, ds, test_entries, test_specs)
+
+
 def test_torsiondrive_dataset_model_delete_entry(snowflake_client: PortalClient):
     ds = snowflake_client.add_dataset("torsiondrive", "Test dataset")
     ds_helpers.run_dataset_model_delete_entry(snowflake_client, ds, test_entries, test_specs)


### PR DESCRIPTION
## Description
This PR aims to add the ability to modify the attributes of an entry within a dataset.
Similar to renaming an entry, this takes a mapping of entry names to the updated attribute values. The current implementation does a full replacement of the attributes of an entry.

## Status
- [x] Code base linted
- [ ] Ready to go
