### PR TITLE
Enable creating portal client from env vars

### DIFF
--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -125,7 +125,6 @@ class PortalClient(PortalClientBase):
         *,
         cache_dir: Optional[str] = None,
         cache_max_size: int = 0,
-        memory_cache_key: Optional[str] = None,
     ) -> None:
         """
         Parameters

--- a/qcportal/qcportal/client_base.py
+++ b/qcportal/qcportal/client_base.py
@@ -235,6 +235,43 @@ class PortalClientBase:
 
         return cls(**data)
 
+    @classmethod
+    def from_env(cls):
+        """Creates a new client given information stored in environment variables
+
+        The environment variables are:
+
+          * QCPORTAL_ADDRESS (required)
+          * QCPORTAL_USERNAME (optional)
+          * QCPORTAL_PASSWORD (optional)
+          * QCPORTAL_VERIFY (optional, defaults to True)
+          * QCPORTAL_CACHE_DIR (optional)
+        """
+
+        address = os.environ.get("QCPORTAL_ADDRESS", None)
+        username = os.environ.get("QCPORTAL_USERNAME", None)
+        password = os.environ.get("QCPORTAL_PASSWORD", None)
+        verify = os.environ.get("QCPORTAL_VERIFY", True)
+        cache_dir = os.environ.get("QCPORTAL_CACHE_DIR", None)
+
+        if address is None:
+            raise KeyError("Required environment variable 'QCPORTAL_ADDRESS' not found")
+
+        data = {"address": address}
+
+        if username is not None:
+            data["username"] = username
+
+        if password is not None:
+            data["password"] = password
+
+        if cache_dir is not None:
+            data["cache_dir"] = cache_dir
+
+        data["verify"] = verify
+
+        return cls(**data)
+
     @property
     def encoding(self) -> str:
         return self._encoding


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Looking ahead to some hosted Jupyter notebooks, it may be beneficial to store server login info in environment variables, and just have QCPortal able to read those. This adds that functionality

## Status
- [X] Code base linted
- [X] Ready to go
