### PR TITLE
Check if native files has been set before fetching

### DIFF
--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -737,7 +737,7 @@ class BaseRecord(BaseModel):
 
     @property
     def native_files(self) -> Optional[Dict[str, NativeFile]]:
-        if self.native_files_ is None:
+        if self.native_files_ is None and "native_files_" not in self.__fields_set__:
             self._fetch_native_files()
         return self.native_files_
 


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
This adds a check to differentiate `BaseRecord.native_files_` being None because there really aren't any (vs there are, but not fetched yet).

Should help with #950 

## Status
- [X] Code base linted
- [ ] Ready to go
