### PR TITLE
Groundwork for file uploads

### DIFF
--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -482,6 +482,9 @@ class FractalConfig(ConfigBase):
     homepage_redirect_url: Optional[str] = Field(None, description="Redirect to this URL when going to the root path")
     homepage_directory: Optional[str] = Field(None, description="Use this directory to serve the homepage")
 
+    # File uploads
+    upload_directory: Optional[str] = Field(None, description="Directory to store user-uploaded files for processing")
+
     # Other settings blocks
     database: DatabaseConfig = Field(..., description="Configuration of the settings for the database")
     api: WebAPIConfig = Field(..., description="Configuration of the REST interface")
@@ -523,6 +526,10 @@ class FractalConfig(ConfigBase):
 
     @validator("homepage_directory")
     def _check_hompepage_directory_path(cls, v, values):
+        return _make_abs_path(v, values["base_folder"], None)
+
+    @validator("upload_directory")
+    def _check_upload_directory_path(cls, v, values):
         return _make_abs_path(v, values["base_folder"], None)
 
     @validator("logfile")

--- a/qcfractal/qcfractal/flask_app/flask_app.py
+++ b/qcfractal/qcfractal/flask_app/flask_app.py
@@ -69,6 +69,9 @@ def create_flask_app(
     app.config["SESSION_COOKIE_NAME"] = qcfractal_config.api.user_session_cookie_name
     app.config["PERMANENT_SESSION_LIFETIME"] = qcfractal_config.api.user_session_max_age
 
+    # Where we store user-uploaded files for processing
+    app.config["UPLOAD_FOLDER"] = qcfractal_config.upload_directory
+
     # Any additional configuration
     if qcfractal_config.api.extra_flask_options:
         app.config.update(**qcfractal_config.api.extra_flask_options)

--- a/qcfractal/qcfractal/flask_app/wrap_route.py
+++ b/qcfractal/qcfractal/flask_app/wrap_route.py
@@ -39,7 +39,9 @@ def wrap_global_route(requested_resource, requested_action, require_security: bo
     requested_resource
         The name of the major resource
     requested_action
-        e of action that this route handles (read, write, etc)
+        Type of action that this route handles (read, write, etc)
+    require_security
+        If true, route is only accessible if security is enabled on the server.
     """
 
     def decorate(fn):


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

This lays the foundation for uploading files for some requests. This will be used in the future, for example, to upload many molecule files and add them to the database without requiring client parsing.

No upload capability is actually added here - just some server and client fixes to handle this in the future.

## Status
- [X] Code base linted
- [X] Ready to go
