### PR TITLE
Simplify & fix sorting of task queue for services

### DIFF
--- a/qcfractal/qcfractal/components/tasks/db_models.py
+++ b/qcfractal/qcfractal/components/tasks/db_models.py
@@ -33,7 +33,7 @@ class TaskQueueORM(BaseORM):
     # when claiming tasks don't work
     required_programs = Column(ARRAY(TEXT), nullable=False)
 
-    sort_date = Column(TIMESTAMP(timezone=True), default=now_at_utc(), nullable=False)
+    sort_date = Column(TIMESTAMP(timezone=True), default=now_at_utc, nullable=False)
     tag = Column(String, nullable=False)
     priority = Column(Integer, nullable=False)
     available = Column(Boolean, nullable=False)


### PR DESCRIPTION
## Description

This simplifies the logic where service dependencies inherit the parent service's create_on as a sort date. Now it doesn't involve that pretty gnarly query in exchange for not handling very rare edge cases where a dependency is part of multiple services.

Also fixes a very dumb mistake - the default value of the `sort_date` in the task queue should be a function, not a value.

## Status
- [X] Code base linted
- [X] Ready to go
