### PR TITLE
Use spawn rather than fork for multiprocessing

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -53,5 +53,7 @@ jobs:
         run: |
           pytest --runslow --client-encoding="${{ matrix.encoding }}" \
                  --log-level=DEBUG \
+                 --log-format="%(asctime)s %(levelname)s %(message)s" \
+                 --log-date-format="%Y-%m-%d %H:%M:%S.%f" \
                  qcfractal qcportal qcfractalcompute
 

--- a/qcfractal/qcfractal/flask_app/waitress_app.py
+++ b/qcfractal/qcfractal/flask_app/waitress_app.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-import logging.handlers
 from typing import TYPE_CHECKING
 
 from .flask_app import create_flask_app
@@ -17,21 +15,12 @@ class FractalWaitressApp:
         self,
         qcfractal_config: FractalConfig,
         finished_queue: Optional[queue.Queue] = None,
-        logging_queue: Optional[queue.Queue] = None,
     ):
         self.qcfractal_config = qcfractal_config
         self.application = create_flask_app(qcfractal_config, finished_queue=finished_queue)
-        self.logging_queue = logging_queue
 
     def run(self):
         from waitress import serve
-
-        if self.logging_queue:
-            # Replace the root handler with one that just sends data to the logging queue
-            log_handler = logging.handlers.QueueHandler(self.logging_queue)
-            root_logger = logging.getLogger()
-            root_logger.handlers.clear()
-            root_logger.addHandler(log_handler)
 
         waitress_opts = self.qcfractal_config.api.extra_waitress_options
         if waitress_opts is None:

--- a/qcfractal/qcfractal/job_runner.py
+++ b/qcfractal/qcfractal/job_runner.py
@@ -7,8 +7,6 @@ dead managers, and updating statistics.
 
 from __future__ import annotations
 
-import logging
-import logging.handlers
 import multiprocessing
 import threading
 from typing import TYPE_CHECKING, Optional
@@ -30,7 +28,6 @@ class FractalJobRunner:
         self,
         qcf_config: FractalConfig,
         finished_queue: Optional[multiprocessing.Queue] = None,
-        logging_queue: Optional[multiprocessing.Queue] = None,
     ):
         """
         Parameters
@@ -42,7 +39,6 @@ class FractalJobRunner:
         self.storage_socket = SQLAlchemySocket(qcf_config)
         self.storage_socket.set_finished_watch(finished_queue)
         self._end_event = threading.Event()
-        self.logging_queue = logging_queue
 
     def start(self) -> None:
         """
@@ -50,13 +46,6 @@ class FractalJobRunner:
 
         This function will block until interrupted
         """
-
-        if self.logging_queue:
-            # Replace the root handler with one that just sends data to the logging queue
-            log_handler = logging.handlers.QueueHandler(self.logging_queue)
-            root_logger = logging.getLogger()
-            root_logger.handlers.clear()
-            root_logger.addHandler(log_handler)
 
         self.storage_socket.internal_jobs.run_loop(self._end_event)
 

--- a/qcfractal/qcfractal/process_targets.py
+++ b/qcfractal/qcfractal/process_targets.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import logging
+import logging.handlers
 import multiprocessing
 from typing import Optional
 
 from qcfractal.config import FractalConfig
 from qcfractal.flask_app.waitress_app import FractalWaitressApp
 from qcfractal.job_runner import FractalJobRunner
-from qcfractalcompute import ComputeManager
-from qcfractalcompute.config import FractalComputeConfig
 
 
 def api_process(
@@ -48,45 +47,6 @@ def api_process(
 
     try:
         api.run()
-    except KeyboardInterrupt:  # Swallow ugly output on CTRL-C
-        pass
-    finally:
-        logging_queue.close()
-        logging_queue.join_thread()
-
-
-def compute_process(compute_config: FractalComputeConfig, logging_queue: multiprocessing.Queue) -> None:
-    import signal
-
-    qh = logging.handlers.QueueHandler(logging_queue)
-    logger = logging.getLogger()
-    logger.handlers.clear()
-    logger.addHandler(qh)
-    logger.setLevel(compute_config.loglevel)
-
-    early_stop = False
-
-    def signal_handler(signum, frame):
-        nonlocal early_stop
-        early_stop = True
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
-
-    compute = ComputeManager(compute_config)
-    if early_stop:
-        logging_queue.close()
-        logging_queue.join_thread()
-        return
-
-    def signal_handler(signum, frame):
-        compute.stop()
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
-
-    try:
-        compute.start()
     except KeyboardInterrupt:  # Swallow ugly output on CTRL-C
         pass
     finally:

--- a/qcfractal/qcfractal/process_targets.py
+++ b/qcfractal/qcfractal/process_targets.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+
+from qcfractal.config import FractalConfig
+from qcfractal.flask_app.waitress_app import FractalWaitressApp
+from qcfractal.job_runner import FractalJobRunner
+from qcfractalcompute import ComputeManager
+from qcfractalcompute.config import FractalComputeConfig
+
+
+def api_process(
+    qcf_config: FractalConfig,
+    logging_queue: multiprocessing.Queue,
+    finished_queue: multiprocessing.Queue,
+) -> None:
+    import signal
+
+    qh = logging.handlers.QueueHandler(logging_queue)
+    logger = logging.getLogger()
+    logger.handlers.clear()
+    logger.addHandler(qh)
+
+    early_stop = False
+
+    def signal_handler(signum, frame):
+        nonlocal early_stop
+        early_stop = True
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    api = FractalWaitressApp(qcf_config, finished_queue)
+
+    if early_stop:
+        logging_queue.close()
+        logging_queue.join_thread()
+        return
+
+    def signal_handler(signum, frame):
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        api.run()
+    finally:
+        logging_queue.close()
+        logging_queue.join_thread()
+
+
+def compute_process(compute_config: FractalComputeConfig, logging_queue: multiprocessing.Queue) -> None:
+    import signal
+
+    qh = logging.handlers.QueueHandler(logging_queue)
+    logger = logging.getLogger()
+    logger.handlers.clear()
+    logger.addHandler(qh)
+
+    early_stop = False
+
+    def signal_handler(signum, frame):
+        nonlocal early_stop
+        early_stop = True
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    compute = ComputeManager(compute_config)
+    if early_stop:
+        logging_queue.close()
+        logging_queue.join_thread()
+        return
+
+    def signal_handler(signum, frame):
+        compute.stop()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        compute.start()
+    finally:
+        logging_queue.close()
+        logging_queue.join_thread()
+
+
+def job_runner_process(
+    qcf_config: FractalConfig, logging_queue: multiprocessing.Queue, finished_queue: multiprocessing.Queue
+) -> None:
+    import signal
+
+    qh = logging.handlers.QueueHandler(logging_queue)
+    logger = logging.getLogger()
+    logger.handlers.clear()
+    logger.addHandler(qh)
+
+    early_stop = False
+
+    def signal_handler(signum, frame):
+        nonlocal early_stop
+        early_stop = True
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    job_runner = FractalJobRunner(qcf_config, finished_queue)
+
+    if early_stop:
+        logging_queue.close()
+        logging_queue.join_thread()
+        return
+
+    def signal_handler(signum, frame):
+        job_runner.stop()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        job_runner.start()
+    finally:
+        logging_queue.close()
+        logging_queue.join_thread()

--- a/qcfractal/qcfractal/snowflake.py
+++ b/qcfractal/qcfractal/snowflake.py
@@ -65,8 +65,8 @@ class FractalSnowflake:
         This can also be used as a context manager (`with FractalSnowflake(...) as s:`)
         """
 
-        # Multiprocessing context - generally use fork
-        self._mp_context = multiprocessing.get_context("fork")
+        # Multiprocessing context - generally use spawn
+        self._mp_context = multiprocessing.get_context("spawn")
 
         self._logger = logging.getLogger("fractal_snowflake")
 

--- a/qcfractal/qcfractal/snowflake.py
+++ b/qcfractal/qcfractal/snowflake.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import requests
 
 from qcportal import PortalClient
+from qcportal.client_base import AllowedConnectionExceptions
 from qcportal.record_models import RecordStatusEnum
 from qcportal.utils import update_nested_dict
 from .config import FractalConfig, DatabaseConfig
@@ -291,7 +292,7 @@ class FractalSnowflake:
         port = self._qcf_config.api.port
         uri = f"http://{host}:{port}/api/v1/ping"
 
-        max_iter = 200
+        max_iter = 100
         iter = 0
         while True:
             try:
@@ -300,8 +301,8 @@ class FractalSnowflake:
                     raise RuntimeError("Error pinging snowflake fractal server: ", r.text)
                 break
 
-            except requests.exceptions.ConnectionError:
-                time.sleep(0.05)
+            except AllowedConnectionExceptions:
+                time.sleep(0.2)
                 iter += 1
                 if iter >= max_iter:
                     raise

--- a/qcfractal/qcfractal/snowflake.py
+++ b/qcfractal/qcfractal/snowflake.py
@@ -291,7 +291,7 @@ class FractalSnowflake:
         port = self._qcf_config.api.port
         uri = f"http://{host}:{port}/api/v1/ping"
 
-        max_iter = 50
+        max_iter = 200
         iter = 0
         while True:
             try:

--- a/qcfractal/qcfractal/snowflake.py
+++ b/qcfractal/qcfractal/snowflake.py
@@ -21,12 +21,13 @@ from qcportal.utils import update_nested_dict
 from .config import FractalConfig, DatabaseConfig
 from .port_util import find_open_port
 from .postgres_harness import create_snowflake_postgres
-from .process_targets import api_process, compute_process, job_runner_process
+from .process_targets import api_process, job_runner_process
 
 if importlib.util.find_spec("qcfractalcompute") is None:
     raise RuntimeError("qcfractalcompute is not installed. Snowflake is useless without it")
 
 from qcfractalcompute.config import FractalComputeConfig, FractalServerSettings, LocalExecutorConfig
+from qcfractalcompute.process_targets import compute_process
 
 if TYPE_CHECKING:
     from typing import Dict, Any, Sequence, Optional, Set

--- a/qcfractal/qcfractal/test_periodics.py
+++ b/qcfractal/qcfractal/test_periodics.py
@@ -58,18 +58,11 @@ def test_periodics_service_iteration(snowflake: QCATestingSnowflake):
 
     snowflake.start_job_runner()
 
-    time.sleep(1.0)
-
     # added after startup
     id_2, _ = submit_go_test_data(storage_socket, "go_H2O2_psi4_b3lyp")
 
-    # The first services iterated at startup
-    rec = storage_socket.records.get([id_1, id_2])
-    assert rec[0]["status"] == RecordStatusEnum.running
-    assert rec[1]["status"] == RecordStatusEnum.waiting
-
-    # wait for the next iteration. Then both should be running
-    time.sleep(service_freq + 0.5)
+    # wait for iteration. Then both should be running
+    time.sleep(service_freq + 1.5)
     rec = storage_socket.records.get([id_1, id_2])
     assert rec[0]["status"] == RecordStatusEnum.running
     assert rec[1]["status"] == RecordStatusEnum.running

--- a/qcfractal/qcfractal/test_server_cli.py
+++ b/qcfractal/qcfractal/test_server_cli.py
@@ -368,7 +368,13 @@ def test_cli_start_options(cli_runner, tmp_path_factory):
     with open(log_path, "r") as f:
         log_output = f.read()
 
-    assert "waitress: Serving on http://0.0.0.0:2828" in log_output
+    if "waitress: Serving on http://0.0.0.0:2828" not in log_output:
+        print("LOGGED OUTPUT")
+        print("-"*80)
+        print(log_output)
+        print("-"*80)
+        raise RuntimeError("Log file does not contain expected output")
+
 
 
 def test_cli_start_outdated(cli_runner_core):

--- a/qcfractalcompute/qcfractalcompute/compute_manager.py
+++ b/qcfractalcompute/qcfractalcompute/compute_manager.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
 import parsl.executors.high_throughput.interchange
-import requests.exceptions
 import tabulate
 from packaging.version import parse as parse_version
 from parsl.config import Config as ParslConfig
@@ -23,12 +22,11 @@ try:
     from pydantic.v1 import BaseModel, Extra, Field
 except ImportError:
     from pydantic import BaseModel, Extra, Field
-from requests.exceptions import Timeout, ConnectTimeout, ConnectionError as RequestsConnectionError
-import urllib3.exceptions
 
 from qcfractalcompute.apps.app_manager import AppManager
 from qcportal import ManagerClient
 from qcportal.managers import ManagerName
+from qcportal.client_base import AllowedConnectionExceptions
 from qcportal.metadata_models import TaskReturnMetadata
 from qcportal.record_models import RecordTask
 from qcportal.utils import seconds_to_hms, apply_jitter
@@ -373,13 +371,7 @@ class ComputeManager:
             )
             self._failed_heartbeats = 0
 
-        except (
-            ConnectionError,
-            Timeout,
-            RequestsConnectionError,
-            ConnectTimeout,
-            urllib3.exceptions.TimeoutError,
-        ) as ex:
+        except AllowedConnectionExceptions as ex:
             self._failed_heartbeats += 1
             self.logger.warning(f"Heartbeat failed: {str(ex).strip()}. QCFractal server down?")
             self.logger.warning(f"Missed {self._failed_heartbeats} heartbeats so far")
@@ -510,7 +502,7 @@ class ComputeManager:
                         f"Did not successfully push jobs from {attempts+1} updates ago. Error: {return_meta.error_string}"
                     )
 
-            except (Timeout, ConnectionError):
+            except AllowedConnectionExceptions:
                 # Tried and failed
                 attempts += 1
 
@@ -565,7 +557,7 @@ class ComputeManager:
                     status_rows.extend([(task_id, "rejected", reason) for task_id, reason in return_meta.rejected_info])
                     self.statistics.total_rejected_tasks += return_meta.n_rejected
 
-                except (ConnectionError, Timeout):
+                except AllowedConnectionExceptions:
                     self.logger.warning("Returning complete tasks failed. Attempting again on next update.")
                     self._deferred_tasks[0].update(executor_results)
 
@@ -660,7 +652,7 @@ class ComputeManager:
                     try:
                         executor_programs = self.executor_programs[executor_label]
                         new_task_info = self.client.claim(executor_programs, executor_config.compute_tags, open_slots)
-                    except (Timeout, ConnectionError) as ex:
+                    except AllowedConnectionExceptions as ex:
                         self.logger.warning(f"Acquisition of new tasks failed: {str(ex).strip()}")
                         return
 

--- a/qcfractalcompute/qcfractalcompute/process_targets.py
+++ b/qcfractalcompute/qcfractalcompute/process_targets.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import multiprocessing
+
+from qcfractalcompute import ComputeManager
+from qcfractalcompute.config import FractalComputeConfig
+
+
+def compute_process(compute_config: FractalComputeConfig, logging_queue: multiprocessing.Queue) -> None:
+    import signal
+
+    qh = logging.handlers.QueueHandler(logging_queue)
+    logger = logging.getLogger()
+    logger.handlers.clear()
+    logger.addHandler(qh)
+    logger.setLevel(compute_config.loglevel)
+
+    early_stop = False
+
+    def signal_handler(signum, frame):
+        nonlocal early_stop
+        early_stop = True
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    compute = ComputeManager(compute_config)
+    if early_stop:
+        logging_queue.close()
+        logging_queue.join_thread()
+        return
+
+    def signal_handler(signum, frame):
+        compute.stop()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        compute.start()
+    except KeyboardInterrupt:  # Swallow ugly output on CTRL-C
+        pass
+    finally:
+        logging_queue.close()
+        logging_queue.join_thread()

--- a/qcportal/qcportal/client_base.py
+++ b/qcportal/qcportal/client_base.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import jwt
+import urllib3.exceptions
 
 try:
     import pydantic.v1 as pydantic
@@ -147,9 +148,7 @@ class PortalClientBase:
 
         # If no 3rd party verification, quiet urllib
         if self._verify is False:
-            from urllib3.exceptions import InsecureRequestWarning
-
-            requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+            requests.packages.urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
 
         if username is not None and password is not None:
             self._username = username
@@ -343,7 +342,7 @@ class PortalClientBase:
                     time.sleep(time_to_wait)
         except requests.exceptions.SSLError:
             raise ConnectionRefusedError(_ssl_error_msg) from None
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, urllib3.exceptions.TimeoutError) as e:
             raise ConnectionRefusedError(_connection_error_msg.format(self.address)) from None
 
         if self.debug_requests:

--- a/qcportal/qcportal/dataset_testing_helpers.py
+++ b/qcportal/qcportal/dataset_testing_helpers.py
@@ -28,7 +28,7 @@ def run_dataset_model_add_get_entry(snowflake_client, ds, test_entries, entry_ex
 
     if background:
         ij = ds.background_add_entries(test_entries)
-        ij.watch(interval=0.1, timeout=10)
+        ij.watch(interval=0.1, timeout=30)
         meta = InsertMetadata(**ij.result)
         ds.fetch_entries()
     else:
@@ -445,7 +445,7 @@ def run_dataset_model_submit(ds, test_entries, test_spec, record_compare, backgr
 
     if background:
         ij = ds.background_submit()
-        ij.watch(interval=0.1, timeout=10)
+        ij.watch(interval=0.1, timeout=30)
         meta = InsertCountsMetadata(**ij.result)
     else:
         meta = ds.submit()
@@ -476,7 +476,7 @@ def run_dataset_model_submit(ds, test_entries, test_spec, record_compare, backgr
 
     if background:
         ij = ds.background_submit()
-        ij.watch(interval=0.1, timeout=10)
+        ij.watch(interval=0.1, timeout=30)
         meta = InsertCountsMetadata(**ij.result)
     else:
         meta = ds.submit()
@@ -493,7 +493,7 @@ def run_dataset_model_submit(ds, test_entries, test_spec, record_compare, backgr
 
     if background:
         ij = ds.background_submit(compute_tag="new_tag", compute_priority=PriorityEnum.high)
-        ij.watch(interval=0.1, timeout=10)
+        ij.watch(interval=0.1, timeout=30)
         meta = InsertCountsMetadata(**ij.result)
     else:
         meta = ds.submit(compute_tag="new_tag", compute_priority=PriorityEnum.high)
@@ -527,7 +527,7 @@ def run_dataset_model_submit(ds, test_entries, test_spec, record_compare, backgr
 
     if background:
         ij = ds.background_submit()
-        ij.watch(interval=0.1, timeout=10)
+        ij.watch(interval=0.1, timeout=30)
         meta = InsertCountsMetadata(**ij.result)
     else:
         meta = ds.submit()
@@ -549,7 +549,7 @@ def run_dataset_model_submit(ds, test_entries, test_spec, record_compare, backgr
 
     if background:
         ij = ds.background_submit(find_existing=False)
-        ij.watch(interval=0.1, timeout=10)
+        ij.watch(interval=0.1, timeout=30)
         meta = InsertCountsMetadata(**ij.result)
     else:
         meta = ds.submit(find_existing=False)

--- a/qcportal/qcportal/manager_client.py
+++ b/qcportal/qcportal/manager_client.py
@@ -128,7 +128,8 @@ class ManagerClient(PortalClientBase):
     def claim(self, programs: Dict[str, List[str]], tags: List[str], limit: int) -> List[RecordTask]:
         body = TaskClaimBody(name_data=self.manager_name_data, programs=programs, compute_tags=tags, limit=limit)
 
-        return self.make_request("post", "compute/v1/tasks/claim", List[RecordTask], body=body)
+        # Don't retry - will be handled elsewhere
+        return self.make_request("post", "compute/v1/tasks/claim", List[RecordTask], body=body, allow_retries=False)
 
     def return_finished(self, results_compressed: Dict[int, bytes]) -> TaskReturnMetadata:
         # Chunk based on the server limit
@@ -143,7 +144,10 @@ class ManagerClient(PortalClientBase):
                 results_compressed={k: v for k, v in results_flat[chunk : chunk + limit]},
             )
 
-            meta = self.make_request("post", "compute/v1/tasks/return", TaskReturnMetadata, body=body)
+            # Don't retry - will be handled elsewhere
+            meta = self.make_request(
+                "post", "compute/v1/tasks/return", TaskReturnMetadata, allow_retries=False, body=body
+            )
 
             task_return_meta.error_description = meta.error_description
             task_return_meta.rejected_info.extend(meta.rejected_info)


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

I had been using `fork` due to its speed, however warnings are starting to pop up due to the use of mixing threads with fork-based multiprocessing.

So this changes the multiprocessing contexts to spawn. This also moves the functions targeted by `multiprocessing.Process` to a separate module so that they can be reused by the CLI code.

Tests are all passing locally, although with a bit of slowdown.

## Status
- [X] Code base linted
- [X] Ready to go
