### PR TITLE
Option to shut down managers if idle for too long

### DIFF
--- a/qcarchivetesting/qcarchivetesting/testing_classes.py
+++ b/qcarchivetesting/qcarchivetesting/testing_classes.py
@@ -191,6 +191,10 @@ class QCATestingSnowflake(FractalSnowflake):
         self._stop_compute()
         self._all_completed = set()
         self._qcf_config = self._original_config.copy(deep=True)
+
+        if self._api_proc is None:
+            self.start_api()
+
         self.pg_harness.recreate_database()
 
     def get_storage_socket(self) -> SQLAlchemySocket:

--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -201,6 +201,12 @@ class FractalComputeConfig(BaseModel):
         gt=0,
     )
 
+    max_idle_time: Optional[int] = Field(
+        None,
+        description="Maximum consecutive time in seconds that the manager "
+        "should be allowed to run. If this is reached, the manager will shutdown.",
+    )
+
     parsl_run_dir: str = "parsl_run_dir"
     parsl_usage_tracking: int = 0
 

--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -226,7 +226,7 @@ class FractalComputeConfig(BaseModel):
     def _check_run_dir(cls, v, values):
         return _make_abs_path(v, values["base_folder"], "parsl_run_dir")
 
-    @validator("update_frequency", pre=True)
+    @validator("update_frequency", "max_idle_time", pre=True)
     def _convert_durations(cls, v):
         return duration_to_seconds(v)
 

--- a/qcfractalcompute/qcfractalcompute/test_compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/test_compute_manager.py
@@ -269,7 +269,7 @@ def test_manager_idle_shutdown_5(snowflake: QCATestingSnowflake):
     time.sleep(9)
     assert compute_thread.is_alive()
 
-    time.sleep(6)
+    time.sleep(10)
     assert not compute_thread.is_alive()
 
     compute_thread._compute_thread.join(5)

--- a/qcfractalcompute/qcfractalcompute/test_manager_config.py
+++ b/qcfractalcompute/qcfractalcompute/test_manager_config.py
@@ -56,17 +56,25 @@ def test_manager_config_durations(tmp_path):
     base_config = copy.deepcopy(_base_config)
 
     base_config["update_frequency"] = "900"
+    base_config["max_idle_time"] = "3600"
     manager_config = FractalComputeConfig(base_folder=base_folder, **base_config)
     assert manager_config.update_frequency == 900
+    assert manager_config.max_idle_time == 3600
 
     base_config["update_frequency"] = 900
+    base_config["max_idle_time"] = 3600
     manager_config = FractalComputeConfig(base_folder=base_folder, **base_config)
     assert manager_config.update_frequency == 900
+    assert manager_config.max_idle_time == 3600
 
     base_config["update_frequency"] = "3d4h80m09s"
+    base_config["max_idle_time"] = "1d8h99m77s"
     manager_config = FractalComputeConfig(base_folder=base_folder, **base_config)
     assert manager_config.update_frequency == 278409
+    assert manager_config.max_idle_time == 121217
 
     base_config["update_frequency"] = "3:04:80:9"
+    base_config["max_idle_time"] = "1:8:99:77"
     manager_config = FractalComputeConfig(base_folder=base_folder, **base_config)
     assert manager_config.update_frequency == 278409
+    assert manager_config.max_idle_time == 121217

--- a/qcfractalcompute/qcfractalcompute/testing_helpers.py
+++ b/qcfractalcompute/qcfractalcompute/testing_helpers.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import threading
 import weakref
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 import parsl
 
@@ -12,13 +12,22 @@ from qcarchivetesting.testing_classes import _activated_manager_programs
 from qcfractal.components.optimization.testing_helpers import submit_test_data as submit_opt_test_data
 from qcfractal.components.singlepoint.testing_helpers import submit_test_data as submit_sp_test_data
 from qcfractal.config import FractalConfig
+from qcfractal.config import update_nested_dict
 from qcfractal.db_socket import SQLAlchemySocket
 from qcfractalcompute.apps.models import AppTaskResult
 from qcfractalcompute.compress import compress_result
 from qcfractalcompute.compute_manager import ComputeManager
 from qcfractalcompute.config import FractalComputeConfig, FractalServerSettings, LocalExecutorConfig
-from qcportal.all_results import AllResultTypes
+from qcportal.all_results import AllResultTypes, FailedOperation
 from qcportal.record_models import PriorityEnum, RecordTask
+
+failed_op = FailedOperation(
+    input_data=None,
+    error={
+        'error_type': 'internal_error',
+        'error_message': 'This is a test error message'
+    },
+)
 
 
 class MockTestingAppManager:
@@ -27,7 +36,12 @@ class MockTestingAppManager:
 
 
 class MockTestingComputeManager(ComputeManager):
-    def __init__(self, qcf_config: FractalConfig, result_data: Dict[int, AllResultTypes]):
+    def __init__(
+        self,
+        qcf_config: FractalConfig,
+        result_data: Optional[Dict[int, AllResultTypes]] = None,
+        additional_manager_config: Optional[Dict[str, Any]] = None,
+    ):
         self._qcf_config = qcf_config
 
         host = self._qcf_config.api.host
@@ -43,7 +57,7 @@ class MockTestingComputeManager(ComputeManager):
         os.makedirs(parsl_run_dir, exist_ok=True)
         os.makedirs(compute_scratch_dir, exist_ok=True)
 
-        self._compute_config = FractalComputeConfig(
+        config_dict = dict(
             base_folder=tmpdir.name,
             parsl_run_dir=parsl_run_dir,
             cluster="mock_compute",
@@ -63,6 +77,11 @@ class MockTestingComputeManager(ComputeManager):
             },
         )
 
+        if additional_manager_config:
+            config_dict = update_nested_dict(config_dict, additional_manager_config)
+
+        self._compute_config = FractalComputeConfig(**config_dict)
+
         # Set the app manager already
         self.app_manager = MockTestingAppManager()
         ComputeManager.__init__(self, self._compute_config)
@@ -81,15 +100,24 @@ class MockTestingComputeManager(ComputeManager):
     def _submit_tasks(self, executor_label: str, tasks: List[RecordTask]):
         # A mock app that just returns the result data given to it after two seconds
         @parsl.python_app(data_flow_kernel=self.dflow_kernel)
-        def _mock_app(result: AllResultTypes) -> AppTaskResult:
+        def _mock_app(result: Optional[AllResultTypes]) -> AppTaskResult:
             import time
 
             time.sleep(2)
-            return AppTaskResult(success=result.success, walltime=2.0, result_compressed=compress_result(result.dict()))
+
+            if result is None:
+                return AppTaskResult(success=False, walltime=2.0, result_compressed=compress_result(failed_op.dict()))
+            else:
+                return AppTaskResult(success=result.success, walltime=2.0, result_compressed=compress_result(result.dict()))
 
         for task in tasks:
             self._record_id_map[task.id] = task.record_id
-            task_future = _mock_app(self._result_data[task.record_id])
+
+            if self._result_data:
+                task_future = _mock_app(self._result_data.get(task.record_id, None))
+            else:
+                task_future = _mock_app(None)
+
             self._task_futures[executor_label][task.id] = task_future
 
 
@@ -98,9 +126,16 @@ class QCATestingComputeThread:
     Runs a compute manager in a separate process
     """
 
-    def __init__(self, qcf_config: FractalConfig, result_data: Dict[int, AllResultTypes] = None):
+    def __init__(
+        self,
+        qcf_config: FractalConfig,
+        result_data: Dict[int, AllResultTypes] = None,
+        additional_manager_config: Optional[Dict[str, Any]] = None,
+    ):
         self._qcf_config = qcf_config
         self._result_data = result_data
+
+        self._additional_manager_config = additional_manager_config
 
         self._compute: Optional[MockTestingComputeManager] = None
         self._compute_thread = None
@@ -117,7 +152,7 @@ class QCATestingComputeThread:
     def start(self, manual_updates) -> None:
         if self._compute is not None:
             raise RuntimeError("Compute manager already started")
-        self._compute = MockTestingComputeManager(self._qcf_config, self._result_data)
+        self._compute = MockTestingComputeManager(self._qcf_config, self._result_data, self._additional_manager_config)
         self._compute_thread = threading.Thread(
             target=self._compute.start, kwargs={"manual_updates": manual_updates}, daemon=True
         )
@@ -138,6 +173,8 @@ class QCATestingComputeThread:
         self._compute_thread = None
 
     def is_alive(self) -> bool:
+        if self._compute_thread is None:
+            return False
         return self._compute_thread.is_alive()
 
 

--- a/qcfractalcompute/qcfractalcompute/testing_helpers.py
+++ b/qcfractalcompute/qcfractalcompute/testing_helpers.py
@@ -23,10 +23,7 @@ from qcportal.record_models import PriorityEnum, RecordTask
 
 failed_op = FailedOperation(
     input_data=None,
-    error={
-        'error_type': 'internal_error',
-        'error_message': 'This is a test error message'
-    },
+    error={"error_type": "internal_error", "error_message": "This is a test error message"},
 )
 
 
@@ -108,7 +105,9 @@ class MockTestingComputeManager(ComputeManager):
             if result is None:
                 return AppTaskResult(success=False, walltime=2.0, result_compressed=compress_result(failed_op.dict()))
             else:
-                return AppTaskResult(success=result.success, walltime=2.0, result_compressed=compress_result(result.dict()))
+                return AppTaskResult(
+                    success=result.success, walltime=2.0, result_compressed=compress_result(result.dict())
+                )
 
         for task in tasks:
             self._record_id_map[task.id] = task.record_id


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
(builds on PR #876)

Sometimes, we would like managers to shut down if they are not running any jobs for too long. This is particularly true if managers themselves are submitted as jobs to a queuing system.

This PR adds the functionality to specify a maximum idle time in the manager config: `max_idle_time`. This time is approximate, as idleness is only checked at the time a manager fetches new tasks from the server.

If at update time the idle time is beyond the configured max, the manager will stop itself.

Because of PR #876, this can also be specified as a string: `60s` or `30m`, or with colons (`30:00` being 30 minutes).

@j-wags 

## Status
- [X] Code base linted
- [X] Ready to go
