### PR TITLE
Allow copying specs between datasets with same name/id

### DIFF
--- a/qcfractal/qcfractal/components/dataset_socket.py
+++ b/qcfractal/qcfractal/components/dataset_socket.py
@@ -1695,6 +1695,11 @@ class BaseDatasetSocket:
             self.specification_orm.specification_id,
         )
 
+        # Join against the CTE for the existing specs
+        # If a spec exists with the same name and spec id, then the "where is null" will be false and it will be
+        #     filtered out from the select
+        # If the name exists BUT THE ID IS DIFFERENT, it is not filtered out, which will cause an integrity error
+        #     when we insert later
         select_stmt = select_stmt.join(
             existing_cte,
             and_(


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Before, when copying specifications from one dataset to another, an error was raised if a spec with the same name existing in the destination dataset. This relaxes that a bit, allowing for the copying to succeed (or at least not error) if the underlying specification_id is the same.

This allows for easier copying of specs & records from multiple datasets with the same specification, which is common.

## Status
- [X] Code base linted
- [X] Ready to go
