### PR TITLE
Add ability to set more flags for session cookie

### DIFF
--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -306,6 +306,21 @@ class WebAPIConfig(ConfigBase):
     user_session_cookie_name: str = Field(
         "qcf_session", description="Name to use for a session cookie (for browser-based sessions)"
     )
+    user_session_cookie_domain: Optional[str] = Field(
+        None, description="Domain to use for the user-session cookie (for browser-based sessions)"
+    )
+    user_session_cookie_samesite: Optional[str] = Field(
+        None, description="Set the SameSite flag for the user-session cookie (for browser-based sessions)"
+    )
+    user_session_cookie_partitioned: bool = Field(
+        False, description="Use the Partitioned flag for the user-session cookie (for browser-based sessions)"
+    )
+    user_session_cookie_secure: bool = Field(
+        False, description="Use Secure flag for the user-session cookie (for browser-based sessions)"
+    )
+    user_session_cookie_httponly: bool = Field(
+        False, description="Use Secure flag for the user-session cookie (for browser-based sessions)"
+    )
 
     extra_flask_options: Optional[Dict[str, Any]] = Field(
         None, description="Any additional options to pass directly to flask"

--- a/qcfractal/qcfractal/flask_app/flask_session.py
+++ b/qcfractal/qcfractal/flask_app/flask_session.py
@@ -107,5 +107,14 @@ class QCFFlaskSessionInterface(SessionInterface):
 
             # Set the cookie in the response
             # Same name & session id, but extend the lifetime
-            response.set_cookie(cookie_name, session_id, max_age=app.permanent_session_lifetime)
+            response.set_cookie(
+                cookie_name,
+                session_id,
+                domain=app.config["QCFRACTAL_CONFIG"].api.user_session_cookie_domain,
+                max_age=app.permanent_session_lifetime,
+                httponly=app.config["QCFRACTAL_CONFIG"].api.user_session_cookie_httponly,
+                samesite=app.config["QCFRACTAL_CONFIG"].api.user_session_cookie_samesite,
+                secure=app.config["QCFRACTAL_CONFIG"].api.user_session_cookie_secure,
+                partitioned=app.config["QCFRACTAL_CONFIG"].api.user_session_cookie_partitioned,
+            )
             response.vary.add("Cookie")


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
Title basically says it all. This adds the ability to set httponly, samesite, secure, partitioned, and domain flags of the browser session cookie.

## Status
- [X] Code base linted
- [X] Ready to go
