### PR TITLE
Remove (almost) EOL python 3.9 support

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         encoding: ["application/json", "application/msgpack"]
         
     steps:

--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/full_tests_snowflake.yml
+++ b/.github/workflows/full_tests_snowflake.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/qcarchivetesting/pyproject.toml
+++ b/qcarchivetesting/pyproject.toml
@@ -13,7 +13,7 @@ description = "A distributed compute and database platform for quantum chemistry
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",

--- a/qcfractal/pyproject.toml
+++ b/qcfractal/pyproject.toml
@@ -13,7 +13,7 @@ description = "A distributed compute and database platform for quantum chemistry
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",

--- a/qcfractalcompute/pyproject.toml
+++ b/qcfractalcompute/pyproject.toml
@@ -13,7 +13,7 @@ description = "A distributed compute and database platform for quantum chemistry
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",

--- a/qcportal/pyproject.toml
+++ b/qcportal/pyproject.toml
@@ -13,7 +13,7 @@ description = "A distributed compute and database platform for quantum chemistry
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Remove support for python 3.9, which is almost EOL. This is needed to use some features in upcoming PRs that require 3.10+


## Status
- [X] Code base linted
- [X] Ready to go
