### PR TITLE
Add handling of extra_executor_options for all executor types

### DIFF
--- a/qcarchivetesting/conda-envs/fulltest_server.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_server.yaml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
   - postgresql
+  - pip
 
   # QCPortal dependencies
   # NOTE: msgpack-python in conda is msgpack in pypi (due to a rename around v0.5)

--- a/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
   - postgresql
+  - pip
 
   # QCPortal dependencies
   # NOTE: msgpack-python in conda is msgpack in pypi (due to a rename around v0.5)

--- a/qcarchivetesting/conda-envs/fulltest_testing.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_testing.yaml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
   - postgresql
+  - pip
 
   # QCPortal dependencies
   # NOTE: msgpack-python in conda is msgpack in pypi (due to a rename around v0.5)

--- a/qcarchivetesting/conda-envs/fulltest_worker.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_worker.yaml
@@ -4,6 +4,8 @@ channels:
   - defaults
 
 dependencies:
+  - pip
+
   # QCPortal dependencies
   # NOTE: msgpack-python in conda is msgpack in pypi (due to a rename around v0.5)
   - numpy

--- a/qcfractalcompute/qcfractalcompute/executors.py
+++ b/qcfractalcompute/qcfractalcompute/executors.py
@@ -94,6 +94,7 @@ def build_executor(executor_label: str, executor_config: ExecutorConfig) -> Pars
                 worker_init=";".join(executor_config.worker_init),
                 scheduler_options="\n".join(executor_config.scheduler_options),
             ),
+            **executor_config.extra_executor_options,
         )
 
     elif executor_config.type == "torque":
@@ -123,6 +124,7 @@ def build_executor(executor_label: str, executor_config: ExecutorConfig) -> Pars
                 worker_init=";".join(executor_config.worker_init),
                 scheduler_options="\n".join(executor_config.scheduler_options),
             ),
+            **executor_config.extra_executor_options,
         )
 
     elif executor_config.type == "lsf":
@@ -162,6 +164,7 @@ def build_executor(executor_label: str, executor_config: ExecutorConfig) -> Pars
                 worker_init=";".join(executor_config.worker_init),
                 scheduler_options="\n".join(executor_config.scheduler_options),
             ),
+            **executor_config.extra_executor_options,
         )
 
     elif executor_config.type == "custom":


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Passes through `extra_executor_options` for all executor types (not just local)

See #1002 

## Status
- [ ] Code base linted
- [ ] Ready to go
