### PR TITLE
Additional checks if dataset records aren't able to be fetched

### DIFF
--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1081,7 +1081,8 @@ class BaseDataset(BaseModel):
         record = None
         if force_refetch:
             records = self._internal_fetch_records([entry_name], [specification_name], None, include)
-            record = records[0][2]
+            if records:
+                record = records[0][2]
         elif fetch_updated:
             records = self._internal_update_records([entry_name], [specification_name], None, include)
             if records:
@@ -1094,7 +1095,8 @@ class BaseDataset(BaseModel):
         if record is None and not self.is_view:
             # not in cache
             records = self._internal_fetch_records([entry_name], [specification_name], None, include)
-            record = records[0][2]
+            if records:
+                record = records[0][2]
 
         if record is not None and self._client is not None:
             record.propagate_client(self._client)


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

If a particular entry/specification does not exist in a dataset, `get_record` can end up trying to access elements of a list that don't exist. This fixes that with some additional checks

## Status
- [X] Code base linted
- [X] Ready to go
