### PR TITLE
no more geometric.qcf_neb.prepare() for the server

### DIFF
--- a/qcarchivetesting/conda-envs/fulltest_server.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_server.yaml
@@ -40,5 +40,4 @@ dependencies:
   # QCFractal Services
   - torsiondrive
   - qcmanybody
-  - geometric
-  - scipy # TODO Required for geometric REMOVE EVENTUALLY
+  - geometric>=1.1.1

--- a/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
@@ -43,8 +43,7 @@ dependencies:
   # QCFractal Services
   - torsiondrive
   - qcmanybody
-  - geometric
-  - scipy # TODO Required for geometric REMOVE EVENTUALLY
+  - geometric>=1.1.1
 
   # Worker codes below
   - qcengine>=0.34,<0.70a0

--- a/qcarchivetesting/conda-envs/fulltest_worker.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_worker.yaml
@@ -31,5 +31,4 @@ dependencies:
   - qcengine>=0.34,<0.70a0
   - psi4>=1.9.1
   - rdkit
-  - geometric
-  - scipy # TODO Required for geometric REMOVE EVENTUALLY
+  - geometric>=1.1.1

--- a/qcarchivetesting/qcarchivetesting/test_full_neb.py
+++ b/qcarchivetesting/qcarchivetesting/test_full_neb.py
@@ -49,7 +49,7 @@ def test_neb_full_1(fulltest_client: PortalClient):
         keywords=neb_keywords,
     )
 
-    for i in range(600):
+    for i in range(40):
         time.sleep(15)
         rec = fulltest_client.get_nebs(ids[0])
         if rec.status not in [RecordStatusEnum.running, RecordStatusEnum.waiting]:
@@ -83,7 +83,7 @@ def test_neb_full_1(fulltest_client: PortalClient):
     # When optimize_ts is False, there should not ba a record for the Hessian.
     assert hessian is None
     # SinglepointRecords should not have 'return_hessian' either.
-    assert sum(1 if singlepoints[0][i].properties["return_hessian"] is None else 0 for i in range(7)) == 7
+    assert sum(1 if not singlepoints[0][i].properties.get("return_hessian") else 0 for i in range(7)) == 7
     # Result of the neb and the highest energy image of the last iteration should have the same molecule id.
     assert ts_guess.id == neb_result_id
 
@@ -99,8 +99,8 @@ def test_neb_full_2(fulltest_client: PortalClient):
         images=11,
         spring_constant=1,
         spring_type=0,
-        maximum_force=0.05,
-        average_force=0.025,
+        maximum_force=0.5,
+        average_force=0.25,
         maximum_cycle=100,
         optimize_ts=True,
         optimize_endpoints=True,
@@ -129,7 +129,7 @@ def test_neb_full_2(fulltest_client: PortalClient):
         keywords=neb_keywords,
     )
 
-    for i in range(600):
+    for i in range(40):
         time.sleep(15)
         rec = fulltest_client.get_nebs(ids[0])
         if rec.status not in [RecordStatusEnum.running, RecordStatusEnum.waiting]:
@@ -165,6 +165,6 @@ def test_neb_full_2(fulltest_client: PortalClient):
     # The rec.hessian should have the Hessian used for the TS optimization.
     assert hessian.properties["return_hessian"] is not None
     # Other SinglepointRecords should not have 'return_hessian'
-    assert sum(1 if singlepoints[0][i].properties["return_hessian"] is None else 0 for i in range(11)) == 11
+    assert sum(1 if not singlepoints[0][i].properties.get("return_hessian") else 0 for i in range(11)) == 11
     # Result of the neb and the highest energy image of the last iteration should have the same molecule id.
     assert ts_guess.id == neb_result_id

--- a/qcarchivetesting/qcarchivetesting/test_full_neb.py
+++ b/qcarchivetesting/qcarchivetesting/test_full_neb.py
@@ -49,7 +49,7 @@ def test_neb_full_1(fulltest_client: PortalClient):
         keywords=neb_keywords,
     )
 
-    for i in range(40):
+    for i in range(600):
         time.sleep(15)
         rec = fulltest_client.get_nebs(ids[0])
         if rec.status not in [RecordStatusEnum.running, RecordStatusEnum.waiting]:
@@ -129,7 +129,7 @@ def test_neb_full_2(fulltest_client: PortalClient):
         keywords=neb_keywords,
     )
 
-    for i in range(40):
+    for i in range(600):
         time.sleep(15)
         rec = fulltest_client.get_nebs(ids[0])
         if rec.status not in [RecordStatusEnum.running, RecordStatusEnum.waiting]:

--- a/qcfractal/pyproject.toml
+++ b/qcfractal/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 services = [
     "torsiondrive",
     "qcmanybody",
-    "geometric",
+    "geometric>=1.1.1",
 ]
 geoip = [
     "geoip2"

--- a/qcfractal/qcfractal/components/neb/record_socket.py
+++ b/qcfractal/qcfractal/components/neb/record_socket.py
@@ -248,15 +248,7 @@ class NEBRecordSocket(BaseRecordSocket):
                     service_state.nebinfo["params"] = params
 
                     with capture_all_output("geometric.nifty") as (rdout, _):
-                        if service_state.iteration == 1:
-                            newcoords, prev = geometric.qcf_neb.prepare(service_state.nebinfo)
-                            service_state.nebinfo = prev
-
-                            next_chain = [Molecule(**molecule_template, geometry=geometry) for geometry in newcoords]
-                            self.submit_singlepoints(session, service_state, service_orm, next_chain)
-                            service_state.iteration += 1
-                        else:
-                            self.submit_nextchain_subtask(session, service_state, service_orm)
+                        self.submit_nextchain_subtask(session, service_state, service_orm)
 
                     output += "\n" + rdout.getvalue()
 

--- a/qcfractal/qcfractal/components/neb/record_socket.py
+++ b/qcfractal/qcfractal/components/neb/record_socket.py
@@ -192,8 +192,14 @@ class NEBRecordSocket(BaseRecordSocket):
                     initial_molecules[0] = complete_opts[0].record.final_molecule.to_model(Molecule)
                     initial_molecules[-1] = complete_opts[-1].record.final_molecule.to_model(Molecule)
 
+                chain_list = [[[mol.molecular_charge, mol.molecular_multiplicity], mol.symbols.tolist(), mol.geometry]
+                              for mol in initial_molecules]
+
                 with capture_all_output("geometric.nifty") as (rdout, _):
-                    respaced_chain = geometric.qcf_neb.arrange(initial_molecules, params.get("align"))
+                    chain_respaced = geometric.qcf_neb.arrange(chain_list, params.get("align"))
+
+                respaced_chain = [
+                    Molecule(**molecule_template, geometry=img[2]) for img in chain_respaced]
 
                 output += "\n" + rdout.getvalue()
 

--- a/qcfractal/qcfractal/components/neb/record_socket.py
+++ b/qcfractal/qcfractal/components/neb/record_socket.py
@@ -318,9 +318,12 @@ class NEBRecordSocket(BaseRecordSocket):
         has_optimization = bool(neb_spec.optimization_specification)
         qc_spec = neb_orm.specification.singlepoint_specification.model_dict()
         if service_state.tsoptimize and service_state.converged:
+            # 5/19/2026 HP: geomeTRIC will convert the Hessian list into an NxN array in a future release.
+            side_length = int(len(service_state.tshessian)**0.5)
+            hessian = [service_state.tshessian[i*side_length : (i+1)*side_length] for i in range(side_length)]
             if has_optimization:
                 opt_spec = neb_orm.specification.optimization_specification.model_dict()
-                opt_spec["keywords"]["hessian"] = service_state.tshessian
+                opt_spec["keywords"]["hess_data"] = hessian
                 opt_spec["keywords"]["transition"] = True
                 opt_spec["program"] = "geometric"
                 opt_spec = OptimizationSpecification(
@@ -334,7 +337,7 @@ class NEBRecordSocket(BaseRecordSocket):
                     keywords={
                         "transition": True,
                         "coordsys": "tric",
-                        "hessian": service_state.tshessian,
+                        "hess_data": hessian,
                     },
                 )
             ts = True

--- a/qcportal/qcportal/neb/record_models.py
+++ b/qcportal/qcportal/neb/record_models.py
@@ -315,7 +315,7 @@ class NEBRecord(BaseRecord):
     @property
     def result(self):
         if self.status != RecordStatusEnum.complete:
-            raise RuntimeError(f"Cannot create QCSchema result from record with status {self.status}")
+            raise ValueError("NEB result is only available after the calculation is complete.")
 
         if self.neb_result_ is None:
             # Fetch the result if possible

--- a/qcportal/qcportal/neb/record_models.py
+++ b/qcportal/qcportal/neb/record_models.py
@@ -315,7 +315,7 @@ class NEBRecord(BaseRecord):
     @property
     def result(self):
         if self.status != RecordStatusEnum.complete:
-            raise ValueError("NEB result is only available after the calculation is complete.")
+            raise RuntimeError(f"Cannot create QCSchema result from record with status {self.status}")
 
         if self.neb_result_ is None:
             # Fetch the result if possible


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
1. The NEB service no longer calls `geometric.qcf_neb.prepare()`, since [`geometric.qcf_neb.nextchain()` handles it.](https://github.com/leeping/geomeTRIC/pull/232/files) This way, the compute nodes carry out the tasks from the `prepare()` function. 
2. `geometric.qcf_neb.arrange()` accepts a nested list instead of a Molecule object. 

The neb tests in `test_full_neb.py` are passing with the [new update](https://github.com/leeping/geomeTRIC/pull/232/changes) on the geomeTRIC side. 

## Status
- [ ] Code base linted
- [ ] Ready to go
