### PR TITLE
Reduce batch size in view creation

### DIFF
--- a/qcfractal/qcfractal/components/dataset_processing/views.py
+++ b/qcfractal/qcfractal/components/dataset_processing/views.py
@@ -160,7 +160,7 @@ def create_view_file(
         record_socket = socket.records.get_socket(record_type_str)
         record_type = BaseRecord.get_subclass(record_type_str)
 
-        for id_chunk in chunk_iterable(record_ids, 200):
+        for id_chunk in chunk_iterable(record_ids, 20):
             record_dicts = record_socket.get(id_chunk, include=include, exclude=exclude, session=session)
             record_data = [record_type(**r) for r in record_dicts]
             view_db.update_records(record_data)


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

When creating dataset view files, a batch size of 200 was used. This number was a wild guess. However, in datasets that contain large records (particularly wavefunctions) this is too large and can cause excess memory usage. This can safely reduced without much performance impact, but should reduce memory usage.

Should help with #946 

## Status
- [X] Code base linted
- [X] Ready to go
