### PR TITLE
allow entry and specification names to be passed to get_properties_df

### DIFF
--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1996,9 +1996,12 @@ class BaseDataset(BaseModel):
         # Make specification top level index.
         return return_val.swaplevel(axis=1)
 
-    def get_properties_df(self, properties_list: Sequence[str], 
-                          entry_names: Sequence[str] | None = None, 
-                          specification_names: Sequence[str] | None = None) -> pd.DataFrame:
+    def get_properties_df(
+        self,
+        properties_list: Sequence[str],
+        entry_names: Sequence[str] | None = None,
+        specification_names: Sequence[str] | None = None,
+    ) -> "DataFrame":
         """
         Retrieve a DataFrame populated with the specified properties from dataset records.
 
@@ -2021,7 +2024,7 @@ class BaseDataset(BaseModel):
 
         Returns:
         --------
-        pd.DataFrame
+        pandas.DataFrame
             A DataFrame populated with the specified properties for each record.
         """
 
@@ -2029,11 +2032,13 @@ class BaseDataset(BaseModel):
         extract_properties = lambda x: [x.properties.get(property_name) for property_name in properties_list]
 
         # retrieve values.
-        result = self.compile_values(extract_properties, 
-                                     value_names=properties_list, 
-                                     unpack=True, 
-                                     specification_names=specification_names, 
-                                     entry_names=entry_names)
+        result = self.compile_values(
+            extract_properties,
+            value_names=properties_list,
+            unpack=True,
+            specification_names=specification_names,
+            entry_names=entry_names,
+        )
 
         # Drop columns with all nan  values. This will occur if a property that is not part of a
         # specification is requested.

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -1996,7 +1996,9 @@ class BaseDataset(BaseModel):
         # Make specification top level index.
         return return_val.swaplevel(axis=1)
 
-    def get_properties_df(self, properties_list: Sequence[str]) -> "DataFrame":
+    def get_properties_df(self, properties_list: Sequence[str], 
+                          entry_names: Sequence[str] | None = None, 
+                          specification_names: Sequence[str] | None = None) -> pd.DataFrame:
         """
         Retrieve a DataFrame populated with the specified properties from dataset records.
 
@@ -2011,9 +2013,15 @@ class BaseDataset(BaseModel):
         properties_list
             List of property names to retrieve from the records.
 
+        entry_names
+            Entry names to filter records. If not provided, considers all entries.
+
+        specification_names
+            Specification names to filter records. If not provided, considers all specifications.
+
         Returns:
         --------
-        pandas.DataFrame
+        pd.DataFrame
             A DataFrame populated with the specified properties for each record.
         """
 
@@ -2021,7 +2029,11 @@ class BaseDataset(BaseModel):
         extract_properties = lambda x: [x.properties.get(property_name) for property_name in properties_list]
 
         # retrieve values.
-        result = self.compile_values(extract_properties, value_names=properties_list, unpack=True)
+        result = self.compile_values(extract_properties, 
+                                     value_names=properties_list, 
+                                     unpack=True, 
+                                     specification_names=specification_names, 
+                                     entry_names=entry_names)
 
         # Drop columns with all nan  values. This will occur if a property that is not part of a
         # specification is requested.


### PR DESCRIPTION
## Description
This PR adds `entry_names` and `specificaiton_names` to be passed to `get_properties_df`.


## Status
- [x] Code base linted
- [x] Ready to go
