### PR TITLE
Fix for very large files on S3

### DIFF
--- a/qcfractal/qcfractal/components/external_files/socket.py
+++ b/qcfractal/qcfractal/components/external_files/socket.py
@@ -132,7 +132,9 @@ class ExternalFileSocket:
             session.flush()
 
             try:
-                while chunk := file_data.read(10 * 1024 * 1024):
+                # Chunk size = 256MiB. There is a limit of 10,000 chunks, which would be
+                # 2.56TiB
+                while chunk := file_data.read(256 * 1024 * 1024):
                     if job_progress is not None:
                         job_progress.raise_if_cancelled()
 
@@ -192,7 +194,8 @@ class ExternalFileSocket:
             ID of the external file (which is also set in the given ORM object)
         """
 
-        self._logger.info(f"Uploading {file_path} to S3. File size: {os.path.getsize(file_path)/1048576} MiB")
+        file_size = os.path.getsize(file_path)
+        self._logger.info(f"Uploading {file_path} to S3. File size: {file_size/1048576} MiB")
 
         with open(file_path, "rb") as f:
             return self.add_data(f, file_orm, job_progress=job_progress, session=session)

--- a/qcportal/qcportal/internal_jobs/models.py
+++ b/qcportal/qcportal/internal_jobs/models.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Optional, Dict, Any, List, Union
 
@@ -11,6 +11,7 @@ except ImportError:
     from pydantic import BaseModel, Extra, validator, PrivateAttr
 
 from qcportal.base_models import QueryProjModelBase
+from qcportal.utils import seconds_to_hms
 from ..base_models import QueryIteratorBase
 from tqdm import tqdm
 
@@ -147,6 +148,20 @@ class InternalJob(BaseModel):
                 time.sleep(min(interval, end_time - curtime + 0.1))
             else:
                 time.sleep(interval)
+
+    @property
+    def duration(self) -> timedelta:
+        if self.started_date is None:
+            return timedelta()
+
+        if self.ended_date is None:
+            return datetime.now() - self.started_date
+
+        return self.ended_date - self.started_date
+
+    @property
+    def duration_str(self) -> str:
+        return seconds_to_hms(self.duration.total_seconds())
 
 
 class InternalJobQueryFilters(QueryProjModelBase):


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

S3 (or boto3?) has a limit of 10,000 parts. I used a part size of 10 MiB, which limits the file size to about 100GiB. We do have datasets that will be bigger than that.

This changes the part size to 256MiB, so a max limit of about 2.56TiB.

(Inside that function, we do not know the end file size, since it is meant to work with BinaryIO streams)

## Status
- [X] Code base linted
- [X] Ready to go
