### PR TITLE
Change how child records are stored (don't use PrivateAttr)

### DIFF
--- a/qcfractal/qcfractal/components/optimization/test_record_client.py
+++ b/qcfractal/qcfractal/components/optimization/test_record_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -287,10 +287,10 @@ def test_optimization_client_traj(snowflake: QCATestingSnowflake, opt_file: str,
     if fetch_traj:
         rec._fetch_trajectory()
         assert rec.trajectory_ids_ is not None
-        assert rec._trajectory_records is not None
+        assert rec.trajectory_records_ is not None
     else:
         assert rec.trajectory_ids_ is None
-        assert rec._trajectory_records is None
+        assert rec.trajectory_records_ is None
 
     assert rec.trajectory_element(0).id == rec_traj.trajectory[0].id
     assert rec.trajectory_element(-1).id == rec_traj.trajectory[-1].id

--- a/qcportal/qcportal/gridoptimization/test_record_models.py
+++ b/qcportal/qcportal/gridoptimization/test_record_models.py
@@ -33,12 +33,12 @@ def test_gridoptimization_record_model(snowflake: QCATestingSnowflake, includes:
         assert record.offline
 
         # children have all data fetched
-        assert all(x.initial_molecule_ is not None for x in record._optimizations_cache.values())
-        assert all(x.final_molecule_ is not None for x in record._optimizations_cache.values())
+        assert all(x.initial_molecule_ is not None for x in record.optimization_records_.values())
+        assert all(x.final_molecule_ is not None for x in record.optimization_records_.values())
     else:
         assert record.initial_molecule_ is None
         assert record.optimizations_ is None
-        assert record._optimizations_cache is None
+        assert record.optimization_records_ is None
 
     assert record.id == rec_id
     assert record.status == RecordStatusEnum.complete

--- a/qcportal/qcportal/manybody/test_record_models.py
+++ b/qcportal/qcportal/manybody/test_record_models.py
@@ -28,7 +28,7 @@ def test_manybody_record_model(snowflake: QCATestingSnowflake, includes: Optiona
     if includes is not None:
         assert record.initial_molecule_ is not None
         assert record.clusters_meta_ is not None
-        assert record._clusters is not None
+        assert record.cluster_records_ is not None
         record.propagate_client(None, None)
         assert record.offline
 
@@ -41,7 +41,7 @@ def test_manybody_record_model(snowflake: QCATestingSnowflake, includes: Optiona
     else:
         assert record.initial_molecule_ is None
         assert record.clusters_meta_ is None
-        assert record._clusters is None
+        assert record.cluster_records_ is None
 
     assert record.id == rec_id
     assert record.status == RecordStatusEnum.complete

--- a/qcportal/qcportal/reaction/test_record_models.py
+++ b/qcportal/qcportal/reaction/test_record_models.py
@@ -28,7 +28,7 @@ def test_reaction_record_model(snowflake: QCATestingSnowflake, includes: Optiona
 
     if includes is not None:
         assert record.components_meta_ is not None
-        assert record._components is not None
+        assert record.component_records_ is not None
         record.propagate_client(None, None)
         assert record.offline
 
@@ -45,7 +45,7 @@ def test_reaction_record_model(snowflake: QCATestingSnowflake, includes: Optiona
                 assert c.optimization_record.comments_ is not None
     else:
         assert record.components_meta_ is None
-        assert record._components is None
+        assert record.component_records_ is None
 
     assert record.id == rec_id
     assert record.status == RecordStatusEnum.complete

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -568,6 +568,19 @@ class BaseRecord(BaseModel):
         if detach:
             self._record_cache = None
 
+    def get_cache_dict(self, **kwargs) -> Dict[str, Any]:
+        """
+        Returns a dictionary of the record meant for caching
+
+        When a record is stored in the cache, it is stored without child records (which
+        are in the cache under their own keys). This function returns a dictionary that
+        excludes those children.
+
+        kwargs are passed directly to the pydantic `dict()` function.
+        """
+
+        return self.dict(**kwargs)
+
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id} status={self.status}>"
 

--- a/qcportal/qcportal/torsiondrive/test_record_models.py
+++ b/qcportal/qcportal/torsiondrive/test_record_models.py
@@ -33,13 +33,13 @@ def test_torsiondrive_record_model(snowflake: QCATestingSnowflake, includes: Opt
         assert record.offline
 
         # children have all data fetched
-        for opts in record._optimizations_cache.values():
+        for opts in record.optimization_records_.values():
             assert all(x.initial_molecule_ is not None for x in opts)
             assert all(x.final_molecule_ is not None for x in opts)
     else:
         assert record.initial_molecules_ is None
         assert record.optimizations_ is None
-        assert record._optimizations_cache is None
+        assert record.optimization_records_ is None
 
     assert record.id == rec_id
     assert record.status == RecordStatusEnum.complete


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

This changes the way child records are stored internally inside records. Before, they were stored as PrivateAttr, which means they were never serialized if you used pydantic's `dict()` function.

However, for saving/transferring/ingesting complete records, we want those child records in place. So this PR makes those child records regular fields.

However, we DON'T want those child records when writing to cache files (where they are handled differently). So a separate function was added for that.

## Status
- [X] Code base linted
- [X] Ready to go
