### PR TITLE
Fix duplicate env in fulltest GHA

### DIFF
--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -103,15 +103,15 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          activate-environment: qcarchive-qcportal
-          environment-file: qcarchive/qcarchivetesting/conda-envs/fulltest_qcportal.yaml
+          activate-environment: qcarchive-testing
+          environment-file: qcarchive/qcarchivetesting/conda-envs/fulltest_testing.yaml
           auto-activate-base: false
 
       - name: Install QCPortal
         shell: bash -l {0}
         run: |
-          pip install --no-deps -e ./qcarchive/qcportal
-          pip install pytest
+          cd qcarchive
+          pip install --no-deps -e ./qcportal -e ./qcfractalcompute -e ./qcfractal -e ./qcarchivetesting
 
       - name: Conda info for the QCPortal client
         shell: bash -l {0}
@@ -126,13 +126,13 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          python3 -m venv testing_env
-          source testing_env/bin/activate
-          pip install --upgrade pip
           cd qcarchive
-          pip install -e ./qcportal -e ./qcfractalcompute -e ./qcfractal -e ./qcarchivetesting
-          pytest --log-level=DEBUG --fractal-uri="http://127.0.0.1:7900" qcarchivetesting
+          pytest --log-level=DEBUG --fractal-uri="http://127.0.0.1:7900" qcarchivetesting -k test_full
 
+
+      #################################################
+      # Cleanup
+      #################################################
       - name: Stop server & worker
         shell: bash -l {0}
         run: |

--- a/qcarchivetesting/conda-envs/fulltest_testing.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_testing.yaml
@@ -1,9 +1,13 @@
-name: qcarchive-qcportal
+name: qcarchive-testing
 channels:
   - conda-forge
   - defaults
 
 dependencies:
+  - pip
+  - postgresql
+
+  # QCPortal dependencies
   # NOTE: msgpack-python in conda is msgpack in pypi (due to a rename around v0.5)
   - numpy
   - msgpack-python
@@ -21,3 +25,18 @@ dependencies:
   - typing_extensions
   - python-dateutil
   - pytz
+
+  # QCFractalCompute dependencies
+  - parsl
+
+  # QCFractal dependencies
+  - flask
+  - flask-jwt-extended
+  - waitress
+  - bcrypt
+  - sqlalchemy>=2.0
+  - alembic
+  - psycopg2
+
+  # Testing packages
+  - pytest


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

The "fulltest" GHA set up a nice conda env with qcportal, then also used a venv. This attempts to clean that up.

## Status
- [X] Code base linted
- [ ] Ready to go
