### PR TITLE
Add getting dataset status by compute tag

### DIFF
--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -138,6 +138,13 @@ def get_dataset_detailed_status_v1(dataset_type: str, dataset_id: int):
     return ds_socket.detailed_status(dataset_id)
 
 
+@api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/status_by_tag", methods=["GET"])
+@wrap_global_route("datasets", "read")
+def get_dataset_status_by_tag_v1(dataset_type: str, dataset_id: int):
+    ds_socket = storage_socket.datasets.get_socket(dataset_type)
+    return ds_socket.status_by_compute_tag(dataset_id)
+
+
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/record_count", methods=["GET"])
 @wrap_global_route("datasets", "read")
 def get_dataset_record_count_v1(dataset_type: str, dataset_id: int):

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -773,6 +773,15 @@ class BaseDataset(BaseModel):
             List[Tuple[str, str, RecordStatusEnum]],
         )
 
+    def status_by_compute_tag(self) -> List[Tuple[str, RecordStatusEnum, int]]:
+        self.assert_online()
+
+        return self._client.make_request(
+            "get",
+            f"{self._base_url}/status_by_tag",
+            List[Tuple[str, RecordStatusEnum, int]],
+        )
+
     @property
     def offline(self) -> bool:
         return self._client is None


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Adds a function (client & server) to get the status of a dataset grouped by tag.

Tested with some larger datasets on a test server and it seems fast enough (typically less than 3 seconds or so)

(if there's any more, I imagine we should make one general function)

Requested by @jaclark5 

## Status
- [X] Code base linted
- [X] Ready to go
