### PR TITLE
Make name/type required in DatasetQueryModel

### DIFF
--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -2322,8 +2322,8 @@ class DatasetModifyMetadata(RestModelBase):
 
 
 class DatasetQueryModel(RestModelBase):
-    dataset_type: Optional[str] = None
-    dataset_name: Optional[str] = None
+    dataset_type: str
+    dataset_name: str
     include: Optional[List[str]] = None
     exclude: Optional[List[str]] = None
 


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Previously, all fields of DatasetQueryModel were optional. However, this allowed some `None` values to propagate down, causing internal server errors.

This makes those fields mandatory, since the only real purpose of this class is getting datasets by name/type

Found by @brandontton

## Status
- [X] Code base linted
- [X] Ready to go
