### PR TITLE
Implement getting direct download url & rework downloads slightly

### DIFF
--- a/qcfractal/qcfractal/components/external_files/routes.py
+++ b/qcfractal/qcfractal/components/external_files/routes.py
@@ -27,3 +27,15 @@ def download_external_file_v1(file_id: int):
     else:
         _, url = storage_socket.external_files.get_url(file_id)
         return redirect(url, code=302)
+
+
+@api_v1.route("/external_files/<int:file_id>/direct_link", methods=["GET"])
+@wrap_global_route("records", "read")
+def get_direct_link_external_file_v1(file_id: int):
+    passthrough = current_app.config["QCFRACTAL_CONFIG"].s3.passthrough
+
+    if passthrough:
+        return f"/api/v1/external_files/{file_id}/download"
+    else:
+        _, url = storage_socket.external_files.get_url(file_id)
+        return url

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -434,6 +434,16 @@ class PortalClient(PortalClientBase):
     ##############################################################
     # External files
     ##############################################################
+    def get_external_file_direct_link(self, file_id: int) -> str:
+        url = self.make_request("get", f"api/v1/external_files/{file_id}/direct_link", str)
+        if url.startswith("/"):
+            # What was returned is a path relative to the current server's address.
+            # That means the file is being passed-through the server, and there's no other link
+            url = url.lstrip("/")
+            url = f"{self.address}{url}"
+
+        return url
+
     def download_external_file(self, file_id: int, destination_path: str, overwrite: bool = False) -> Tuple[int, str]:
         """
         Downloads an external file to the given path

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -528,6 +528,10 @@ class BaseDataset(BaseModel):
             Optional[List[DatasetAttachment]],
         )
 
+        if self.attachments_ is not None:
+            for x in self.attachments_:
+                x.propagate_client(self._client)
+
     @property
     def attachments(self) -> List[DatasetAttachment]:
         if not self.attachments_:
@@ -573,7 +577,7 @@ class BaseDataset(BaseModel):
             attachment_data = attachment_map[attachment_id]
             destination_path = os.path.join(os.getcwd(), attachment_data.file_name)
 
-        self._client.download_external_file(attachment_id, destination_path, overwrite=overwrite)
+        attachment_map[attachment_id].download(destination_path, overwrite=overwrite)
 
     #########################################
     # View creation and use
@@ -1245,7 +1249,7 @@ class BaseDataset(BaseModel):
             - Sends a patch request to the server to update entry names.
             - Updates the local cache and entry names list with the new names.
         """
-        
+
         self.assert_is_not_view()
         self.assert_online()
 
@@ -1268,16 +1272,16 @@ class BaseDataset(BaseModel):
     ):
         """
         Modifies the entries in the dataset by updating their attributes or comments.
-        
+
         Parameters:
-            attribute_map (Optional[Dict[str, Dict[str, Any]]]): 
-                A dictionary mapping entry names to their updated attributes. 
+            attribute_map (Optional[Dict[str, Dict[str, Any]]]):
+                A dictionary mapping entry names to their updated attributes.
                 Each entry name maps to a dictionary of attribute key-value pairs to be updated.
-            comment_map (Optional[Dict[str, str]]): 
+            comment_map (Optional[Dict[str, str]]):
                 A dictionary mapping entry names to their updated comments.
-            overwrite_attributes (bool): 
-                If True, existing attributes for the specified entries will be completely 
-                replaced by the provided attributes in ``attribute_map``. If False, only the 
+            overwrite_attributes (bool):
+                If True, existing attributes for the specified entries will be completely
+                replaced by the provided attributes in ``attribute_map``. If False, only the
                 specified attributes will be updated, leaving others unchanged.
         Raises:
             AssertionError: If the dataset is a view or if the client is offline.
@@ -1285,7 +1289,7 @@ class BaseDataset(BaseModel):
             - Sends a request to the server to modify the specified entries.
             - Synchronizes the local cache with the updated server data for the modified entries.
         """
-        
+
         self.assert_is_not_view()
         self.assert_online()
 
@@ -1315,8 +1319,7 @@ class BaseDataset(BaseModel):
         Raises:
             AssertionError: If the dataset is a view or not online.
         """
-        
-        
+
         self.assert_is_not_view()
         self.assert_online()
 

--- a/qcportal/qcportal/external_files/models.py
+++ b/qcportal/qcportal/external_files/models.py
@@ -40,3 +40,35 @@ class ExternalFile(BaseModel):
 
     sha256sum: str
     file_size: int
+
+    _client: Any = PrivateAttr(None)
+
+    def propagate_client(self, client):
+        self._client = client
+
+    def get_direct_url(self):
+        if self._client is None:
+            raise RuntimeError("No client to use with this ExternalFile")
+
+        return self._client.get_external_file_direct_link(self.id)
+
+    def download(self, destination_path: str, overwrite: bool = False) -> None:
+        """
+        Downloads an external file to the given path
+
+        The file size and checksum will be checked against the metadata stored on the server
+
+        Parameters
+        ----------
+        destination_path
+            Full path to the destination file (including filename)
+        overwrite
+            If True, allow for overwriting an existing file. If False, and a file already exists at the given
+            destination path, an exception will be raised.
+        """
+
+        if self._client is None:
+            raise RuntimeError("No client to use with this ExternalFile")
+
+        # Swallow return value - no one cares
+        self._client.download_external_file(self.id, destination_path, overwrite)


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

This adds the ability to get the direct link of an external file (including dataset attachments and views). To do so, use the `ExternalFile` object. For example, for a dataset attachment or view:

```
a = ds.attachments[0]
a.get_direct_url()
```

Note that URLs coming from an S3 bucket may have an expiration time.

Requested by @chrisiacovella

## Status
- [X] Code base linted
- [X] Ready to go
