### PR TITLE
Remove raw import of qcmanybody

### DIFF
--- a/qcfractal/qcfractal/components/manybody/record_socket.py
+++ b/qcfractal/qcfractal/components/manybody/record_socket.py
@@ -7,7 +7,6 @@ import logging
 import textwrap
 from typing import List, Dict, Tuple, Optional, Sequence, Any, Union, TYPE_CHECKING
 
-import qcmanybody
 import tabulate
 from sqlalchemy import select, func
 from sqlalchemy.dialects.postgresql import array_agg, aggregate_order_by


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Very simple - qcmanybody is optional so shouldn't be imported directly - it is handled further down in the file. Somehow this import snuck in

## Status
- [X] Code base linted
- [X] Ready to go
