### PR TITLE
Make flask storage socket less global

### DIFF
--- a/qcfractal/qcfractal/flask_app/flask_app.py
+++ b/qcfractal/qcfractal/flask_app/flask_app.py
@@ -5,29 +5,29 @@ import logging
 import queue
 from typing import TYPE_CHECKING
 
-from flask import Flask
+from flask import Flask, current_app
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
+from werkzeug.local import LocalProxy
 from werkzeug.routing import IntegerConverter
 
-from qcfractal.db_socket.socket import SQLAlchemySocket
 from .flask_session import QCFFlaskSessionInterface
+from .flask_socket import FlaskStorageSocket
 from .home_v1 import home_v1
+from ..db_socket import SQLAlchemySocket
 
 if TYPE_CHECKING:
     from ..config import FractalConfig
     from typing import Optional
 
-
-class _FlaskSQLAlchemySocket(SQLAlchemySocket):
-    def __init__(self):
-        pass
-
-    def init(self, qcf_config):
-        SQLAlchemySocket.__init__(self, qcf_config)
+app_storage_sockets = FlaskStorageSocket()
 
 
-storage_socket = _FlaskSQLAlchemySocket()
+def _get_storage_socket() -> SQLAlchemySocket:
+    return app_storage_sockets.get_socket(current_app)
+
+
+storage_socket = LocalProxy(_get_storage_socket)
 
 jwt = JWTManager()
 
@@ -38,9 +38,7 @@ class SignedIntConverter(IntegerConverter):
     regex = r"-?\d+"
 
 
-def create_flask_app(
-    qcfractal_config: FractalConfig, init_storage: bool = True, finished_queue: Optional[queue.Queue] = None
-):
+def create_flask_app(qcfractal_config: FractalConfig, finished_queue: Optional[queue.Queue] = None):
     app = Flask(__name__)
 
     app.url_map.converters["signed_int"] = SignedIntConverter
@@ -84,15 +82,11 @@ def create_flask_app(
         app.config["CORS_HEADERS"] = qcfractal_config.cors.headers
         CORS(app)
 
-    if init_storage:
-        # Initialize the database socket, API logger, and view handler
-        storage_socket.init(qcfractal_config)
-
-    if finished_queue:
-        storage_socket.set_finished_watch(finished_queue)
+    # Initialize the database socket, API logger, and view handler
+    app_storage_sockets.init_app(app, finished_queue=finished_queue)
 
     # Initialize the session interface after the storage socket
-    app.session_interface = QCFFlaskSessionInterface(storage_socket)
+    app.session_interface = QCFFlaskSessionInterface(app)
 
     # Registers the various error and before/after request handlers
     importlib.import_module("qcfractal.flask_app.handlers")

--- a/qcfractal/qcfractal/flask_app/flask_session.py
+++ b/qcfractal/qcfractal/flask_app/flask_session.py
@@ -8,7 +8,6 @@ from flask.sessions import SessionInterface, SecureCookieSession
 from qcportal.utils import now_at_utc
 
 if TYPE_CHECKING:
-    from qcfractal.db_socket import SQLAlchemySocket
     from flask import Flask, Response, Request
 
 
@@ -26,8 +25,11 @@ class QCFFlaskSessionInterface(SessionInterface):
     If there is something to store in the database, a random session_key will be generated in save_session.
     """
 
-    def __init__(self, storage_socket: SQLAlchemySocket):
-        self._storage_socket = storage_socket
+    def __init__(self, app: Flask):
+        if not hasattr(app, "extensions") or "storage_socket" not in app.extensions:
+            raise RuntimeError("The QCFFlaskSessionInterface requires the storage_socket extension to be initialized")
+
+        self._storage_socket = app.extensions["storage_socket"]
 
     def open_session(self, app: Flask, request: Request) -> QCFFlaskSession:
         """

--- a/qcfractal/qcfractal/flask_app/flask_socket.py
+++ b/qcfractal/qcfractal/flask_app/flask_socket.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from queue import Queue
+from typing import Optional
+from weakref import WeakKeyDictionary
+
+from flask import Flask
+
+from qcfractal.db_socket import SQLAlchemySocket
+
+
+class FlaskStorageSocket:
+
+    _app_sockets: WeakKeyDictionary[Flask, SQLAlchemySocket]
+
+    def __init__(self):
+        self._app_sockets = WeakKeyDictionary()
+
+    def init_app(self, app: Flask, finished_queue: Optional[Queue] = None):
+        socket = SQLAlchemySocket(app.config["QCFRACTAL_CONFIG"])
+
+        if not hasattr(app, "extensions"):
+            app.extensions = {}
+
+        app.extensions["storage_socket"] = socket
+
+        if finished_queue:
+            socket.set_finished_watch(finished_queue)
+
+        self._app_sockets[app] = socket
+
+    def get_socket(self, app) -> SQLAlchemySocket:
+        app_co = app._get_current_object()
+
+        s = self._app_sockets.get(app_co, None)
+        if s is None:
+            raise RuntimeError("Socket not initialized for this flask app")
+
+        return s


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

The global `storage_socket` in flask app was not safe for use when there are multiple flask apps (sometimes happens with snowflakes if using threads). This makes the storage socket object more app-aware and context-aware.

## Status
- [X] Code base linted
- [X] Ready to go
