### PR TITLE
Fix active task reporting in compute manager

### DIFF
--- a/qcfractalcompute/qcfractalcompute/compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/compute_manager.py
@@ -591,6 +591,7 @@ class ComputeManager:
         # total_successful_tasks/n_failed_tasks are updated above, per executor
         ########################################################################
 
+        self.statistics.active_tasks = self.n_total_active_tasks
         n_active_tasks = self.n_active_tasks
 
         # Active cores - active tasks * cores per task (worker) for each executor


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Number of active tasks stored on the server is always zero. Turns out the statistics were never updated in the compute manager. This fixes that in a single line

## Status
- [X] Code base linted
- [X] Ready to go
