### PR TITLE
Add redirect to new ml datasets app

### DIFF
--- a/docs/source/apps/ml_datasets/index.rst
+++ b/docs/source/apps/ml_datasets/index.rst
@@ -1,0 +1,3 @@
+.. raw:: html
+
+    <meta http-equiv="refresh" content="0; url=https://ml-datasets.molssi.org">


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Looking to replace the main qcarchive webpage with the docs, so we should redirect the ml datasets app to the new github-hosted version

## Status
- [X] Code base linted
- [X] Ready to go
