### PR TITLE
Vendor in some models from qcelemental

### DIFF
--- a/docs/source/user_guide/records/optimization.rst
+++ b/docs/source/user_guide/records/optimization.rst
@@ -101,9 +101,8 @@ when adding to datasets).
 
       .. code-block:: py3
 
-        from qcportal.optimization import OptimizationSpecification
+        from qcportal.optimization import OptimizationSpecification, OptimizationProtocols
         from qcportal.singlepoint import QCSpecification
-        from qcelemental.models.procedures import OptimizationProtocols
 
         opt_spec = OptimizationSpecification(
             program="geometric",

--- a/qcfractal/qcfractal/components/gridoptimization/testing_helpers.py
+++ b/qcfractal/qcfractal/components/gridoptimization/testing_helpers.py
@@ -8,13 +8,12 @@ try:
 except ImportError:
     import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, OptimizationResult as QCEl_OptimizationResult
-from qcelemental.models.procedures import OptimizationProtocols
 
 from qcarchivetesting.helpers import read_procedure_data, read_record_data
 from qcfractal.components.gridoptimization.record_db_models import GridoptimizationRecordORM
 from qcfractal.testing_helpers import run_service
 from qcportal.gridoptimization import GridoptimizationSpecification, GridoptimizationKeywords, GridoptimizationRecord
-from qcportal.optimization import OptimizationSpecification
+from qcportal.optimization import OptimizationSpecification, OptimizationProtocols
 from qcportal.record_models import PriorityEnum, RecordStatusEnum, RecordTask
 from qcportal.singlepoint import SinglepointProtocols, QCSpecification
 from qcportal.utils import recursive_normalizer

--- a/qcfractal/qcfractal/components/optimization/record_socket.py
+++ b/qcfractal/qcfractal/components/optimization/record_socket.py
@@ -308,7 +308,7 @@ class OptimizationRecordSocket(BaseRecordSocket):
         to_add = []
 
         for opt_spec in opt_specs:
-            protocols_dict = opt_spec.protocols.dict(exclude_defaults=True)
+            protocols_dict = opt_spec.protocols.dict(exclude_defaults=True, exclude_unset=True)
 
             # Don't include lower specifications in the hash
             opt_spec_dict = opt_spec.dict(exclude={"protocols", "qc_specification"})

--- a/qcfractal/qcfractal/components/optimization/test_record_socket.py
+++ b/qcfractal/qcfractal/components/optimization/test_record_socket.py
@@ -108,7 +108,7 @@ def test_optimization_socket_task_spec(
 
         task_input = t.function_kwargs["input_data"]
         assert task_input["keywords"] == kw_with_prog
-        assert task_input["protocols"] == spec.protocols.dict(exclude_defaults=True)
+        assert task_input["protocols"] == spec.protocols.dict(exclude_defaults=True, exclude_unset=True)
 
         # Forced to gradient in the qcschema input
         assert task_input["input_specification"]["driver"] == SinglepointDriver.gradient

--- a/qcfractal/qcfractal/components/singlepoint/record_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/record_socket.py
@@ -234,7 +234,7 @@ class SinglepointRecordSocket(BaseRecordSocket):
         to_add = []
 
         for qc_spec in qc_specs:
-            protocols_dict = qc_spec.protocols.dict(exclude_defaults=True)
+            protocols_dict = qc_spec.protocols.dict(exclude_defaults=True, exclude_unset=True)
 
             # TODO - if error_correction is manually specified as the default, then it will be an empty dict
             if "error_correction" in protocols_dict:

--- a/qcfractal/qcfractal/components/singlepoint/test_record_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/test_record_socket.py
@@ -108,7 +108,9 @@ def test_singlepoint_socket_task_spec(
     for t in tasks:
         function_kwargs = t.function_kwargs
         assert function_kwargs["input_data"]["model"] == {"method": spec.method, "basis": spec.basis}
-        assert function_kwargs["input_data"]["protocols"] == spec.protocols.dict(exclude_defaults=True)
+        assert function_kwargs["input_data"]["protocols"] == spec.protocols.dict(
+            exclude_defaults=True, exclude_unset=True
+        )
         assert function_kwargs["input_data"]["keywords"] == spec.keywords
         assert function_kwargs["program"] == spec.program
         assert t.compute_tag == "tag1"

--- a/qcfractal/qcfractal/components/torsiondrive/testing_helpers.py
+++ b/qcfractal/qcfractal/components/torsiondrive/testing_helpers.py
@@ -8,12 +8,11 @@ try:
 except ImportError:
     import pydantic
 from qcelemental.models import Molecule, FailedOperation, ComputeError, OptimizationResult as QCEl_OptimizationResult
-from qcelemental.models.procedures import OptimizationProtocols
 
 from qcarchivetesting.helpers import read_procedure_data, read_record_data
 from qcfractal.components.torsiondrive.record_db_models import TorsiondriveRecordORM
 from qcfractal.testing_helpers import run_service
-from qcportal.optimization import OptimizationSpecification
+from qcportal.optimization import OptimizationSpecification, OptimizationProtocols
 from qcportal.record_models import PriorityEnum, RecordStatusEnum, RecordTask
 from qcportal.singlepoint import SinglepointProtocols, QCSpecification
 from qcportal.torsiondrive import TorsiondriveSpecification, TorsiondriveKeywords, TorsiondriveRecord

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -8,23 +8,28 @@ from enum import Enum
 from typing import Optional, Dict, Any, List, Union, Iterable, Tuple, Type, Sequence, ClassVar, TypeVar
 
 from dateutil.parser import parse as date_parser
-
-try:
-    from pydantic.v1 import BaseModel, Extra, constr, validator, PrivateAttr, Field, parse_obj_as, root_validator
-except ImportError:
-    from pydantic import BaseModel, Extra, constr, validator, PrivateAttr, Field, parse_obj_as, root_validator
-from qcelemental.models.results import Provenance
+from pydantic.v1 import BaseModel, Extra, constr, validator, PrivateAttr, Field, root_validator
 
 from qcportal.base_models import (
     RestModelBase,
     QueryModelBase,
     QueryIteratorBase,
 )
-
 from qcportal.cache import RecordCache, get_records_with_cache
 from qcportal.compression import CompressionEnum, decompress, get_compressed_ext
 
 _T = TypeVar("_T")
+
+
+class Provenance(BaseModel):
+    """Provenance information."""
+
+    creator: str = Field(..., description="The name of the program, library, or person who created the object.")
+    version: str = Field("", description="The version of the creator, blank otherwise")
+    routine: str = Field("", description="The name of the routine or function within the creator, blank otherwise.")
+
+    class Config(BaseModel.Config):
+        extra: str = "allow"
 
 
 class PriorityEnum(int, Enum):


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

This is part of a migration to pydantic v2.

Because of the long-lived nature of the QCFractal database, we can be a bit sensitive to input parameters which are used in de-duplication. So given the changes coming towards QCElemental/schema (version 2, required for pydantic v2), we should copy some of the models we directly import from QCElemental.

These are small models - mostly protocols and provenance. This allows us to be a little more flexible with legacy data while QCElemental goes through the changes.

I have no plans for vendoring the big models, though (`Molecule` and `WavefunctionProperties`). Most other imports are for validating/creating those models directly (ie, creating `AtomicResult` from our SinglepointRecord) so should stay.

## Status
- [X] Code base linted
- [X] Ready to go
