### PR TITLE
Allow for manual specification of snowflake host

### DIFF
--- a/qcarchivetesting/qcarchivetesting/testing_classes.py
+++ b/qcarchivetesting/qcarchivetesting/testing_classes.py
@@ -70,7 +70,7 @@ class QCATestingPostgresServer:
 
     def __init__(self, db_path: str):
         self.logger = logging.getLogger(__name__)
-        self.harness = create_snowflake_postgres(db_path)
+        self.harness = create_snowflake_postgres("localhost", db_path)
         self.logger.debug(f"Using database located at {db_path} with uri {self.harness.config.safe_uri}")
 
         # Postgres process is up, but the database is not created

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -296,7 +296,7 @@ class WebAPIConfig(ConfigBase):
         description="If the master process does not hear from a worker for the given amount of time (in seconds),"
         "kill it. This effectively limits the time a worker has to respond to a request",
     )
-    host: str = Field("127.0.0.1", description="The IP address or hostname to bind to")
+    host: str = Field("localhost", description="The IP address or hostname to bind to")
     port: int = Field(7777, description="The port on which to run the REST interface.")
 
     secret_key: str = Field(..., description="Secret key for flask api. See documentation")
@@ -570,8 +570,8 @@ def write_initial_configuration(file_path: str, full_config: bool = True):
         base_folder=base_folder, api={"secret_key": secret_key, "jwt_secret_key": jwt_secret_key}, database=db_config
     )
 
-    default_config.database.port = find_open_port(5432)
-    default_config.api.port = find_open_port(7777)
+    default_config.database.port = find_open_port(starting_port=5432)
+    default_config.api.port = find_open_port(starting_port=7777)
 
     include = None
     if not full_config:

--- a/qcfractal/qcfractal/port_util.py
+++ b/qcfractal/qcfractal/port_util.py
@@ -6,33 +6,33 @@ import socket
 from typing import Optional
 
 
-def find_open_port(starting_port: Optional[int] = None) -> int:
+def find_open_port(host: str = "localhost", starting_port: Optional[int] = None) -> int:
     """
     Finds an open port that we can bind to
     """
 
     if starting_port is None:
         sock = socket.socket()
-        sock.bind(("localhost", 0))
+        sock.bind((host, 0))
         _, port = sock.getsockname()
     else:
         port = starting_port
-        while is_port_inuse("127.0.0.1", port):
+        while is_port_inuse(host, port):
             port += 1
 
     return port
 
 
-def is_port_inuse(ip: str, port: int) -> bool:
+def is_port_inuse(host: str, port: int) -> bool:
     """
     Determine if an ip/port is being used or not
 
     Parameters
     ----------
-    ip: str
-        The host IP address to check
-    port: int
-        The port on the IP address to check
+    host
+        The host name or IP address to check
+    port
+        The port on the host to check
 
     Returns
     -------
@@ -42,7 +42,7 @@ def is_port_inuse(ip: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.settimeout(1)
         try:
-            s.connect((ip, int(port)))
+            s.connect((host, int(port)))
             s.shutdown(socket.SHUT_RDWR)
             return True
         except ConnectionRefusedError:

--- a/qcfractal/qcfractal/postgres_harness.py
+++ b/qcfractal/qcfractal/postgres_harness.py
@@ -597,11 +597,13 @@ class PostgresHarness:
         return self.sql_command(f"SELECT pg_database_size('{self.config.database_name}');")[0][0]
 
 
-def create_snowflake_postgres(data_dir: str) -> PostgresHarness:
+def create_snowflake_postgres(host: str, data_dir: str) -> PostgresHarness:
     """Create and Initialize a postgres instance in a particular directory
 
     Parameters
     ----------
+    host
+        The host name or IP address to bind to
     data_dir
         Path to the directory to store the database data
     """
@@ -609,7 +611,7 @@ def create_snowflake_postgres(data_dir: str) -> PostgresHarness:
     data_dir = data_dir
     sock_dir = os.path.join(data_dir, "sock")
 
-    port = find_open_port()
+    port = find_open_port(host)
     db_config = {
         "port": port,
         "data_directory": data_dir,

--- a/qcfractal/qcfractal/snowflake.py
+++ b/qcfractal/qcfractal/snowflake.py
@@ -169,6 +169,8 @@ class FractalSnowflake:
         compute_workers: int = 2,
         database_config: Optional[DatabaseConfig] = None,
         extra_config: Optional[Dict[str, Any]] = None,
+        *,
+        host: str = "localhost",
     ):
         """A temporary, self-contained server
 
@@ -208,15 +210,14 @@ class FractalSnowflake:
         if database_config is None:
             # db and socket are subdirs of the base temporary directory
             db_dir = os.path.join(self._tmpdir.name, "db")
-            self._pg_harness = create_snowflake_postgres(db_dir)
+            self._pg_harness = create_snowflake_postgres(host, db_dir)
             self._pg_harness.create_database(True)
             db_config = self._pg_harness.config
         else:
             db_config = database_config
 
-        api_host = "127.0.0.1"
-        api_port = find_open_port()
-        self._fractal_uri = f"http://{api_host}:{api_port}"
+        api_port = find_open_port(host)
+        self._fractal_uri = f"http://{host}:{api_port}"
 
         # Create a configuration for QCFractal
         # Assign the log level for subprocesses. Use the same level as what is assigned for this object
@@ -232,7 +233,7 @@ class FractalSnowflake:
         qcf_cfg["heartbeat_frequency"] = 5
         qcf_cfg["heartbeat_max_missed"] = 3
         qcf_cfg["api"] = {
-            "host": api_host,
+            "host": host,
             "port": api_port,
             "secret_key": secrets.token_urlsafe(32),
             "jwt_secret_key": secrets.token_urlsafe(32),


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
Sometimes you may want to bind a snowflake to a different IP/host. I have heard that on Windows, the WSL may choose a  different IP for localhost (where I had hardcoded `127.0.0.1`).

This allows you to bind to a different host/ip. It also changes `127.0.0.1` to `localhost` for the default.

@sjayellis maybe this will help

## Status
- [X] Code base linted
- [X] Ready to go
