### PR TITLE
add optional progress bar to client for downloading files

### DIFF
--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -379,7 +379,11 @@ class PortalClient(PortalClientBase):
         file_info = self.make_request("get", meta_url, ExternalFile)
 
         # Now actually download the file
-        file_size, file_sha256 = self.download_file(download_url, destination_path, overwrite=overwrite)
+        file_size, file_sha256 = self.download_file(download_url, 
+                                                    destination_path, 
+                                                    overwrite=overwrite, 
+                                                    expected_size=file_info.file_size,
+                                                    show_progress=True)
 
         if file_size != file_info.file_size:
             raise RuntimeError(f"Inconsistent file size. Expected {file_info.file_size}, got {file_size}")

--- a/qcportal/qcportal/client_base.py
+++ b/qcportal/qcportal/client_base.py
@@ -25,6 +25,8 @@ import yaml
 import hashlib
 from packaging.version import parse as parse_version
 
+from tqdm import tqdm
+
 from . import __version__
 from .exceptions import AuthenticationFailure
 from .serialization import serialize, deserialize
@@ -507,8 +509,28 @@ class PortalClientBase:
         else:
             return pydantic.parse_obj_as(response_model, d)
 
-    def download_file(self, endpoint: str, destination_path: str, overwrite: bool = False) -> Tuple[int, str]:
-
+    def download_file(self, endpoint: str, 
+                 destination_path: str, 
+                 overwrite: bool = False,
+                 expected_size: Optional[int] = None,
+                 show_progress: bool = False) -> Tuple[int, str]:
+        """
+        Download a file with optional progress bar
+        
+        Parameters
+        ----------
+        endpoint
+            API endpoint to download from
+        destination_path
+            Where to save the file
+        overwrite
+            Whether to overwrite existing files
+        expected_size
+            Expected size of the file in bytes (used for progress bar if enabled)
+        show_progress
+            Whether to show a progress bar during download
+        """
+        
         sha256 = hashlib.sha256()
         file_size = 0
 
@@ -530,12 +552,38 @@ class PortalClientBase:
             response = requests.get(new_location, stream=True, allow_redirects=True)
 
         response.raise_for_status()
+        
+        # Get filename for display in progress bar
+        filename = os.path.basename(destination_path)
+        
         with open(destination_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=None):
-                if chunk:
-                    f.write(chunk)
-                    sha256.update(chunk)
-                    file_size += len(chunk)
+            if show_progress:
+                # Show progress bar with expected_size (which can be None)
+                with tqdm(
+                    total=expected_size,
+                    unit='B',
+                    unit_scale=True,
+                    unit_divisor=1024,
+                    desc=f"Downloading to {filename}",
+                    miniters=1,        # Update after each iteration
+                    mininterval=0.1     # Allow updates as frequently as every 0.1 seconds
+                ) as pbar:
+                    # set chunk_size here so that progress bar can be updated
+                    # if set to None, it may only be updated after the entire download is complete
+                    # 4*1024*1024 is 4MB
+                    for chunk in response.iter_content(chunk_size=4*1024*1024):
+                        if chunk:
+                            f.write(chunk)
+                            sha256.update(chunk)
+                            chunk_size = len(chunk)
+                            file_size += chunk_size
+                            pbar.update(chunk_size)
+            else:
+                for chunk in response.iter_content(chunk_size=None):
+                    if chunk:
+                        f.write(chunk)
+                        sha256.update(chunk)
+                        file_size += len(chunk)
 
         return file_size, sha256.hexdigest()
 


### PR DESCRIPTION
## Description
This PR adds a progress bar to `download_file` in `client_base` by using `tqdm`. Two new optional arguments are added to `download_file`:

* `show_progress` - This indicates whether or not to show a progress bar for a particular downloaded file. It is set to `False` by default to keep default behavior the same (I am unsure of where else the function is used, and I imagine that you do not always want a progress bar)
* `expected_size` - This is the expected size of the file. If an expected size is provided to tqdm, it will show a bar. Otherwise, it will just print the speed.

I set chunk size when using tqdm because when set to `None` I was not seeing the progress bar update (would sit at zero and suddenly increase at the end). This size (8 MB) worked well for showing progress and actually resulted in faster speeds than no chunk size (tested on server).

In order for this progress bar to be displayed when downloading views, I also added passing these arguments to `download_external_file` in client.

Sample status bar:
```
Downloading to dataset_353_view.sqlite: 100%|██████████████████████| 22.1G/22.1G [00:54<00:00, 433MB/s]
```

## Status
- [ ] Code base linted
- [ ] Ready to go
