### PR TITLE
Add extra compute route for information (for logging)

### DIFF
--- a/qcfractal/qcfractal/alembic/versions/2024-12-13-f8a7c273f18a_update_compute_role_for_new_endpoint.py
+++ b/qcfractal/qcfractal/alembic/versions/2024-12-13-f8a7c273f18a_update_compute_role_for_new_endpoint.py
@@ -1,0 +1,35 @@
+"""Update compute role for new endpoint
+
+Revision ID: f8a7c273f18a
+Revises: d03466436fec
+Create Date: 2024-12-13 15:39:28.701912
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f8a7c273f18a"
+down_revision = "d03466436fec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    stmt = """
+        UPDATE "role" SET permissions = jsonb_build_object(
+                    'Statement', (permissions->'Statement')::jsonb || jsonb_build_object(
+                               'Effect', 'Allow',
+                               'Action', jsonb_build_array('READ'),
+                               'Resource', '/compute/v1/information'
+                )
+            )::json
+        WHERE rolename = 'compute'
+        """
+
+    op.execute(sa.text(stmt))
+
+
+def downgrade():
+    pass

--- a/qcfractal/qcfractal/components/auth/role_socket.py
+++ b/qcfractal/qcfractal/components/auth/role_socket.py
@@ -59,6 +59,7 @@ default_roles: Dict[str, Any] = {
     "compute": {
         "Statement": [
             {"Effect": "Allow", "Action": ["READ"], "Resource": "/api/v1/information"},
+            {"Effect": "Allow", "Action": ["READ"], "Resource": "/compute/v1/information"},
             {"Effect": "Allow", "Action": ["READ", "WRITE"], "Resource": "/api/v1/users"},
             {"Effect": "Allow", "Action": "*", "Resource": ["/compute/v1/managers", "/compute/v1/tasks"]},
         ]

--- a/qcfractal/qcfractal/components/serverinfo/routes.py
+++ b/qcfractal/qcfractal/components/serverinfo/routes.py
@@ -1,9 +1,9 @@
 from flask import current_app
 
-from qcfractal import __version__ as qcfractal_version
 from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.api_v1.helpers import wrap_route
+from qcfractal.flask_app.helpers import get_public_server_information
 from qcportal.serverinfo import (
     AccessLogSummaryFilters,
     AccessLogQueryFilters,
@@ -16,23 +16,7 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/information", methods=["GET"])
 @wrap_route("READ")
 def get_information():
-    qcf_cfg = current_app.config["QCFRACTAL_CONFIG"]
-
-    # TODO - remove version limits after a while. They are there to support older clients
-    public_info = {
-        "name": qcf_cfg.name,
-        "manager_heartbeat_frequency": qcf_cfg.heartbeat_frequency,
-        "manager_heartbeat_max_missed": qcf_cfg.heartbeat_max_missed,
-        "version": qcfractal_version,
-        "api_limits": qcf_cfg.api_limits.dict(),
-        "client_version_lower_limit": "0.50",
-        "client_version_upper_limit": "1.00",
-        "manager_version_lower_limit": "0.50",
-        "manager_version_upper_limit": "1.00",
-        "motd": storage_socket.serverinfo.get_motd(),
-    }
-
-    return public_info
+    return get_public_server_information()
 
 
 @api_v1.route("/motd", methods=["GET"])

--- a/qcfractal/qcfractal/flask_app/compute_v1/routes.py
+++ b/qcfractal/qcfractal/flask_app/compute_v1/routes.py
@@ -1,0 +1,9 @@
+from qcfractal.flask_app.api_v1.helpers import wrap_route
+from qcfractal.flask_app.compute_v1.blueprint import compute_v1
+from qcfractal.flask_app.helpers import get_public_server_information
+
+
+@compute_v1.route("/information", methods=["GET"])
+@wrap_route("READ")
+def get_information():
+    return get_public_server_information()

--- a/qcfractal/qcfractal/flask_app/flask_app.py
+++ b/qcfractal/qcfractal/flask_app/flask_app.py
@@ -89,6 +89,7 @@ def create_flask_app(
     # Must be done before registering the blueprint
     importlib.import_module("qcfractal.flask_app.api_v1.routes")
     importlib.import_module("qcfractal.flask_app.auth_v1.routes")
+    importlib.import_module("qcfractal.flask_app.compute_v1.routes")
     importlib.import_module("qcfractal.flask_app.dashboard_v1.routes")
     importlib.import_module("qcfractal.components.register_all")
 

--- a/qcfractal/qcfractal/flask_app/helpers.py
+++ b/qcfractal/qcfractal/flask_app/helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple, Optional
 from urllib.parse import urlparse
+from qcfractal import __version__ as qcfractal_version
 
 from flask import request, g, current_app
 from flask_jwt_extended import (
@@ -172,3 +173,23 @@ def login_and_get_jwt(get_refresh_token: bool) -> Tuple[str, Optional[str]]:
 
     current_app.logger.info(f"Successful login for user {username}")
     return access_token, refresh_token
+
+
+def get_public_server_information():
+    qcf_cfg = current_app.config["QCFRACTAL_CONFIG"]
+
+    # TODO - remove version limits after a while. They are there to support older clients
+    public_info = {
+        "name": qcf_cfg.name,
+        "manager_heartbeat_frequency": qcf_cfg.heartbeat_frequency,
+        "manager_heartbeat_max_missed": qcf_cfg.heartbeat_max_missed,
+        "version": qcfractal_version,
+        "api_limits": qcf_cfg.api_limits.dict(),
+        "client_version_lower_limit": "0.50",
+        "client_version_upper_limit": "1.00",
+        "manager_version_lower_limit": "0.50",
+        "manager_version_upper_limit": "1.00",
+        "motd": storage_socket.serverinfo.get_motd(),
+    }
+
+    return public_info

--- a/qcportal/qcportal/client_base.py
+++ b/qcportal/qcportal/client_base.py
@@ -73,6 +73,8 @@ class PortalClientBase:
         password: Optional[str] = None,
         verify: bool = True,
         show_motd: bool = True,
+        *,
+        information_endpoint: str = "api/v1/information",
     ) -> None:
         """Initializes a PortalClient instance from an address and verification information.
 
@@ -96,6 +98,9 @@ class PortalClientBase:
 
         # For developer use and debugging
         self.debug_requests = False
+
+        # Where we get the server information from
+        self._information_endpoint = information_endpoint.strip("/")
 
         if not address.startswith("http://") and not address.startswith("https://"):
             address = "https://" + address
@@ -451,4 +456,4 @@ class PortalClientBase:
         """
 
         # Request the info, and store here for later use
-        return self.make_request("get", "api/v1/information", Dict[str, Any])
+        return self.make_request("get", self._information_endpoint, Dict[str, Any])

--- a/qcportal/qcportal/manager_client.py
+++ b/qcportal/qcportal/manager_client.py
@@ -43,7 +43,13 @@ class ManagerClient(PortalClientBase):
         """
 
         PortalClientBase.__init__(
-            self, address=address, username=username, password=password, verify=verify, show_motd=show_motd
+            self,
+            address=address,
+            username=username,
+            password=password,
+            verify=verify,
+            show_motd=show_motd,
+            information_endpoint="compute/v1/information",
         )
 
         self.manager_name_data = name_data


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Right now, compute workers get info from the server via `/api/v1/information`.  This PR allows managers to contact `/compute/v1/information` instead. This allows for cleaner metrics between general API usage and compute workers. Old managers can still be run as the `/api/v1/information` endpoint will still be available.

NOTE: default roles have changed (new API route added to the "compute" role), so there is a tiny migration adding the those permissions.

## Status
- [X] Code base linted
- [X] Ready to go
