### PR TITLE
Fix math for finding dead managers

### DIFF
--- a/qcfractal/qcfractal/components/managers/socket.py
+++ b/qcfractal/qcfractal/components/managers/socket.py
@@ -298,7 +298,7 @@ class ManagerSocket:
 
         # Take into account the maximum jitter allowed
         manager_window = self._manager_max_missed_heartbeats * (
-            self._manager_heartbeat_frequency + self._manager_heartbeat_frequency_jitter
+            self._manager_heartbeat_frequency * (1 + self._manager_heartbeat_frequency_jitter)
         )
         dt = now_at_utc() - timedelta(seconds=manager_window)
 


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Fix a dumb math mistake related to the amount of time a manager hasn't been seen to declare it deactivated (when jitter is taken into account)

## Status
- [X] Code base linted
- [X] Ready to go
