### PR TITLE
Add ability to submit dataset records as a background job

### DIFF
--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -207,6 +207,22 @@ def submit_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubm
     )
 
 
+@api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/background_submit", methods=["POST"])
+@wrap_route("WRITE")
+def background_submit_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubmitBody):
+    ds_socket = storage_socket.datasets.get_socket(dataset_type)
+    return ds_socket.background_submit(
+        dataset_id,
+        entry_names=body_data.entry_names,
+        specification_names=body_data.specification_names,
+        tag=body_data.tag,
+        priority=body_data.priority,
+        owner_user=g.username,
+        owner_group=body_data.owner_group,
+        find_existing=body_data.find_existing,
+    )
+
+
 ###################
 # Specifications
 ###################

--- a/qcfractal/qcfractal/components/gridoptimization/dataset_socket.py
+++ b/qcfractal/qcfractal/components/gridoptimization/dataset_socket.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from qcfractal.components.dataset_socket import BaseDatasetSocket
 from qcfractal.components.gridoptimization.record_db_models import GridoptimizationRecordORM
 from qcportal.gridoptimization import GridoptimizationDatasetNewEntry, GridoptimizationSpecification
+from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.record_models import PriorityEnum
 from .dataset_db_models import (
     GridoptimizationDatasetORM,
@@ -17,7 +18,6 @@ from .dataset_db_models import (
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
-    from qcportal.metadata_models import InsertMetadata
     from qcfractal.db_socket.socket import SQLAlchemySocket
     from typing import Optional, Sequence, Iterable, Tuple
 
@@ -76,7 +76,11 @@ class GridoptimizationDatasetSocket(BaseDatasetSocket):
         owner_user_id: Optional[int],
         owner_group_id: Optional[int],
         find_existing: bool,
-    ):
+    ) -> InsertCountsMetadata:
+
+        n_inserted = 0
+        n_existing = 0
+
         for spec in spec_orm:
             goopt_spec_obj = spec.specification.to_model(GridoptimizationSpecification)
             goopt_spec_input_dict = goopt_spec_obj.dict()
@@ -113,3 +117,8 @@ class GridoptimizationDatasetSocket(BaseDatasetSocket):
                         record_id=gridopt_ids[0],
                     )
                     session.add(rec)
+
+                n_inserted += meta.n_inserted
+                n_existing += meta.n_existing
+
+        return InsertCountsMetadata(n_inserted=n_inserted, n_existing=n_existing)

--- a/qcfractal/qcfractal/components/internal_jobs/socket.py
+++ b/qcfractal/qcfractal/components/internal_jobs/socket.py
@@ -12,6 +12,9 @@ from typing import TYPE_CHECKING
 
 import psycopg2.extensions
 from sqlalchemy import select, delete, update, and_, or_
+
+from qcportal.serialization import encode_to_json
+
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 
@@ -361,7 +364,7 @@ class InternalJobSocket:
             job_orm.status = InternalJobStatusEnum.complete
             job_orm.progress = 100
             job_orm.progress_description = "Complete"
-            job_orm.result = result
+            job_orm.result = encode_to_json(result)
 
         # Job itself is being cancelled
         except CancelledJobException:

--- a/qcfractal/qcfractal/components/internal_jobs/socket.py
+++ b/qcfractal/qcfractal/components/internal_jobs/socket.py
@@ -12,9 +12,6 @@ from typing import TYPE_CHECKING
 
 import psycopg2.extensions
 from sqlalchemy import select, delete, update, and_, or_
-
-from qcportal.serialization import encode_to_json
-
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 
@@ -22,6 +19,7 @@ from qcfractal.components.auth.db_models import UserIDMapSubquery
 from qcfractal.db_socket.helpers import get_query_proj_options
 from qcportal.exceptions import MissingDataError
 from qcportal.internal_jobs.models import InternalJobStatusEnum, InternalJobQueryFilters
+from qcportal.serialization import encode_to_json
 from qcportal.utils import now_at_utc
 from .db_models import InternalJobORM
 from .status import JobProgress, CancelledJobException, JobRunnerStoppingException

--- a/qcfractal/qcfractal/components/manybody/dataset_socket.py
+++ b/qcfractal/qcfractal/components/manybody/dataset_socket.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from qcfractal.components.dataset_socket import BaseDatasetSocket
 from qcfractal.components.manybody.record_db_models import ManybodyRecordORM
 from qcportal.manybody import ManybodyDatasetNewEntry, ManybodySpecification
+from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.record_models import PriorityEnum
 from .dataset_db_models import (
     ManybodyDatasetORM,
@@ -17,7 +18,6 @@ from .dataset_db_models import (
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
-    from qcportal.metadata_models import InsertMetadata
     from qcfractal.db_socket.socket import SQLAlchemySocket
     from typing import Optional, Sequence, Iterable, Tuple
 
@@ -74,7 +74,11 @@ class ManybodyDatasetSocket(BaseDatasetSocket):
         owner_user_id: Optional[int],
         owner_group_id: Optional[int],
         find_existing: bool,
-    ):
+    ) -> InsertCountsMetadata:
+
+        n_inserted = 0
+        n_existing = 0
+
         # Weed out any with additional keywords
         special_entries = [x for x in entry_orm if x.additional_keywords]
         normal_entries = [x for x in entry_orm if not x.additional_keywords]
@@ -100,6 +104,9 @@ class ManybodyDatasetSocket(BaseDatasetSocket):
                     dataset_id=dataset_id, entry_name=entry.name, specification_name=spec.name, record_id=oid
                 )
                 session.add(rec)
+
+            n_inserted += meta.n_inserted
+            n_existing += meta.n_existing
 
         # Now the ones with additional keywords
         for spec in spec_orm:
@@ -132,3 +139,8 @@ class ManybodyDatasetSocket(BaseDatasetSocket):
                         record_id=mb_ids[0],
                     )
                     session.add(rec)
+
+                n_inserted += meta.n_inserted
+                n_existing += meta.n_existing
+
+        return InsertCountsMetadata(n_inserted=n_inserted, n_existing=n_existing)

--- a/qcfractal/qcfractal/components/neb/dataset_socket.py
+++ b/qcfractal/qcfractal/components/neb/dataset_socket.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from qcfractal.components.dataset_socket import BaseDatasetSocket
 from qcfractal.components.neb.record_db_models import NEBRecordORM
+from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.molecules import Molecule
 from qcportal.neb import NEBDatasetNewEntry, NEBSpecification
 from qcportal.record_models import PriorityEnum
@@ -19,7 +20,6 @@ from .dataset_db_models import (
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
-    from qcportal.metadata_models import InsertMetadata
     from qcfractal.db_socket.socket import SQLAlchemySocket
     from typing import Optional, Sequence, Iterable, Tuple
 
@@ -78,7 +78,11 @@ class NEBDatasetSocket(BaseDatasetSocket):
         owner_user_id: Optional[int],
         owner_group_id: Optional[int],
         find_existing: bool,
-    ):
+    ) -> InsertCountsMetadata:
+
+        n_inserted = 0
+        n_existing = 0
+
         for spec in spec_orm:
             neb_spec_obj = spec.specification.to_model(NEBSpecification)
             neb_spec_input_dict = neb_spec_obj.dict()
@@ -110,3 +114,8 @@ class NEBDatasetSocket(BaseDatasetSocket):
                         record_id=neb_ids[0],
                     )
                     session.add(rec)
+
+                n_inserted += meta.n_inserted
+                n_existing += meta.n_existing
+
+        return InsertCountsMetadata(n_inserted=n_inserted, n_existing=n_existing)

--- a/qcfractal/qcfractal/components/reaction/dataset_socket.py
+++ b/qcfractal/qcfractal/components/reaction/dataset_socket.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from qcfractal.components.dataset_socket import BaseDatasetSocket
 from qcfractal.components.reaction.record_db_models import ReactionRecordORM
+from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.reaction import ReactionDatasetNewEntry, ReactionSpecification
 from qcportal.record_models import PriorityEnum
 from .dataset_db_models import (
@@ -18,7 +19,6 @@ from .dataset_db_models import (
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
-    from qcportal.metadata_models import InsertMetadata
     from qcfractal.db_socket.socket import SQLAlchemySocket
     from typing import Optional, Sequence, Iterable, Tuple
 
@@ -87,7 +87,11 @@ class ReactionDatasetSocket(BaseDatasetSocket):
         owner_user_id: Optional[int],
         owner_group_id: Optional[int],
         find_existing: bool,
-    ):
+    ) -> InsertCountsMetadata:
+
+        n_inserted = 0
+        n_existing = 0
+
         # Weed out any with additional keywords
         special_entries = [x for x in entry_orm if x.additional_keywords]
         normal_entries = [x for x in entry_orm if not x.additional_keywords]
@@ -113,6 +117,9 @@ class ReactionDatasetSocket(BaseDatasetSocket):
                     dataset_id=dataset_id, entry_name=entry.name, specification_name=spec.name, record_id=oid
                 )
                 session.add(rec)
+
+            n_inserted += meta.n_inserted
+            n_existing += meta.n_existing
 
         # Now the ones with additional keywords
         for spec in spec_orm:
@@ -147,3 +154,8 @@ class ReactionDatasetSocket(BaseDatasetSocket):
                         record_id=rxn_ids[0],
                     )
                     session.add(rec)
+
+                n_inserted += meta.n_inserted
+                n_existing += meta.n_existing
+
+        return InsertCountsMetadata(n_inserted=n_inserted, n_existing=n_existing)

--- a/qcfractal/qcfractal/components/singlepoint/dataset_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/dataset_socket.py
@@ -78,7 +78,11 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
         owner_user_id: Optional[int],
         owner_group_id: Optional[int],
         find_existing: bool,
-    ):
+    ) -> InsertCountsMetadata:
+
+        n_inserted = 0
+        n_existing = 0
+
         # Weed out any with additional keywords
         special_entries = [x for x in entry_orm if x.additional_keywords]
         normal_entries = [x for x in entry_orm if not x.additional_keywords]
@@ -104,6 +108,9 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
                     dataset_id=dataset_id, entry_name=entry.name, specification_name=spec.name, record_id=oid
                 )
                 session.add(rec)
+
+            n_inserted += meta.n_inserted
+            n_existing += meta.n_existing
 
         # Now the ones with additional keywords
         for spec in spec_orm:
@@ -136,6 +143,11 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
                         record_id=sp_ids[0],
                     )
                     session.add(rec)
+
+                n_inserted += meta.n_inserted
+                n_existing += meta.n_existing
+
+        return InsertCountsMetadata(n_inserted=n_inserted, n_existing=n_existing)
 
     def add_entries_from_ds(
         self,

--- a/qcfractal/qcfractal/components/torsiondrive/dataset_socket.py
+++ b/qcfractal/qcfractal/components/torsiondrive/dataset_socket.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from qcfractal.components.dataset_socket import BaseDatasetSocket
 from qcfractal.components.torsiondrive.record_db_models import TorsiondriveRecordORM
+from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.record_models import PriorityEnum
 from qcportal.torsiondrive import TorsiondriveDatasetNewEntry, TorsiondriveSpecification
 from .dataset_db_models import (
@@ -18,7 +19,6 @@ from .dataset_db_models import (
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
-    from qcportal.metadata_models import InsertMetadata
     from qcfractal.db_socket.socket import SQLAlchemySocket
     from typing import Optional, Sequence, Iterable, Tuple
 
@@ -77,7 +77,11 @@ class TorsiondriveDatasetSocket(BaseDatasetSocket):
         owner_user_id: Optional[int],
         owner_group_id: Optional[int],
         find_existing: bool,
-    ):
+    ) -> InsertCountsMetadata:
+
+        n_inserted = 0
+        n_existing = 0
+
         for spec in spec_orm:
             td_spec_obj = spec.specification.to_model(TorsiondriveSpecification)
             td_spec_input_dict = td_spec_obj.dict()
@@ -115,3 +119,8 @@ class TorsiondriveDatasetSocket(BaseDatasetSocket):
                         record_id=td_ids[0],
                     )
                     session.add(rec)
+
+                n_inserted += meta.n_inserted
+                n_existing += meta.n_existing
+
+        return InsertCountsMetadata(n_inserted=n_inserted, n_existing=n_existing)

--- a/qcportal/qcportal/gridoptimization/test_dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/test_dataset_models.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import qcportal.dataset_testing_helpers as ds_helpers
+from qcportal.dataset_testing_helpers import dataset_submit_test_client
 from qcportal.gridoptimization import (
     GridoptimizationDatasetNewEntry,
     GridoptimizationSpecification,
@@ -161,15 +164,16 @@ def test_gridoptimization_dataset_model_remove_record(snowflake_client: PortalCl
     ds_helpers.run_dataset_model_remove_record(snowflake_client, ds, test_entries, test_specs)
 
 
-def test_gridoptimization_dataset_model_submit(submitter_client: PortalClient):
-    ds = submitter_client.add_dataset(
+@pytest.mark.parametrize("background", [True, False])
+def test_gridoptimization_dataset_model_submit(dataset_submit_test_client: PortalClient, background):
+    ds = dataset_submit_test_client.add_dataset(
         "gridoptimization",
         "Test dataset",
         default_tag="default_tag",
         default_priority=PriorityEnum.low,
         owner_group="group1",
     )
-    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare)
+    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare, background)
 
 
 def test_gridoptimization_dataset_model_submit_missing(snowflake_client: PortalClient):

--- a/qcportal/qcportal/manybody/test_dataset_models.py
+++ b/qcportal/qcportal/manybody/test_dataset_models.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import qcportal.dataset_testing_helpers as ds_helpers
 from qcarchivetesting import load_molecule_data
+from qcportal.dataset_testing_helpers import dataset_submit_test_client
 from qcportal.manybody import ManybodyDatasetNewEntry, ManybodySpecification, ManybodyKeywords, BSSECorrectionEnum
 from qcportal.record_models import PriorityEnum
 from qcportal.singlepoint.record_models import QCSpecification
@@ -117,15 +120,16 @@ def test_manybody_dataset_model_remove_record(snowflake_client: PortalClient):
     ds_helpers.run_dataset_model_remove_record(snowflake_client, ds, test_entries, test_specs)
 
 
-def test_manybody_dataset_model_submit(submitter_client: PortalClient):
-    ds = submitter_client.add_dataset(
+@pytest.mark.parametrize("background", [True, False])
+def test_manybody_dataset_model_submit(dataset_submit_test_client: PortalClient, background):
+    ds = dataset_submit_test_client.add_dataset(
         "manybody",
         "Test dataset",
         default_tag="default_tag",
         default_priority=PriorityEnum.low,
         owner_group="group1",
     )
-    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare)
+    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare, background)
 
 
 def test_manybody_dataset_model_submit_missing(snowflake_client: PortalClient):

--- a/qcportal/qcportal/neb/test_dataset_models.py
+++ b/qcportal/qcportal/neb/test_dataset_models.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import qcportal.dataset_testing_helpers as ds_helpers
 from qcarchivetesting import load_molecule_data
+from qcportal.dataset_testing_helpers import dataset_submit_test_client
 from qcportal.neb import NEBDatasetNewEntry, NEBKeywords, NEBSpecification
 from qcportal.record_models import PriorityEnum
 from qcportal.singlepoint.record_models import QCSpecification
@@ -163,11 +166,12 @@ def test_neb_dataset_model_remove_record(snowflake_client: PortalClient):
     ds_helpers.run_dataset_model_remove_record(snowflake_client, ds, test_entries, test_specs)
 
 
-def test_neb_dataset_model_submit(submitter_client: PortalClient):
-    ds = submitter_client.add_dataset(
+@pytest.mark.parametrize("background", [True, False])
+def test_neb_dataset_model_submit(dataset_submit_test_client: PortalClient, background):
+    ds = dataset_submit_test_client.add_dataset(
         "neb", "Test dataset", default_tag="default_tag", default_priority=PriorityEnum.low, owner_group="group1"
     )
-    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare)
+    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare, background)
 
 
 def test_neb_dataset_model_submit_missing(snowflake_client: PortalClient):

--- a/qcportal/qcportal/optimization/test_dataset_models.py
+++ b/qcportal/qcportal/optimization/test_dataset_models.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import qcportal.dataset_testing_helpers as ds_helpers
+from qcportal.dataset_testing_helpers import dataset_submit_test_client
 from qcportal.molecules import Molecule
 from qcportal.optimization import OptimizationDatasetNewEntry
 from qcportal.optimization.record_models import OptimizationSpecification, OptimizationProtocols
@@ -119,15 +122,16 @@ def test_optimization_dataset_model_remove_record(snowflake_client: PortalClient
     ds_helpers.run_dataset_model_remove_record(snowflake_client, ds, test_entries, test_specs)
 
 
-def test_optimization_dataset_model_submit(submitter_client: PortalClient):
-    ds = submitter_client.add_dataset(
+@pytest.mark.parametrize("background", [True, False])
+def test_optimization_dataset_model_submit(dataset_submit_test_client: PortalClient, background):
+    ds = dataset_submit_test_client.add_dataset(
         "optimization",
         "Test dataset",
         default_tag="default_tag",
         default_priority=PriorityEnum.low,
         owner_group="group1",
     )
-    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare)
+    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare, background)
 
 
 def test_optimization_dataset_model_submit_missing(snowflake_client: PortalClient):

--- a/qcportal/qcportal/reaction/test_dataset_models.py
+++ b/qcportal/qcportal/reaction/test_dataset_models.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import qcportal.dataset_testing_helpers as ds_helpers
 from qcarchivetesting import load_molecule_data
+from qcportal.dataset_testing_helpers import dataset_submit_test_client
 from qcportal.optimization.record_models import OptimizationSpecification, OptimizationProtocols
 from qcportal.reaction import ReactionDatasetNewEntry, ReactionSpecification
 from qcportal.record_models import PriorityEnum
@@ -139,15 +142,16 @@ def test_reaction_dataset_model_remove_record(snowflake_client: PortalClient):
     ds_helpers.run_dataset_model_remove_record(snowflake_client, ds, test_entries, test_specs)
 
 
-def test_reaction_dataset_model_submit(submitter_client: PortalClient):
-    ds = submitter_client.add_dataset(
+@pytest.mark.parametrize("background", [True, False])
+def test_reaction_dataset_model_submit(dataset_submit_test_client: PortalClient, background):
+    ds = dataset_submit_test_client.add_dataset(
         "reaction",
         "Test dataset",
         default_tag="default_tag",
         default_priority=PriorityEnum.low,
         owner_group="group1",
     )
-    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare)
+    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare, background)
 
 
 def test_reaction_dataset_model_submit_missing(snowflake_client: PortalClient):

--- a/qcportal/qcportal/serialization.py
+++ b/qcportal/qcportal/serialization.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import Union, Any
+from typing import Union, Any, Optional
 
 import msgpack
 import numpy as np
@@ -33,6 +33,42 @@ def _msgpack_encode(obj: Any) -> Any:
 
 
 def _msgpack_decode(obj: Any) -> Any:
+    return obj
+
+
+def encode_to_json(obj: Any, encoder: Optional[json.JSONEncoder] = None) -> Any:
+    """
+    Takes an object and turns it into plain python that can be encoded to JSON.
+
+    This does not actually turn the object into JSON (string), just prepares it to be done.
+    This is useful for turning various objects into something that can be put into a JSON(B) column
+    in the database
+    """
+    # JSON does not handle byte arrays
+    # So convert to base64
+    if isinstance(obj, bytes):
+        return {"_bytes_base64_": base64.b64encode(obj).decode("ascii")}
+
+    # Now do anything with pydantic, excluding unset fields
+    # Also always use aliases when serializing
+    if isinstance(obj, BaseModel):
+        return obj.dict(exclude_unset=True, by_alias=True)
+
+    # Let pydantic handle other things
+    try:
+        return pydantic_encoder(obj)
+    except TypeError:
+        pass
+
+    # Flatten numpy arrays
+    # This is mostly for Molecule class
+    # TODO - remove once all data in the database in converted
+    if isinstance(obj, np.ndarray):
+        if obj.shape:
+            return obj.ravel().tolist()
+        else:
+            return obj.tolist()
+
     return obj
 
 

--- a/qcportal/qcportal/singlepoint/test_dataset_models.py
+++ b/qcportal/qcportal/singlepoint/test_dataset_models.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import qcportal.dataset_testing_helpers as ds_helpers
+from qcportal.dataset_testing_helpers import dataset_submit_test_client
 from qcportal.molecules import Molecule
 from qcportal.record_models import PriorityEnum
 from qcportal.singlepoint import SinglepointDatasetNewEntry
@@ -104,15 +107,16 @@ def test_singlepoint_dataset_model_remove_record(snowflake_client: PortalClient)
     ds_helpers.run_dataset_model_remove_record(snowflake_client, ds, test_entries, test_specs)
 
 
-def test_singlepoint_dataset_model_submit(submitter_client: PortalClient):
-    ds = submitter_client.add_dataset(
+@pytest.mark.parametrize("background", [True, False])
+def test_singlepoint_dataset_model_submit(dataset_submit_test_client: PortalClient, background):
+    ds = dataset_submit_test_client.add_dataset(
         "singlepoint",
         "Test dataset",
         default_tag="default_tag",
         default_priority=PriorityEnum.low,
         owner_group="group1",
     )
-    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare)
+    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare, background)
 
 
 def test_singlepoint_dataset_model_submit_missing(snowflake_client: PortalClient):

--- a/qcportal/qcportal/test_dataset_models.py
+++ b/qcportal/qcportal/test_dataset_models.py
@@ -170,6 +170,8 @@ def test_dataset_model_add_submit_many(snowflake_client: PortalClient):
         "test_spec_2", specification={"program": "test_prog_2", "driver": "energy", "method": "HF", "basis": "sto-3g"}
     )
 
-    ds.submit()
+    meta = ds.submit()
+    assert meta.n_inserted == test_count * 2
+    assert meta.n_existing == 0
 
     assert ds.record_count == test_count * 2

--- a/qcportal/qcportal/torsiondrive/test_dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/test_dataset_models.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import qcportal.dataset_testing_helpers as ds_helpers
+from qcportal.dataset_testing_helpers import dataset_submit_test_client
 from qcportal.molecules import Molecule
 from qcportal.optimization.record_models import OptimizationSpecification, OptimizationProtocols
 from qcportal.record_models import PriorityEnum
@@ -166,15 +169,16 @@ def test_torsiondrive_dataset_model_remove_record(snowflake_client: PortalClient
     ds_helpers.run_dataset_model_remove_record(snowflake_client, ds, test_entries, test_specs)
 
 
-def test_torsiondrive_dataset_model_submit(submitter_client: PortalClient):
-    ds = submitter_client.add_dataset(
+@pytest.mark.parametrize("background", [True, False])
+def test_torsiondrive_dataset_model_submit(dataset_submit_test_client: PortalClient, background):
+    ds = dataset_submit_test_client.add_dataset(
         "torsiondrive",
         "Test dataset",
         default_tag="default_tag",
         default_priority=PriorityEnum.low,
         owner_group="group1",
     )
-    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare)
+    ds_helpers.run_dataset_model_submit(ds, test_entries, test_specs[0], record_compare, background)
 
 
 def test_torsiondrive_dataset_model_submit_missing(snowflake_client: PortalClient):


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
dataset.submit() can take a very long time for large datasets (large numbers of entries). A workaround is to batch entries and submit only a few at a time, something the dataset class does automatically.

This PR adds the ability to instead run the submission server-side. This creates an internal job on the server that does the actual submission, which you can then watch for progress.

Only one dataset submission will run at one time for a dataset, but you can submit multiple internal jobs if you want.

## Status
- [x] Implement job progress in submit
- [x] Tests
- [x] Code base linted
- [x] Ready to go
