### PR TITLE
Change to using spawn rather than fork

### DIFF
--- a/qcfractal/qcfractal/qcfractal_server_cli.py
+++ b/qcfractal/qcfractal/qcfractal_server_cli.py
@@ -387,7 +387,7 @@ def server_start(config):
     logger.info("*** Starting a QCFractal server ***")
 
     # Set up a multiprocessing context
-    mp_context = multiprocessing.get_context("fork")
+    mp_context = multiprocessing.get_context("spawn")
 
     stdout_logging = setup_logging(config, logger)
 

--- a/qcfractal/qcfractal/snowflake.py
+++ b/qcfractal/qcfractal/snowflake.py
@@ -69,8 +69,8 @@ class FractalSnowflake:
         This can also be used as a context manager (`with FractalSnowflake(...) as s:`)
         """
 
-        # Multiprocessing context - generally use fork
-        self._mp_context = multiprocessing.get_context("fork")
+        # Multiprocessing context - generally use spawn
+        self._mp_context = multiprocessing.get_context("spawn")
 
         self._logger = logging.getLogger("fractal_snowflake")
 


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

There are some warnings popping up that mixing threads and `fork` is not that good of an idea. After #955 and #957 things should be ready for changing to using `spawn`. Creating new processes this way is slower, but safer.

Everything passes locally, but let's see how GHA handles this

## Status
- [X] Code base linted
- [ ] Ready to go
