### PR TITLE
Ability to add entries in the background

### DIFF
--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -303,6 +303,22 @@ def fetch_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Data
     )
 
 
+@api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/background_add_entries", methods=["POST"])
+@wrap_route("WRITE")
+def background_add_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubmitBody):
+    ds_socket = storage_socket.datasets.get_socket(dataset_type)
+    return ds_socket.background_submit(
+        dataset_id,
+        entry_names=body_data.entry_names,
+        specification_names=body_data.specification_names,
+        compute_tag=body_data.compute_tag,
+        compute_priority=body_data.compute_priority,
+        owner_user=g.username,
+        owner_group=body_data.owner_group,
+        find_existing=body_data.find_existing,
+    )
+
+
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/entries", methods=["PATCH"])
 @wrap_route("WRITE")
 def rename_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dict[str, str]):

--- a/qcfractal/qcfractal/components/dataset_socket.py
+++ b/qcfractal/qcfractal/components/dataset_socket.py
@@ -789,17 +789,20 @@ class BaseDatasetSocket:
                     )
                 )
 
-                existing_entries = session.execute(stmt).scalars().all()
+                existing_entries = set(session.execute(stmt).scalars().all())
+                entries_to_add = []
 
                 for entry in entry_orm_batch:
                     # Only add if the entry does not exist
                     if entry.name in existing_entries:
                         existing_idx.append(idx)
                     else:
-                        session.add(entry)
+                        entries_to_add.append(entry)
                         inserted_idx.append(idx)
 
                     idx += 1
+
+                session.add_all(entries_to_add)
 
         return InsertMetadata(inserted_idx=inserted_idx, existing_idx=existing_idx)
 

--- a/qcfractal/qcfractal/components/gridoptimization/routes.py
+++ b/qcfractal/qcfractal/components/gridoptimization/routes.py
@@ -71,7 +71,12 @@ def add_gridoptimization_dataset_specifications_v1(
 @api_v1.route("/datasets/gridoptimization/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @wrap_route("WRITE")
 def add_gridoptimization_dataset_entries_v1(dataset_id: int, body_data: List[GridoptimizationDatasetNewEntry]):
-    return storage_socket.datasets.gridoptimization.add_entries(
-        dataset_id,
-        new_entries=body_data,
-    )
+    return storage_socket.datasets.gridoptimization.add_entries(dataset_id, new_entries=body_data)
+
+
+@api_v1.route("/datasets/gridoptimization/<int:dataset_id>/background_add_entries", methods=["POST"])
+@wrap_route("WRITE")
+def background_add_gridoptimization_dataset_entries_v1(
+    dataset_id: int, body_data: List[GridoptimizationDatasetNewEntry]
+):
+    return storage_socket.datasets.gridoptimization.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/manybody/routes.py
+++ b/qcfractal/qcfractal/components/manybody/routes.py
@@ -67,7 +67,10 @@ def add_manybody_dataset_specifications_v1(dataset_id: int, body_data: List[Many
 @api_v1.route("/datasets/manybody/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @wrap_route("WRITE")
 def add_manybody_dataset_entries_v1(dataset_id: int, body_data: List[ManybodyDatasetNewEntry]):
-    return storage_socket.datasets.manybody.add_entries(
-        dataset_id,
-        new_entries=body_data,
-    )
+    return storage_socket.datasets.manybody.add_entries(dataset_id, new_entries=body_data)
+
+
+@api_v1.route("/datasets/manybody/<int:dataset_id>/background_add_entries", methods=["POST"])
+@wrap_route("WRITE")
+def background_add_manybody_dataset_entries_v1(dataset_id: int, body_data: List[ManybodyDatasetNewEntry]):
+    return storage_socket.datasets.manybody.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/neb/routes.py
+++ b/qcfractal/qcfractal/components/neb/routes.py
@@ -80,7 +80,10 @@ def add_neb_dataset_specifications_v1(dataset_id: int, body_data: List[NEBDatase
 @api_v1.route("/datasets/neb/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @wrap_route("WRITE")
 def add_neb_dataset_entries_v1(dataset_id: int, body_data: List[NEBDatasetNewEntry]):
-    return storage_socket.datasets.neb.add_entries(
-        dataset_id,
-        new_entries=body_data,
-    )
+    return storage_socket.datasets.neb.add_entries(dataset_id, new_entries=body_data)
+
+
+@api_v1.route("/datasets/neb/<int:dataset_id>/background_add_entries", methods=["POST"])
+@wrap_route("WRITE")
+def background_add_neb_dataset_entries_v1(dataset_id: int, body_data: List[NEBDatasetNewEntry]):
+    return storage_socket.datasets.neb.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/optimization/routes.py
+++ b/qcfractal/qcfractal/components/optimization/routes.py
@@ -69,7 +69,10 @@ def add_optimization_dataset_specifications_v1(dataset_id: int, body_data: List[
 @api_v1.route("/datasets/optimization/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @wrap_route("WRITE")
 def add_optimization_dataset_entries_v1(dataset_id: int, body_data: List[OptimizationDatasetNewEntry]):
-    return storage_socket.datasets.optimization.add_entries(
-        dataset_id,
-        new_entries=body_data,
-    )
+    return storage_socket.datasets.optimization.add_entries(dataset_id, new_entries=body_data)
+
+
+@api_v1.route("/datasets/optimization/<int:dataset_id>/background_add_entries", methods=["POST"])
+@wrap_route("WRITE")
+def background_add_optimization_dataset_entries_v1(dataset_id: int, body_data: List[OptimizationDatasetNewEntry]):
+    return storage_socket.datasets.optimization.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/reaction/routes.py
+++ b/qcfractal/qcfractal/components/reaction/routes.py
@@ -67,7 +67,10 @@ def add_reaction_dataset_specifications_v1(dataset_id: int, body_data: List[Reac
 @api_v1.route("/datasets/reaction/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @wrap_route("WRITE")
 def add_reaction_dataset_entries_v1(dataset_id: int, body_data: List[ReactionDatasetNewEntry]):
-    return storage_socket.datasets.reaction.add_entries(
-        dataset_id,
-        new_entries=body_data,
-    )
+    return storage_socket.datasets.reaction.add_entries(dataset_id, new_entries=body_data)
+
+
+@api_v1.route("/datasets/reaction/<int:dataset_id>/background_add_entries", methods=["POST"])
+@wrap_route("WRITE")
+def background_add_reaction_dataset_entries_v1(dataset_id: int, body_data: List[ReactionDatasetNewEntry]):
+    return storage_socket.datasets.reaction.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/singlepoint/routes.py
+++ b/qcfractal/qcfractal/components/singlepoint/routes.py
@@ -74,10 +74,13 @@ def add_singlepoint_dataset_specifications_v1(dataset_id: int, body_data: List[S
 @api_v1.route("/datasets/singlepoint/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @wrap_route("WRITE")
 def add_singlepoint_dataset_entries_v1(dataset_id: int, body_data: List[SinglepointDatasetNewEntry]):
-    return storage_socket.datasets.singlepoint.add_entries(
-        dataset_id,
-        new_entries=body_data,
-    )
+    return storage_socket.datasets.singlepoint.add_entries(dataset_id, new_entries=body_data)
+
+
+@api_v1.route("/datasets/singlepoint/<int:dataset_id>/background_add_entries", methods=["POST"])
+@wrap_route("WRITE")
+def background_add_singlepoint_dataset_entries_v1(dataset_id: int, body_data: List[SinglepointDatasetNewEntry]):
+    return storage_socket.datasets.singlepoint.background_add_entries(dataset_id, new_entries=body_data)
 
 
 @api_v1.route("/datasets/singlepoint/<int:dataset_id>/entries/addFrom", methods=["POST"])

--- a/qcfractal/qcfractal/components/torsiondrive/routes.py
+++ b/qcfractal/qcfractal/components/torsiondrive/routes.py
@@ -82,7 +82,10 @@ def add_torsiondrive_dataset_specifications_v1(dataset_id: int, body_data: List[
 @api_v1.route("/datasets/torsiondrive/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @wrap_route("WRITE")
 def add_torsiondrive_dataset_entries_v1(dataset_id: int, body_data: List[TorsiondriveDatasetNewEntry]):
-    return storage_socket.datasets.torsiondrive.add_entries(
-        dataset_id,
-        new_entries=body_data,
-    )
+    return storage_socket.datasets.torsiondrive.add_entries(dataset_id, new_entries=body_data)
+
+
+@api_v1.route("/datasets/torsiondrive/<int:dataset_id>/background_add_entries", methods=["POST"])
+@wrap_route("WRITE")
+def background_add_torsiondrive_dataset_entries_v1(dataset_id: int, body_data: List[TorsiondriveDatasetNewEntry]):
+    return storage_socket.datasets.torsiondrive.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcportal/qcportal/gridoptimization/dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/dataset_models.py
@@ -12,6 +12,7 @@ from qcportal.gridoptimization.record_models import (
     GridoptimizationSpecification,
 )
 from qcportal.metadata_models import InsertMetadata
+from qcportal.internal_jobs import InternalJob
 from qcportal.molecules import Molecule
 
 
@@ -70,6 +71,11 @@ class GridoptimizationDataset(BaseDataset):
         self, entries: Union[GridoptimizationDatasetNewEntry, Iterable[GridoptimizationDatasetNewEntry]]
     ) -> InsertMetadata:
         return self._add_entries(entries)
+
+    def background_add_entries(
+        self, entries: Union[GridoptimizationDatasetNewEntry, Iterable[GridoptimizationDatasetNewEntry]]
+    ) -> InternalJob:
+        return self._background_add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/gridoptimization/test_dataset_models.py
+++ b/qcportal/qcportal/gridoptimization/test_dataset_models.py
@@ -114,9 +114,12 @@ def record_compare(rec, ent, spec):
     assert rec.specification == GridoptimizationSpecification(**merged_spec)
 
 
-def test_gridoptimization_dataset_model_add_get_entry(snowflake_client: PortalClient):
-    ds = snowflake_client.add_dataset("gridoptimization", "Test dataset")
-    ds_helpers.run_dataset_model_add_get_entry(snowflake_client, ds, test_entries, entry_extra_compare)
+@pytest.mark.parametrize("background", [True, False])
+def test_gridoptimization_dataset_model_add_get_entry(dataset_submit_test_client: PortalClient, background: bool):
+    ds = dataset_submit_test_client.add_dataset("gridoptimization", "Test dataset")
+    ds_helpers.run_dataset_model_add_get_entry(
+        dataset_submit_test_client, ds, test_entries, entry_extra_compare, background
+    )
 
 
 def test_gridoptimization_dataset_model_add_entry_duplicate(snowflake_client: PortalClient):

--- a/qcportal/qcportal/manybody/dataset_models.py
+++ b/qcportal/qcportal/manybody/dataset_models.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset
 from qcportal.manybody.record_models import ManybodyRecord, ManybodySpecification
+from qcportal.internal_jobs import InternalJob
 from qcportal.metadata_models import InsertMetadata
 from qcportal.molecules import Molecule
 
@@ -61,6 +62,11 @@ class ManybodyDataset(BaseDataset):
 
     def add_entries(self, entries: Union[ManybodyDatasetNewEntry, Iterable[ManybodyDatasetNewEntry]]) -> InsertMetadata:
         return self._add_entries(entries)
+
+    def background_add_entries(
+        self, entries: Union[ManybodyDatasetNewEntry, Iterable[ManybodyDatasetNewEntry]]
+    ) -> InternalJob:
+        return self._background_add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/manybody/test_dataset_models.py
+++ b/qcportal/qcportal/manybody/test_dataset_models.py
@@ -87,9 +87,12 @@ def record_compare(rec, ent, spec):
     assert rec.specification == ManybodySpecification(**merged_spec)
 
 
-def test_manybody_dataset_model_add_get_entry(snowflake_client: PortalClient):
-    ds = snowflake_client.add_dataset("manybody", "Test dataset")
-    ds_helpers.run_dataset_model_add_get_entry(snowflake_client, ds, test_entries, entry_extra_compare)
+@pytest.mark.parametrize("background", [True, False])
+def test_manybody_dataset_model_add_get_entry(dataset_submit_test_client: PortalClient, background: bool):
+    ds = dataset_submit_test_client.add_dataset("manybody", "Test dataset")
+    ds_helpers.run_dataset_model_add_get_entry(
+        dataset_submit_test_client, ds, test_entries, entry_extra_compare, background
+    )
 
 
 def test_manybody_dataset_model_add_entry_duplicate(snowflake_client: PortalClient):

--- a/qcportal/qcportal/neb/dataset_models.py
+++ b/qcportal/qcportal/neb/dataset_models.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset
 from qcportal.metadata_models import InsertMetadata
+from qcportal.internal_jobs import InternalJob
 from qcportal.molecules import Molecule
 from qcportal.neb.record_models import (
     NEBRecord,
@@ -69,6 +70,9 @@ class NEBDataset(BaseDataset):
 
     def add_entries(self, entries: Union[NEBDatasetNewEntry, Iterable[NEBDatasetNewEntry]]) -> InsertMetadata:
         return self._add_entries(entries)
+
+    def background_add_entries(self, entries: Union[NEBDatasetNewEntry, Iterable[NEBDatasetNewEntry]]) -> InternalJob:
+        return self._background_add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/neb/test_dataset_models.py
+++ b/qcportal/qcportal/neb/test_dataset_models.py
@@ -116,9 +116,12 @@ def record_compare(rec, ent, spec):
     assert rec.specification == NEBSpecification(**merged_spec)
 
 
-def test_neb_dataset_model_add_get_entry(snowflake_client: PortalClient):
-    ds = snowflake_client.add_dataset("neb", "Test dataset")
-    ds_helpers.run_dataset_model_add_get_entry(snowflake_client, ds, test_entries, entry_extra_compare)
+@pytest.mark.parametrize("background", [True, False])
+def test_neb_dataset_model_add_get_entry(dataset_submit_test_client: PortalClient, background: bool):
+    ds = dataset_submit_test_client.add_dataset("neb", "Test dataset")
+    ds_helpers.run_dataset_model_add_get_entry(
+        dataset_submit_test_client, ds, test_entries, entry_extra_compare, background
+    )
 
 
 def test_neb_dataset_model_add_entry_duplicate(snowflake_client: PortalClient):

--- a/qcportal/qcportal/optimization/dataset_models.py
+++ b/qcportal/qcportal/optimization/dataset_models.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset
 from qcportal.metadata_models import InsertMetadata
+from qcportal.internal_jobs import InternalJob
 from qcportal.molecules import Molecule
 from qcportal.optimization.record_models import OptimizationRecord, OptimizationSpecification
 
@@ -66,6 +67,11 @@ class OptimizationDataset(BaseDataset):
         self, entries: Union[OptimizationDatasetNewEntry, Iterable[OptimizationDatasetNewEntry]]
     ) -> InsertMetadata:
         return self._add_entries(entries)
+
+    def background_add_entries(
+        self, entries: Union[OptimizationDatasetNewEntry, Iterable[OptimizationDatasetNewEntry]]
+    ) -> InternalJob:
+        return self._background_add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/optimization/test_dataset_models.py
+++ b/qcportal/qcportal/optimization/test_dataset_models.py
@@ -72,9 +72,12 @@ def record_compare(rec, ent, spec):
     assert rec.specification == OptimizationSpecification(**merged_spec)
 
 
-def test_optimization_dataset_model_add_get_entry(snowflake_client: PortalClient):
-    ds = snowflake_client.add_dataset("optimization", "Test dataset")
-    ds_helpers.run_dataset_model_add_get_entry(snowflake_client, ds, test_entries, entry_extra_compare)
+@pytest.mark.parametrize("background", [True, False])
+def test_optimization_dataset_model_add_get_entry(dataset_submit_test_client: PortalClient, background: bool):
+    ds = dataset_submit_test_client.add_dataset("optimization", "Test dataset")
+    ds_helpers.run_dataset_model_add_get_entry(
+        dataset_submit_test_client, ds, test_entries, entry_extra_compare, background
+    )
 
 
 def test_optimization_dataset_model_add_entry_duplicate(snowflake_client: PortalClient):

--- a/qcportal/qcportal/reaction/dataset_models.py
+++ b/qcportal/qcportal/reaction/dataset_models.py
@@ -9,6 +9,7 @@ from typing_extensions import Literal
 from qcportal.dataset_models import BaseDataset
 from qcportal.metadata_models import InsertMetadata
 from qcportal.molecules import Molecule
+from qcportal.internal_jobs import InternalJob
 from qcportal.reaction.record_models import ReactionRecord, ReactionSpecification
 
 
@@ -72,6 +73,11 @@ class ReactionDataset(BaseDataset):
 
     def add_entries(self, entries: Union[ReactionDatasetEntry, Iterable[ReactionDatasetNewEntry]]) -> InsertMetadata:
         return self._add_entries(entries)
+
+    def background_add_entries(
+        self, entries: Union[ReactionDatasetNewEntry, Iterable[ReactionDatasetNewEntry]]
+    ) -> InternalJob:
+        return self._background_add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/reaction/test_dataset_models.py
+++ b/qcportal/qcportal/reaction/test_dataset_models.py
@@ -102,9 +102,12 @@ def record_compare(rec, ent, spec):
     assert rec.specification == ReactionSpecification(**merged_spec)
 
 
-def test_reaction_dataset_model_add_get_entry(snowflake_client: PortalClient):
-    ds = snowflake_client.add_dataset("reaction", "Test dataset")
-    ds_helpers.run_dataset_model_add_get_entry(snowflake_client, ds, test_entries, entry_extra_compare)
+@pytest.mark.parametrize("background", [True, False])
+def test_reaction_dataset_model_add_get_entry(dataset_submit_test_client: PortalClient, background: bool):
+    ds = dataset_submit_test_client.add_dataset("reaction", "Test dataset")
+    ds_helpers.run_dataset_model_add_get_entry(
+        dataset_submit_test_client, ds, test_entries, entry_extra_compare, background
+    )
 
 
 def test_reaction_dataset_model_add_entry_duplicate(snowflake_client: PortalClient):

--- a/qcportal/qcportal/singlepoint/dataset_models.py
+++ b/qcportal/qcportal/singlepoint/dataset_models.py
@@ -9,6 +9,7 @@ from typing_extensions import Literal
 from qcportal.dataset_models import BaseDataset
 from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.molecules import Molecule
+from qcportal.internal_jobs import InternalJob
 from qcportal.singlepoint.record_models import (
     SinglepointRecord,
     QCSpecification,
@@ -90,6 +91,11 @@ class SinglepointDataset(BaseDataset):
         self, entries: Union[SinglepointDatasetNewEntry, Iterable[SinglepointDatasetNewEntry]]
     ) -> InsertMetadata:
         return self._add_entries(entries)
+
+    def background_add_entries(
+        self, entries: Union[SinglepointDatasetNewEntry, Iterable[SinglepointDatasetNewEntry]]
+    ) -> InternalJob:
+        return self._background_add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/singlepoint/test_dataset_models.py
+++ b/qcportal/qcportal/singlepoint/test_dataset_models.py
@@ -57,9 +57,12 @@ def record_compare(rec, ent, spec):
     assert rec.specification == QCSpecification(**merged_spec)
 
 
-def test_singlepoint_dataset_model_add_get_entry(snowflake_client: PortalClient):
-    ds = snowflake_client.add_dataset("singlepoint", "Test dataset")
-    ds_helpers.run_dataset_model_add_get_entry(snowflake_client, ds, test_entries, entry_extra_compare)
+@pytest.mark.parametrize("background", [True, False])
+def test_singlepoint_dataset_model_add_get_entry(dataset_submit_test_client: PortalClient, background: bool):
+    ds = dataset_submit_test_client.add_dataset("singlepoint", "Test dataset")
+    ds_helpers.run_dataset_model_add_get_entry(
+        dataset_submit_test_client, ds, test_entries, entry_extra_compare, background
+    )
 
 
 def test_singlepoint_dataset_model_add_entry_duplicate(snowflake_client: PortalClient):

--- a/qcportal/qcportal/torsiondrive/dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/dataset_models.py
@@ -9,6 +9,7 @@ from typing_extensions import Literal
 from qcportal.dataset_models import BaseDataset
 from qcportal.metadata_models import InsertMetadata
 from qcportal.molecules import Molecule
+from qcportal.internal_jobs import InternalJob
 from qcportal.torsiondrive.record_models import TorsiondriveRecord, TorsiondriveSpecification
 
 
@@ -69,6 +70,11 @@ class TorsiondriveDataset(BaseDataset):
         self, entries: Union[TorsiondriveDatasetNewEntry, Iterable[TorsiondriveDatasetNewEntry]]
     ) -> InsertMetadata:
         return self._add_entries(entries)
+
+    def background_add_entries(
+        self, entries: Union[TorsiondriveDatasetNewEntry, Iterable[TorsiondriveDatasetNewEntry]]
+    ) -> InternalJob:
+        return self._background_add_entries(entries)
 
     def add_entry(
         self,

--- a/qcportal/qcportal/torsiondrive/test_dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/test_dataset_models.py
@@ -119,9 +119,12 @@ def record_compare(rec, ent, spec):
     assert rec.specification == TorsiondriveSpecification(**merged_spec)
 
 
-def test_torsiondrive_dataset_model_add_get_entry(snowflake_client: PortalClient):
-    ds = snowflake_client.add_dataset("torsiondrive", "Test dataset")
-    ds_helpers.run_dataset_model_add_get_entry(snowflake_client, ds, test_entries, entry_extra_compare)
+@pytest.mark.parametrize("background", [True, False])
+def test_torsiondrive_dataset_model_add_get_entry(dataset_submit_test_client: PortalClient, background: bool):
+    ds = dataset_submit_test_client.add_dataset("torsiondrive", "Test dataset")
+    ds_helpers.run_dataset_model_add_get_entry(
+        dataset_submit_test_client, ds, test_entries, entry_extra_compare, background
+    )
 
 
 def test_torsiondrive_dataset_model_add_entry_duplicate(snowflake_client: PortalClient):


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Adding large numbers of entries to a dataset can be time consuming. This PR adds the ability to add them via a background internal job on the server.

Will be interesting to see how the internal jobs table handles a large blob of data :)

## Status
- [X] Code base linted
- [X] Ready to go
