### PR TITLE
Jitter for manager heartbeats and updates

### DIFF
--- a/qcarchivetesting/qcarchivetesting/testing_classes.py
+++ b/qcarchivetesting/qcarchivetesting/testing_classes.py
@@ -142,6 +142,7 @@ class QCATestingSnowflake(FractalSnowflake):
         qcf_config["service_frequency"] = 5
         qcf_config["loglevel"] = "DEBUG"
         qcf_config["heartbeat_frequency"] = 3
+        qcf_config["heartbeat_frequency_jitter"] = 0.0
         qcf_config["heartbeat_max_missed"] = 2
 
         qcf_config["database"] = {"pool_size": 0}

--- a/qcfractal/qcfractal/components/managers/socket.py
+++ b/qcfractal/qcfractal/components/managers/socket.py
@@ -293,8 +293,6 @@ class ManagerSocket:
         ----------
         session
             An existing SQLAlchemy session to use.
-        job_progress
-            An object used to report the current job progress and status
         """
         self._logger.debug("Checking manager heartbeats")
 

--- a/qcfractal/qcfractal/components/managers/socket.py
+++ b/qcfractal/qcfractal/components/managers/socket.py
@@ -28,6 +28,7 @@ class ManagerSocket:
         self._logger = logging.getLogger(__name__)
 
         self._manager_heartbeat_frequency = root_socket.qcf_config.heartbeat_frequency
+        self._manager_heartbeat_frequency_jitter = root_socket.qcf_config.heartbeat_frequency_jitter
         self._manager_max_missed_heartbeats = root_socket.qcf_config.heartbeat_max_missed
 
         with self.root_socket.session_scope() as session:
@@ -296,7 +297,11 @@ class ManagerSocket:
             An object used to report the current job progress and status
         """
         self._logger.debug("Checking manager heartbeats")
-        manager_window = self._manager_max_missed_heartbeats * self._manager_heartbeat_frequency
+
+        # Take into account the maximum jitter allowed
+        manager_window = self._manager_max_missed_heartbeats * (
+            self._manager_heartbeat_frequency + self._manager_heartbeat_frequency_jitter
+        )
         dt = now_at_utc() - timedelta(seconds=manager_window)
 
         dead_managers = self.deactivate(modified_before=dt, reason="missing heartbeat", session=session)

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -400,6 +400,7 @@ class FractalConfig(ConfigBase):
     heartbeat_frequency: int = Field(
         1800, description="The frequency (in seconds) to check the heartbeat of compute managers"
     )
+    heartbeat_frequency_jitter: int = Field(0.1, description="Jitter fraction to be applied to the heartbeat frequency")
     heartbeat_max_missed: int = Field(
         5,
         description="The maximum number of heartbeats that a compute manager can miss. If more are missed, the worker is considered dead",

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -398,12 +398,17 @@ class FractalConfig(ConfigBase):
     service_frequency: int = Field(60, description="The frequency at which to update services (in seconds)")
     max_active_services: int = Field(20, description="The maximum number of concurrent active services")
     heartbeat_frequency: int = Field(
-        1800, description="The frequency (in seconds) to check the heartbeat of compute managers"
+        1800,
+        description="The frequency (in seconds) to check the heartbeat of compute managers",
+        gt=0,
     )
-    heartbeat_frequency_jitter: int = Field(0.1, description="Jitter fraction to be applied to the heartbeat frequency")
+    heartbeat_frequency_jitter: int = Field(
+        0.1, description="Jitter fraction to be applied to the heartbeat frequency", ge=0
+    )
     heartbeat_max_missed: int = Field(
         5,
         description="The maximum number of heartbeats that a compute manager can miss. If more are missed, the worker is considered dead",
+        ge=0,
     )
 
     # Access logging

--- a/qcfractal/qcfractal/flask_app/helpers.py
+++ b/qcfractal/qcfractal/flask_app/helpers.py
@@ -182,6 +182,7 @@ def get_public_server_information():
     public_info = {
         "name": qcf_cfg.name,
         "manager_heartbeat_frequency": qcf_cfg.heartbeat_frequency,
+        "manager_heartbeat_frequency_jitter": qcf_cfg.heartbeat_frequency_jitter,
         "manager_heartbeat_max_missed": qcf_cfg.heartbeat_max_missed,
         "version": qcfractal_version,
         "api_limits": qcf_cfg.api_limits.dict(),

--- a/qcfractal/qcfractal/snowflake.py
+++ b/qcfractal/qcfractal/snowflake.py
@@ -232,6 +232,7 @@ class FractalSnowflake:
         qcf_cfg["hide_internal_errors"] = False
         qcf_cfg["service_frequency"] = 10
         qcf_cfg["heartbeat_frequency"] = 5
+        qcf_cfg["heartbeat_frequency_jitter"] = 0.0
         qcf_cfg["heartbeat_max_missed"] = 3
         qcf_cfg["api"] = {
             "host": host,
@@ -262,6 +263,7 @@ class FractalSnowflake:
             parsl_run_dir=parsl_run_dir,
             cluster="snowflake_compute",
             update_frequency=5,
+            update_frequency_jitter=0.0,
             server=FractalServerSettings(
                 fractal_uri=uri,
                 verify=False,

--- a/qcfractalcompute/qcfractalcompute/compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/compute_manager.py
@@ -185,7 +185,7 @@ class ComputeManager:
         # Pull server info
         self.server_info = self.client.get_server_information()
         self.heartbeat_frequency = self.server_info["manager_heartbeat_frequency"]
-        self.heartbeat_frequency_jitter = self.server_info.get("manager_heartbeat_frequency_jitter", 0.1)
+        self.heartbeat_frequency_jitter = self.server_info.get("manager_heartbeat_frequency_jitter", 0.0)
 
         self.client.activate(__version__, self.all_program_info, tags=self.all_queue_tags)
 

--- a/qcfractalcompute/qcfractalcompute/compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/compute_manager.py
@@ -29,7 +29,7 @@ from qcportal import ManagerClient
 from qcportal.managers import ManagerName
 from qcportal.metadata_models import TaskReturnMetadata
 from qcportal.record_models import RecordTask
-from qcportal.utils import seconds_to_hms
+from qcportal.utils import seconds_to_hms, apply_jitter
 from . import __version__
 from .apps.models import AppTaskResult
 from .compress import compress_result
@@ -185,6 +185,7 @@ class ComputeManager:
         # Pull server info
         self.server_info = self.client.get_server_information()
         self.heartbeat_frequency = self.server_info["manager_heartbeat_frequency"]
+        self.heartbeat_frequency_jitter = self.server_info.get("manager_heartbeat_frequency_jitter", 0.1)
 
         self.client.activate(__version__, self.all_program_info, tags=self.all_queue_tags)
 
@@ -288,13 +289,15 @@ class ComputeManager:
             if not manual_updates:
                 self.update(new_tasks=True)
             if not self._is_stopping:
-                self.scheduler.enter(self.manager_config.update_frequency, 1, scheduler_update)
+                delay = apply_jitter(self.manager_config.update_frequency, self.manager_config.update_frequency_jitter)
+                self.scheduler.enter(delay, 1, scheduler_update)
 
         def scheduler_heartbeat():
             if not manual_updates:
                 self.heartbeat()
             if not self._is_stopping:
-                self.scheduler.enter(self.heartbeat_frequency, 1, scheduler_heartbeat)
+                delay = apply_jitter(self.heartbeat_frequency, self.heartbeat_frequency_jitter)
+                self.scheduler.enter(delay, 1, scheduler_heartbeat)
 
         self.logger.info("Compute Manager successfully started.")
 

--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -191,6 +191,13 @@ class FractalComputeConfig(BaseModel):
         "itself down to maintain integrity between it and the Fractal Server. Units of seconds",
         gt=0,
     )
+    update_frequency_jitter: float = Field(
+        0.1,
+        description="The update frequency will be modified by up to a certain amount for each request. The "
+        "update_frequency_jitter represents a fraction of the update_frequency to allow as a max. "
+        "Ie, update_frequency=60, and jitter=0.1, updates will happen between 54 and 66 seconds. "
+        "This helps with spreading out server load.",
+    )
 
     max_idle_time: Optional[int] = Field(
         None,

--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -197,6 +197,7 @@ class FractalComputeConfig(BaseModel):
         "update_frequency_jitter represents a fraction of the update_frequency to allow as a max. "
         "Ie, update_frequency=60, and jitter=0.1, updates will happen between 54 and 66 seconds. "
         "This helps with spreading out server load.",
+        ge=0,
     )
 
     max_idle_time: Optional[int] = Field(

--- a/qcfractalcompute/qcfractalcompute/testing_helpers.py
+++ b/qcfractalcompute/qcfractalcompute/testing_helpers.py
@@ -59,6 +59,7 @@ class MockTestingComputeManager(ComputeManager):
             parsl_run_dir=parsl_run_dir,
             cluster="mock_compute",
             update_frequency=1,
+            update_frequency_jitter=0.0,
             server=FractalServerSettings(
                 fractal_uri=uri,
                 verify=False,

--- a/qcportal/qcportal/client_base.py
+++ b/qcportal/qcportal/client_base.py
@@ -288,7 +288,7 @@ class PortalClientBase:
 
         Parameters
         ----------
-        prep_req
+        req
             A prepared request to send
         allow_retries
             If true, attempts to retry on certain kinds of errors
@@ -423,6 +423,7 @@ class PortalClientBase:
         url_params: Optional[Dict[str, Any]] = None,
         internal_retry: Optional[bool] = True,
         allow_retries: bool = True,
+        additional_headers: Optional[Dict[str, Any]] = None,
     ) -> requests.Response:
         # If refresh token has expired, log in again
         if self._jwt_refresh_exp and self._jwt_refresh_exp < time.time():
@@ -433,7 +434,9 @@ class PortalClientBase:
             self._refresh_JWT_token()
 
         full_uri = self.address + endpoint
-        req = requests.Request(method=method.upper(), url=full_uri, data=body, params=url_params)
+        req = requests.Request(
+            method=method.upper(), url=full_uri, data=body, params=url_params, headers=additional_headers
+        )
         r = self._send_request(req, allow_retries=allow_retries)
 
         # If JWT token expired, automatically renew it and retry once. This should have been caught above,
@@ -468,6 +471,7 @@ class PortalClientBase:
         body: Optional[Union[_T, Dict[str, Any]]] = None,
         url_params: Optional[Union[_U, Dict[str, Any]]] = None,
         allow_retries: bool = True,
+        additional_headers: Optional[Dict[str, Any]] = None,
     ) -> _V:
         # If body_model or url_params_model are None, then use the type given
         if body_model is None and body is not None:
@@ -489,7 +493,12 @@ class PortalClientBase:
             parsed_url_params = parsed_url_params.dict()
 
         r = self._request(
-            method, endpoint, body=serialized_body, url_params=parsed_url_params, allow_retries=allow_retries
+            method,
+            endpoint,
+            body=serialized_body,
+            url_params=parsed_url_params,
+            allow_retries=allow_retries,
+            additional_headers=additional_headers,
         )
         d = deserialize(r.content, r.headers["Content-Type"])
 

--- a/qcportal/qcportal/manager_client.py
+++ b/qcportal/qcportal/manager_client.py
@@ -62,6 +62,7 @@ class ManagerClient(PortalClientBase):
             None,
             body=manager_update,
             allow_retries=False,
+            additional_headers={"Connection": "close"},
         )
 
     def activate(

--- a/qcportal/qcportal/utils.py
+++ b/qcportal/qcportal/utils.py
@@ -8,6 +8,7 @@ import itertools
 import json
 import logging
 import math
+import random
 import re
 import time
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
@@ -449,3 +450,8 @@ def update_nested_dict(d: Dict[str, Any], u: Dict[str, Any]):
         else:
             d[k] = v
     return d
+
+
+def apply_jitter(t: Union[int, float], jitter_fraction: float) -> float:
+    f = random.uniform(-jitter_fraction, jitter_fraction)
+    return max(t * (1 + f), 0.0)


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Adds options for adding jitter to manager heartbeats and updates. This does two things - helps with some random errors related to TCP keepalive, and also prevents the thundering herd effect where lots of managers started at the same time will all try heartbeat/update at the same time as well.

In addition, this PR disables keepalive connections for certain manager requests that are expected to be infrequent.

Heartbeat frequency jitter is controlled by the server, while update frequency jitter is set in the manager config.

Changes in this PR are backwards & forwards compatible.

## Status
- [X] Code base linted
- [X] Ready to go
