### PR TITLE
Slight cleanup of dataset routes & socket

### DIFF
--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -113,16 +113,6 @@ def add_dataset_v1(dataset_type: str, body_data: DatasetAddBody):
 #########################
 # Getting info
 #########################
-@api_v1.route("/datasets/<int:dataset_id>", methods=["GET"])
-@wrap_route("READ")
-def get_dataset_general_v1(dataset_id: int, url_params: ProjURLParameters):
-    return storage_socket.datasets.get(
-        dataset_id,
-        url_params.include,
-        url_params.exclude,
-    )
-
-
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>", methods=["GET"])
 @wrap_route("READ")
 def get_dataset_v1(dataset_type: str, dataset_id: int, url_params: ProjURLParameters):
@@ -182,7 +172,7 @@ def modify_dataset_metadata_v1(dataset_type: str, dataset_id: int, body_data: Da
 
 
 #########################
-# Views & Attachments
+# Views
 #########################
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/create_view", methods=["POST"])
 @wrap_route("WRITE")

--- a/qcfractal/qcfractal/components/dataset_socket.py
+++ b/qcfractal/qcfractal/components/dataset_socket.py
@@ -397,7 +397,7 @@ class BaseDatasetSocket:
         """
         Create a new dataset in the database
 
-        If a dataset already exists with the same name and type, an exception is raised
+        If a dataset already exists with the same name and type, an exception is raised if existing_ok is False
 
         Returns
         -------


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
Very small cleanup discovered while working on something else.

1. Dataset route for `/dataset/<dataset_id>`  was effectively duplicated
2. Some small docs and comments update

## Status
- [X] Code base linted
- [X] Ready to go
