### PR TITLE
Qcportal jupyterhub

### DIFF
--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+EXPOSE 8000
+
+RUN apt-get upgrade -y && apt-get update -y && apt-get install -yqq --no-install-recommends python3-pip && pip3 install --upgrade pip
+RUN apt-get install npm nodejs -y \
+    && npm install -g configurable-http-proxy \
+    && pip3 install jupyterhub \
+    && pip3 install --upgrade notebook \
+    && pip3 install --upgrade jupyterlab \
+    && pip3 install --upgrade qcportal \
+    && rm -rf /var/lib/apt/lists/* /var/log/* /var/tmp/* ~/.npm
+
+ADD docker/jupyterhub_config.py /etc/jupyterhub_config.py
+ADD docker/qcarchive_authenticator.py /etc/qcarchive_authenticator.py
+
+ENV PYTHONPATH="${PYTHONPATH}:/etc"
+
+CMD ["jupyterhub", "--ip=0.0.0.0", "--port=8000", "--no-ssl", "-f", "/etc/jupyterhub_config.py"]

--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -1,7 +1,6 @@
-"""sample jupyterhub config file for testing
+"""Jupyterhub Config file for hosting QCPortal.
 
-configures jupyterhub with dummyauthenticator and simplespawner
-to enable testing without administrative privileges.
+This authenticates using QCArchive server usernames and passwords.
 """
 
 c = get_config()  # noqa
@@ -19,6 +18,4 @@ c.JupyterHub.tornado_settings = {
 c.JupyterHub.allow_named_servers = True
 c.JupyterHub.default_url = "/hub/home"
 
-# make sure admin UI is available and any user can login
-#c.Authenticator.admin_users = {"admin"}
 c.Authenticator.allow_all = True

--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -1,0 +1,24 @@
+"""sample jupyterhub config file for testing
+
+configures jupyterhub with dummyauthenticator and simplespawner
+to enable testing without administrative privileges.
+"""
+
+c = get_config()  # noqa
+
+from qcarchive_authenticator import QCArchiveAuthenticator
+
+c.JupyterHub.authenticator_class = QCArchiveAuthenticator
+
+# don't cache static files
+c.JupyterHub.tornado_settings = {
+    "no_cache_static": True,
+    "slow_spawn_timeout": 0,
+}
+
+c.JupyterHub.allow_named_servers = True
+c.JupyterHub.default_url = "/hub/home"
+
+# make sure admin UI is available and any user can login
+#c.Authenticator.admin_users = {"admin"}
+c.Authenticator.allow_all = True

--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -3,7 +3,13 @@
 This authenticates using QCArchive server usernames and passwords.
 """
 
+import os
+
 c = get_config()  # noqa
+
+# Get the base url from the environment
+base_url = os.getenv("QCFRACTAL_JHUB_BASE_URL", "/")
+c.JupyterHub.base_url = base_url
 
 from qcarchive_authenticator import QCArchiveAuthenticator
 
@@ -16,6 +22,5 @@ c.JupyterHub.tornado_settings = {
 }
 
 c.JupyterHub.allow_named_servers = True
-c.JupyterHub.default_url = "/hub/home"
 
 c.Authenticator.allow_all = True

--- a/docker/qcarchive_authenticator.py
+++ b/docker/qcarchive_authenticator.py
@@ -5,52 +5,62 @@ import requests
 import jwt
 from subprocess import PIPE, STDOUT, Popen
 
+
 class QCArchiveAuthenticator(Authenticator):
-    
+
     @gen.coroutine
     def authenticate(self, handler, data):
         base_address = os.getenv("QCFRACTAL_ADDRESS")
-        
+
         if base_address is None:
             raise RuntimeError(f"QCArchive address returned None.")
-        
+
         login_address = f"{base_address}/auth/v1/login"
         uinfo_address = f"{base_address}/api/v1/users/{data['username']}"
 
         # Log in to get JWT
-        body = {"username": data['username'], "password": data['password']}
+        body = {"username": data["username"], "password": data["password"]}
 
         # 'verify' means whether or not to verify SSL certificates
         r = requests.post(login_address, json=body, verify=True)
 
         if r.status_code != 200:
-            fail_msg = r.json()['msg']
+            fail_msg = r.json()["msg"]
             raise RuntimeError(f"Login failure: {r.status_code} - {fail_msg}")
 
         print("Successfully logged in!")
 
         # Grab access token, use to get all user information
-        access_token = r.json()['access_token']
+        access_token = r.json()["access_token"]
 
-        headers = {'Authorization': f"Bearer {access_token}"}
+        headers = {"Authorization": f"Bearer {access_token}"}
         r = requests.get(uinfo_address, headers=headers)
 
         if r.status_code != 200:
-            fail_msg = r.json()['msg']
-            raise RuntimeError(f"Unable to get user information: {r.status_code} - {fail_msg}")
+            fail_msg = r.json()["msg"]
+            raise RuntimeError(
+                f"Unable to get user information: {r.status_code} - {fail_msg}"
+            )
 
         uinfo = r.json()
-        username = uinfo['username']
-        user_id = uinfo['id']
-        role = uinfo['role']
+        username = uinfo["username"]
+        user_id = uinfo["id"]
+        role = uinfo["role"]
 
-        cmd = ['adduser', '-q', '--disabled-password', '--uid', f'{100000+user_id}', username]
+        cmd = [
+            "adduser",
+            "-q",
+            "--disabled-password",
+            "--uid",
+            f"{100000+user_id}",
+            username,
+        ]
         p = Popen(cmd, stdout=PIPE, stderr=STDOUT)
         p.wait()
 
-        os.environ['QCPORTAL_ADDRESS'] = base_address
-        os.environ['QCPORTAL_USERNAME'] = username
-        os.environ['QCORTAL_PASSWORD'] = data['password']
-        os.environ['QCPORTAL_VERIFY'] = os.getenv("QCFRACTAL_VERIFY", "True")
+        os.environ["QCPORTAL_ADDRESS"] = base_address
+        os.environ["QCPORTAL_USERNAME"] = username
+        os.environ["QCORTAL_PASSWORD"] = data["password"]
+        os.environ["QCPORTAL_VERIFY"] = os.getenv("QCFRACTAL_VERIFY", "True")
 
         return username

--- a/docker/qcarchive_authenticator.py
+++ b/docker/qcarchive_authenticator.py
@@ -1,0 +1,56 @@
+from tornado import gen
+import os
+from jupyterhub.auth import Authenticator
+import requests
+import jwt
+from subprocess import PIPE, STDOUT, Popen
+
+class QCArchiveAuthenticator(Authenticator):
+    
+    @gen.coroutine
+    def authenticate(self, handler, data):
+        base_address = os.getenv("QCFRACTAL_ADDRESS")
+        
+        if base_address is None:
+            raise RuntimeError(f"QCArchive address returned None.")
+        
+        login_address = f"{base_address}/auth/v1/login"
+        uinfo_address = f"{base_address}/api/v1/users/{data['username']}"
+
+        # Log in to get JWT
+        body = {"username": data['username'], "password": data['password']}
+
+        # 'verify' means whether or not to verify SSL certificates
+        r = requests.post(login_address, json=body, verify=True)
+
+        if r.status_code != 200:
+            fail_msg = r.json()['msg']
+            raise RuntimeError(f"Login failure: {r.status_code} - {fail_msg}")
+
+        print("Successfully logged in!")
+
+        # Grab access token, use to get all user information
+        access_token = r.json()['access_token']
+
+        headers = {'Authorization': f"Bearer {access_token}"}
+        r = requests.get(uinfo_address, headers=headers)
+
+        if r.status_code != 200:
+            fail_msg = r.json()['msg']
+            raise RuntimeError(f"Unable to get user information: {r.status_code} - {fail_msg}")
+
+        uinfo = r.json()
+        username = uinfo['username']
+        user_id = uinfo['id']
+        role = uinfo['role']
+
+        cmd = ['adduser', '-q', '--disabled-password', '--uid', f'{100000+user_id}', username]
+        p = Popen(cmd, stdout=PIPE, stderr=STDOUT)
+        p.wait()
+
+        os.environ['QCPORTAL_ADDRESS'] = base_address
+        os.environ['QCPORTAL_USERNAME'] = username
+        os.environ['QCORTAL_PASSWORD'] = data['password']
+        os.environ['QCPORTAL_VERIFY'] = os.getenv("QCFRACTAL_VERIFY", "True")
+
+        return username


### PR DESCRIPTION
## Description
This PR adds `Dockerfile.jupyterhub`, a dockerfile for hosting a Jupyterhub with QCPortal, along with a configuration file and a custom authenticator that uses QCArchive to authenticate a user.

Users have directories created in home, so it needs to be mounted to allow any created notebooks to persist.

## Status
- [x] Code base linted
- [ ] Ready to go
