### PR TITLE
Switch to using threads in snowflake

### DIFF
--- a/qcarchivetesting/qcarchivetesting/testing_classes.py
+++ b/qcarchivetesting/qcarchivetesting/testing_classes.py
@@ -194,7 +194,7 @@ class QCATestingSnowflake(FractalSnowflake):
         self._all_completed = set()
         self._qcf_config = self._original_config.copy(deep=True)
 
-        if self._api_proc is None:
+        if self._api_thread is None:
             self.start_api(wait=True)
 
         self._pg_harness.recreate_database()

--- a/qcfractal/qcfractal/db_socket/socket.py
+++ b/qcfractal/qcfractal/db_socket/socket.py
@@ -328,14 +328,14 @@ class SQLAlchemySocket:
         else:
             return self.session_scope(read_only)
 
-    def set_finished_watch(self, mp_queue):
+    def set_finished_watch(self, finished_queue):
         """
         Set the finished watch queue to the given multiprocessing queue
 
         When a calculation finishes, its record ID and status will be placed in this queue
         """
 
-        self._finished_queue = mp_queue
+        self._finished_queue = finished_queue
 
     def notify_finished_watch(self, record_id, status):
         """

--- a/qcfractal/qcfractal/process_targets.py
+++ b/qcfractal/qcfractal/process_targets.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import logging
 import logging.handlers
 import multiprocessing
+import queue
+import threading
+import weakref
 from typing import Optional
 
+from werkzeug.serving import make_server
+
 from qcfractal.config import FractalConfig
+from qcfractal.flask_app import create_flask_app
 from qcfractal.flask_app.waitress_app import FractalWaitressApp
 from qcfractal.job_runner import FractalJobRunner
 
@@ -58,6 +64,64 @@ def api_process(
         logging_queue.join_thread()
 
 
+class QCFAPIThread:
+    """
+    A class that runs the QCFractal API in a separate thread
+
+    This does not use waitress, but instead runs the Flask app directly. This is useful for debugging and testing
+    (such as with the snowflake) but shouldn't be used in user-facing production.
+    """
+
+    def __init__(
+        self,
+        qcf_config: FractalConfig,
+        finished_queue: Optional[queue.Queue] = None,
+    ):
+        self._qcf_config = qcf_config
+        self._flask_app = create_flask_app(qcf_config, finished_queue=finished_queue)
+        self._server = make_server(self._qcf_config.api.host, self._qcf_config.api.port, self._flask_app)
+        self._api_thread = None
+        self._finalizer = None
+
+    # Classmethod because finalizer can't handle bound methods
+    @classmethod
+    def _stop(cls, server, api_thread):
+        if server is not None:
+            server.shutdown()
+            api_thread.join()
+
+    def start(self, initialized_event: Optional[threading.Event] = None) -> None:
+        if self._api_thread is not None:
+            raise RuntimeError("API already started")
+
+        # We use daemon=True
+        # This means that the main python process can exit, calling various destructors
+        # and finalizers (rather than waiting for those threads to finish before doing so)
+        self._api_thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._api_thread.start()
+
+        if initialized_event is not None:
+            initialized_event.set()
+
+        self._finalizer = weakref.finalize(
+            self,
+            self._stop,
+            self._server,
+            self._api_thread,
+        )
+
+    def stop(self) -> None:
+        if self._finalizer is not None:
+            self._finalizer()
+
+        self._api_thread = None
+
+    def is_alive(self) -> bool:
+        if self._api_thread is None:
+            return False
+        return self._api_thread.is_alive()
+
+
 def job_runner_process(
     qcf_config: FractalConfig,
     logging_queue: multiprocessing.Queue,
@@ -104,3 +168,57 @@ def job_runner_process(
     finally:
         logging_queue.close()
         logging_queue.join_thread()
+
+
+class QCFJobRunnerThread:
+    def __init__(
+        self,
+        qcf_config: FractalConfig,
+        finished_queue: Optional[queue.Queue] = None,
+    ):
+        self._qcf_config = qcf_config
+        self._job_runner: Optional[FractalJobRunner] = None
+        self._job_runner_thread = None
+        self._finalizer = None
+        self._finished_queue = finished_queue
+
+    # Classmethod because finalizer can't handle bound methods
+    @classmethod
+    def _stop(cls, job_runner, job_runner_thread):
+        if job_runner is not None:
+            job_runner.stop()
+            job_runner_thread.join()
+
+    def start(self, initialized_event: Optional[threading.Event] = None) -> None:
+        if self._job_runner is not None:
+            raise RuntimeError("Job Runner already started")
+
+        self._job_runner = FractalJobRunner(self._qcf_config, self._finished_queue)
+
+        # We use daemon=True
+        # This means that the main python process can exit, calling various destructors
+        # and finalizers (rather than waiting for those threads to finish before doing so)
+        self._job_runner_thread = threading.Thread(target=self._job_runner.start, daemon=True)
+        self._job_runner_thread.start()
+
+        if initialized_event is not None:
+            initialized_event.set()
+
+        self._finalizer = weakref.finalize(
+            self,
+            self._stop,
+            self._job_runner,
+            self._job_runner_thread,
+        )
+
+    def stop(self) -> None:
+        if self._finalizer is not None:
+            self._finalizer()
+
+        self._job_runner = None
+        self._job_runner_thread = None
+
+    def is_alive(self) -> bool:
+        if self._job_runner_thread is None:
+            return False
+        return self._job_runner_thread.is_alive()

--- a/qcfractal/qcfractal/test_snowflake.py
+++ b/qcfractal/qcfractal/test_snowflake.py
@@ -19,17 +19,17 @@ def test_snowflake_restarting(tmp_path):
 
     time.sleep(5)
 
-    assert s._api_proc is None
-    assert s._compute_proc is None
-    assert s._job_runner_proc is None
+    assert s._api_thread is None
+    assert s._compute_thread is None
+    assert s._job_runner_thread is None
 
     s._start_api()
     s._start_compute()
     s._start_job_runner()
 
-    assert s._api_proc.is_alive()
-    assert s._compute_proc.is_alive()
-    assert s._job_runner_proc.is_alive()
+    assert s._api_thread.is_alive()
+    assert s._compute_thread.is_alive()
+    assert s._job_runner_thread.is_alive()
 
     c = s.client()
     assert c.ping()

--- a/qcfractalcompute/qcfractalcompute/process_targets.py
+++ b/qcfractalcompute/qcfractalcompute/process_targets.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import logging
 import logging.handlers
 import multiprocessing
+import threading
+import weakref
+from typing import Optional
 
 from qcfractalcompute import ComputeManager
 from qcfractalcompute.config import FractalComputeConfig
-from typing import Optional
 
 
 def compute_process(
@@ -53,3 +55,55 @@ def compute_process(
     finally:
         logging_queue.close()
         logging_queue.join_thread()
+
+
+class QCFComputeThread:
+    def __init__(
+        self,
+        compute_config: FractalComputeConfig,
+    ):
+        self._compute_config = compute_config
+        self._compute: Optional[ComputeManager] = None
+        self._compute_thread = None
+        self._finalizer = None
+
+    # Classmethod because finalizer can't handle bound methods
+    @classmethod
+    def _stop(cls, compute, compute_thread):
+        if compute is not None:
+            compute.stop()
+            compute_thread.join()
+
+    def start(self, initialized_event: Optional[threading.Event] = None) -> None:
+        if self._compute is not None:
+            raise RuntimeError("Compute manager already started")
+
+        self._compute = ComputeManager(self._compute_config)
+
+        # We use daemon=True
+        # This means that the main python process can exit, calling various destructors
+        # and finalizers (rather than waiting for those threads to finish before doing so)
+        self._compute_thread = threading.Thread(target=self._compute.start, daemon=True)
+        self._compute_thread.start()
+
+        if initialized_event is not None:
+            initialized_event.set()
+
+        self._finalizer = weakref.finalize(
+            self,
+            self._stop,
+            self._compute,
+            self._compute_thread,
+        )
+
+    def stop(self) -> None:
+        if self._finalizer is not None:
+            self._finalizer()
+
+        self._compute = None
+        self._compute_thread = None
+
+    def is_alive(self) -> bool:
+        if self._compute_thread is None:
+            return False
+        return self._compute_thread.is_alive()


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Multiprocessing is just awkward. `fork` can have random issues due to mixing forking and threads (see https://discuss.python.org/t/switching-default-multiprocessing-context-to-spawn-on-posix-as-well/21868)

On the other hand, `spawn` (and `forkserver`) are slow and have other awkward requirements (you absolutely need to have any use of a snowflake under an `if __name__ == "__main__"` block).

So instead lets try threads. This seems to work just fine, although perhaps with some resource usage issues if being highly utilized (GIL and all that).

## Status
- [X] Code base linted
- [X] Ready to go
