### PR TITLE
Add ability to create torsiondrive dataset entries from an optimization dataset

### DIFF
--- a/qcfractal/qcfractal/components/singlepoint/dataset_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/dataset_socket.py
@@ -259,24 +259,27 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
                     )
 
             if from_dataset_type == "singlepoint":
-                stmt = """
-                    INSERT INTO singlepoint_dataset_entry (dataset_id, name, comment, molecule_id, attributes, additional_keywords)
-                    SELECT :dataset_id, sde.name, sde.comment, sde.molecule_id, sde.attributes, sde.additional_keywords
-                    FROM singlepoint_dataset_entry sde
-                    WHERE sde.dataset_id = :from_dataset_id
-                    ON CONFLICT (dataset_id, name) DO NOTHING
-                    RETURNING 1
-                """
+                stmt = text("""
+                    WITH inserted_entries AS (
+                        INSERT INTO singlepoint_dataset_entry (dataset_id, name, comment, molecule_id, attributes, additional_keywords)
+                        SELECT :dataset_id, sde.name, sde.comment, sde.molecule_id, sde.attributes, sde.additional_keywords
+                        FROM singlepoint_dataset_entry sde
+                        WHERE sde.dataset_id = :from_dataset_id
+                        ON CONFLICT (dataset_id, name) DO NOTHING
+                        RETURNING name
+                    )
+                    SELECT count(*) FROM inserted_entries
+                """)
 
-                r = session.execute(
-                    text(stmt),
+                n_inserted = session.execute(
+                    stmt,
                     {
                         "dataset_id": dataset_id,
                         "from_dataset_id": from_dataset_id,
                     },
-                )
+                ).scalar_one()
 
-                meta = InsertCountsMetadata(n_inserted=r.rowcount, n_existing=0)
+                meta = InsertCountsMetadata(n_inserted=n_inserted, n_existing=0)
 
             elif from_dataset_type == "optimization":
 
@@ -285,31 +288,34 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
                         "from_specification_name must be provided when adding entries from an optimization dataset"
                     )
 
-                stmt = """
-                    INSERT INTO singlepoint_dataset_entry (dataset_id, name, comment, molecule_id, attributes, additional_keywords)
-                    SELECT :dataset_id, ode.name, ode.comment, opr.final_molecule_id, ode.attributes, '{}'::jsonb
-                    FROM optimization_dataset_entry ode
-                    INNER JOIN optimization_dataset_record odr ON ode.dataset_id = odr.dataset_id AND ode.name = odr.entry_name
-                    INNER JOIN optimization_record opr ON odr.record_id = opr.id
-                    INNER JOIN base_record br ON opr.id = br.id
-                    WHERE ode.dataset_id = :optimization_dataset_id
-                    AND odr.specification_name = :specification_name
-                    AND br.status = 'complete'
-                    AND opr.final_molecule_id IS NOT NULL
-                    ON CONFLICT (dataset_id, name) DO NOTHING
-                    RETURNING 1
-                """
+                stmt = text("""
+                    WITH inserted_entries AS (
+                        INSERT INTO singlepoint_dataset_entry (dataset_id, name, comment, molecule_id, attributes, additional_keywords)
+                        SELECT :dataset_id, ode.name, ode.comment, opr.final_molecule_id, ode.attributes, '{}'::jsonb
+                        FROM optimization_dataset_entry ode
+                        INNER JOIN optimization_dataset_record odr ON ode.dataset_id = odr.dataset_id AND ode.name = odr.entry_name
+                        INNER JOIN optimization_record opr ON odr.record_id = opr.id
+                        INNER JOIN base_record br ON opr.id = br.id
+                        WHERE ode.dataset_id = :optimization_dataset_id
+                        AND odr.specification_name = :specification_name
+                        AND br.status = 'complete'
+                        AND opr.final_molecule_id IS NOT NULL
+                        ON CONFLICT (dataset_id, name) DO NOTHING
+                        RETURNING name
+                    )
+                    SELECT count(*) FROM inserted_entries
+                """)
 
-                r = session.execute(
-                    text(stmt),
+                n_inserted = session.execute(
+                    stmt,
                     {
                         "dataset_id": dataset_id,
                         "optimization_dataset_id": from_dataset_id,
                         "specification_name": from_specification_name,
                     },
-                )
+                ).scalar_one()
 
-                meta = InsertCountsMetadata(n_inserted=r.rowcount, n_existing=0)
+                meta = InsertCountsMetadata(n_inserted=n_inserted, n_existing=0)
             else:
                 raise InvalidArgumentsError(
                     f"Unable to handle adding singlepoint dataset entries from dataset of type {from_dataset_type}"

--- a/qcfractal/qcfractal/components/torsiondrive/dataset_socket.py
+++ b/qcfractal/qcfractal/components/torsiondrive/dataset_socket.py
@@ -4,9 +4,10 @@ import copy
 import logging
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select, literal, insert
+from sqlalchemy import select, literal, insert, text
 
 from qcfractal.components.torsiondrive.record_db_models import TorsiondriveRecordORM
+from qcportal.exceptions import InvalidArgumentsError, MissingDataError
 from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.record_models import PriorityEnum
 from qcportal.torsiondrive import TorsiondriveDatasetNewEntry, TorsiondriveSpecification
@@ -185,3 +186,216 @@ class TorsiondriveDatasetSocket(BaseDatasetSocket):
         )
 
         session.execute(stmt)
+
+    def add_entries_from_ds(
+        self,
+        dataset_id: int,
+        from_dataset_id: Optional[int],
+        from_dataset_type: Optional[str],
+        from_dataset_name: Optional[str],
+        from_specification_name: Optional[str],
+        *,
+        session: Optional[Session] = None,
+    ) -> InsertCountsMetadata:
+        """
+        Adds entries from another dataset into this torsiondrive dataset
+
+        Either the from_dataset_id or both the from_dataset_type and from_dataset_name
+        must be provided.
+
+        If copying from an optimization dataset, then
+        the from_specification_name must be provided.
+
+        Parameters
+        ----------
+        dataset_id
+            ID of the dataset to add entries to
+        from_dataset_id
+            ID of the dataset to add entries from
+        from_dataset_type
+            Type of the dataset to add entries from
+        from_dataset_name
+            Name of the dataset to add entries from
+        from_specification_name
+            Specification of the source dataset to use for molecules
+
+        Returns
+        -------
+        :
+            Metadata about the added entries
+        """
+
+        if from_dataset_id is None and (from_dataset_type is None or from_dataset_name is None):
+            raise InvalidArgumentsError("from_dataset_id or both from_dataset_type and from_dataset_name must be provided")
+
+        with self.root_socket.optional_session(session) as session:
+            # Make sure dataset exists
+            stmt = "SELECT (id) FROM base_dataset WHERE id = :dataset_id"
+            r = session.execute(text(stmt), {"dataset_id": dataset_id}).scalar_one_or_none()
+            if r is None:
+                raise MissingDataError(f"Cannot find dataset with id={dataset_id}")
+
+            # No matter what was passed in, we need the dataset type and id to copy from
+            if from_dataset_id is not None:
+                stmt = "SELECT (dataset_type) FROM base_dataset WHERE id = :from_dataset_id"
+                ds_type = session.execute(text(stmt), {"from_dataset_id": from_dataset_id}).scalar_one_or_none()
+
+                if ds_type is None:
+                    raise MissingDataError(f"Cannot find dataset with id={from_dataset_id}")
+
+                if from_dataset_type is not None and from_dataset_type.lower() != ds_type.lower():
+                    raise InvalidArgumentsError(
+                        f"Dataset id and type specified, but the type of the dataset id={from_dataset_id} is {ds_type}, not {from_dataset_type}"
+                    )
+                from_dataset_type = ds_type
+            else:
+                assert from_dataset_type is not None and from_dataset_name is not None
+                stmt = "SELECT (id) FROM base_dataset WHERE dataset_type = :from_dataset_type and lname = :from_dataset_name"
+                from_dataset_id = session.execute(
+                    text(stmt), {"from_dataset_type": from_dataset_type, "from_dataset_name": from_dataset_name.lower()}
+                ).scalar_one_or_none()
+
+                if from_dataset_id is None:
+                    raise MissingDataError(
+                        f"Cannot find dataset with type={from_dataset_type} and name={from_dataset_name}"
+                    )
+
+            if from_dataset_type == "torsiondrive":
+                stmt = text("""
+                     WITH inserted_entries AS (
+                         INSERT INTO torsiondrive_dataset_entry (
+                                                                 dataset_id,
+                                                                 name,
+                                                                 comment,
+                                                                 additional_keywords,
+                                                                 additional_optimization_keywords,
+                                                                 attributes
+                             )
+                             SELECT :dataset_id,
+                                 name,
+                                 comment,
+                                 additional_keywords,
+                                 additional_optimization_keywords,
+                                 attributes
+                             FROM torsiondrive_dataset_entry
+                             WHERE dataset_id = :from_dataset_id
+                             ON CONFLICT (dataset_id, name) DO NOTHING
+                             RETURNING name
+                     ),
+                     inserted_molecules AS (
+                             INSERT INTO torsiondrive_dataset_molecule (
+                                                                        dataset_id,
+                                                                        entry_name,
+                                                                        molecule_id
+                                 )
+                                 SELECT
+                                     :dataset_id,
+                                     m.entry_name,
+                                     m.molecule_id
+                                 FROM torsiondrive_dataset_molecule m
+                                          JOIN inserted_entries ie
+                                               ON m.entry_name = ie.name
+                                 WHERE m.dataset_id = :from_dataset_id
+                                 ON CONFLICT DO NOTHING
+                          )
+                     SELECT count(*)
+                     FROM inserted_entries
+                """)
+
+                n_inserted = session.execute(
+                    stmt,
+                    {
+                        "dataset_id": dataset_id,
+                        "from_dataset_id": from_dataset_id,
+                    },
+                ).scalar_one()
+
+                meta = InsertCountsMetadata(
+                    n_inserted=n_inserted,
+                    n_existing=0,
+                )
+
+
+            elif from_dataset_type == "optimization":
+
+                if from_specification_name is None:
+                    raise InvalidArgumentsError(
+                        "from_specification_name must be provided when adding entries from an optimization dataset"
+                    )
+
+                stmt = text("""
+                    WITH source_rows AS (
+                        SELECT
+                            ode.name,
+                            ode.comment,
+                            ode.attributes,
+                            opr.final_molecule_id
+                        FROM optimization_dataset_entry ode
+                                 INNER JOIN optimization_dataset_record odr
+                                            ON ode.dataset_id = odr.dataset_id
+                                                AND ode.name = odr.entry_name
+                                 INNER JOIN optimization_record opr
+                                            ON odr.record_id = opr.id
+                                 INNER JOIN base_record br
+                                            ON opr.id = br.id
+                        WHERE ode.dataset_id = :optimization_dataset_id
+                          AND odr.specification_name = :specification_name
+                          AND br.status = 'complete'
+                          AND opr.final_molecule_id IS NOT NULL
+                    ),
+                         inserted_entries AS (
+                             INSERT INTO torsiondrive_dataset_entry (
+                                                                     dataset_id,
+                                                                     name,
+                                                                     comment,
+                                                                     additional_keywords,
+                                                                     additional_optimization_keywords,
+                                                                     attributes
+                                 )
+                                 SELECT
+                                     :dataset_id,
+                                     name,
+                                     comment,
+                                     '{}'::jsonb,
+                                     '{}'::jsonb,
+                                     attributes
+                                 FROM source_rows
+                                 ON CONFLICT (dataset_id, name) DO NOTHING
+                                 RETURNING name
+                         ),
+                         inserted_molecules AS (
+                             INSERT INTO torsiondrive_dataset_molecule (
+                                                                        dataset_id,
+                                                                        entry_name,
+                                                                        molecule_id
+                                 )
+                                 SELECT
+                                     :dataset_id,
+                                     s.name,
+                                     s.final_molecule_id
+                                 FROM source_rows s
+                                          INNER JOIN inserted_entries ie
+                                                     ON s.name = ie.name
+                                 ON CONFLICT DO NOTHING
+                         )
+                    SELECT count(*)
+                    FROM inserted_entries;
+                """)
+
+                n_inserted = session.execute(
+                    stmt,
+                    {
+                        "dataset_id": dataset_id,
+                        "optimization_dataset_id": from_dataset_id,
+                        "specification_name": from_specification_name,
+                    },
+                ).scalar_one()
+
+
+                meta = InsertCountsMetadata(n_inserted=n_inserted, n_existing=0)
+            else:
+                raise InvalidArgumentsError(
+                    f"Unable to handle adding torsiondrive dataset entries from dataset of type {from_dataset_type}"
+                )
+
+        return meta

--- a/qcfractal/qcfractal/components/torsiondrive/routes.py
+++ b/qcfractal/qcfractal/components/torsiondrive/routes.py
@@ -11,6 +11,7 @@ from qcportal.torsiondrive import (
     TorsiondriveDatasetNewEntry,
     TorsiondriveAddBody,
     TorsiondriveQueryFilters,
+    TorsiondriveDatasetEntriesFrom,
 )
 from qcportal.utils import calculate_limit
 
@@ -88,3 +89,15 @@ def add_torsiondrive_dataset_entries_v1(dataset_id: int, body_data: List[Torsion
 @wrap_global_route("datasets", "modify")
 def background_add_torsiondrive_dataset_entries_v1(dataset_id: int, body_data: List[TorsiondriveDatasetNewEntry]):
     return storage_socket.datasets.torsiondrive.background_add_entries(dataset_id, new_entries=body_data)
+
+
+@api_v1.route("/datasets/torsiondrive/<int:dataset_id>/entries/addFrom", methods=["POST"])
+@wrap_global_route("datasets", "modify")
+def add_torsiondrive_dataset_entries_from_v1(dataset_id: int, body_data: TorsiondriveDatasetEntriesFrom):
+    return storage_socket.datasets.torsiondrive.add_entries_from_ds(
+        dataset_id=dataset_id,
+        from_dataset_id=body_data.dataset_id,
+        from_dataset_type=body_data.dataset_type,
+        from_dataset_name=body_data.dataset_name,
+        from_specification_name=body_data.specification_name,
+    )

--- a/qcportal/qcportal/singlepoint/dataset_models.py
+++ b/qcportal/qcportal/singlepoint/dataset_models.py
@@ -124,7 +124,7 @@ class SinglepointDataset(BaseDataset):
         *,
         dataset_type: Optional[str] = None,
         dataset_name: Optional[str] = None,
-        dataset_id: Optional[str] = None,
+        dataset_id: Optional[int] = None,
         specification_name: Optional[str] = None,
     ) -> InsertCountsMetadata:
         body = SinglepointDatasetEntriesFrom(

--- a/qcportal/qcportal/singlepoint/test_dataset_entries_from.py
+++ b/qcportal/qcportal/singlepoint/test_dataset_entries_from.py
@@ -192,3 +192,76 @@ def test_singlepoint_dataset_model_entries_from_errors(snowflake: QCATestingSnow
     # Source is optimization ds, but no specification given
     with pytest.raises(PortalRequestError, match="from_specification_name must be provided"):
         sp_ds.add_entries_from(dataset_id=src_opt_ds.id)
+
+
+
+@pytest.mark.parametrize("use_id", [True, False])
+def test_torsiondrive_dataset_model_entries_from_opt_1(snowflake: QCATestingSnowflake, use_id: bool):
+    snowflake_client = snowflake.client()
+    src_ds = snowflake_client.add_dataset("optimization", "Test src optimization dataset")
+
+    # Slight cheat
+    # Run the data as standalone calculations just so they finish
+    activated_manager_name, _ = snowflake.activate_manager()
+    socket = snowflake.get_storage_socket()
+    run_optimization_procedure_data(socket, activated_manager_name, "opt_psi4_benzene")
+    run_optimization_procedure_data(socket, activated_manager_name, "opt_psi4_methane")
+
+    # Now load as a dataset entry/spec
+    input_spec_1, molecule_1, _ = load_optimization_procedure_data("opt_psi4_benzene")
+    input_spec_2, molecule_2, _ = load_optimization_procedure_data("opt_psi4_methane")
+    molecule_3 = load_molecule_data("hooh")  # Won't be run
+
+    src_ds.add_entry(
+        name="test_molecule_1", initial_molecule=molecule_1, comment="This is a comment", attributes={"key": "value"}
+    )
+    src_ds.add_entry(name="test_molecule_2", initial_molecule=molecule_2)
+    src_ds.add_entry(name="test_molecule_3", initial_molecule=molecule_3)
+    src_ds.add_specification("test_spec", input_spec_1, "test_specification")
+
+    src_ds.submit()
+    assert src_ds.status()["test_spec"]["complete"] == 2
+    assert src_ds.status()["test_spec"]["waiting"] == 1
+
+    # Now create the torsiondrive dataset
+    td_ds = snowflake_client.add_dataset("torsiondrive", "Test torsiondrive dataset")
+
+    if use_id:
+        m = td_ds.add_entries_from(dataset_id=src_ds.id, specification_name="test_spec")
+    else:
+        # Purposefully change case of name - should be case insensitive
+        m = td_ds.add_entries_from(
+            dataset_type="optimization", dataset_name=src_ds.name.upper(), specification_name="test_spec"
+        )
+    assert m.n_inserted == 2
+
+    # refetch for up-to-date info
+    td_ds = snowflake_client.get_dataset_by_id(td_ds.id)
+
+    # Is missing molecule_3 - wasn't run
+    assert set(td_ds.entry_names) == {"test_molecule_1", "test_molecule_2"}
+
+    td_entry_1 = td_ds.get_entry("test_molecule_1")
+    td_entry_2 = td_ds.get_entry("test_molecule_2")
+    opt_entry_1 = src_ds.get_entry("test_molecule_1")
+    opt_entry_2 = src_ds.get_entry("test_molecule_2")
+    opt_record_1 = src_ds.get_record("test_molecule_1", "test_spec")
+    opt_record_2 = src_ds.get_record("test_molecule_2", "test_spec")
+
+    assert opt_record_1.final_molecule_id == td_entry_1.initial_molecules[0].id
+    assert opt_record_2.final_molecule_id == td_entry_2.initial_molecules[0].id
+
+    assert opt_entry_1.comment == td_entry_1.comment
+    assert opt_entry_2.comment == td_entry_2.comment
+
+    assert opt_entry_1.attributes == td_entry_1.attributes
+    assert opt_entry_2.attributes == td_entry_2.attributes
+
+    # If we add again, nothing happens
+    if use_id:
+        m = td_ds.add_entries_from(dataset_id=src_ds.id, specification_name="test_spec")
+    else:
+        m = td_ds.add_entries_from(
+            dataset_type="optimization", dataset_name=src_ds.name.upper(), specification_name="test_spec"
+        )
+    assert m.n_inserted == 0

--- a/qcportal/qcportal/torsiondrive/__init__.py
+++ b/qcportal/qcportal/torsiondrive/__init__.py
@@ -3,6 +3,7 @@ from .dataset_models import (
     TorsiondriveDatasetNewEntry,
     TorsiondriveDatasetSpecification,
     TorsiondriveDatasetEntry,
+    TorsiondriveDatasetEntriesFrom,
 )
 from .record_models import (
     serialize_key,

--- a/qcportal/qcportal/torsiondrive/dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/dataset_models.py
@@ -1,13 +1,13 @@
 from typing import Dict, Any, Union, Optional, List, Iterable
 
 try:
-    from pydantic.v1 import BaseModel, Extra
+    from pydantic.v1 import BaseModel, Extra, root_validator
 except ImportError:
-    from pydantic import BaseModel, Extra
+    from pydantic import BaseModel, Extra, root_validator
 from typing_extensions import Literal
 
 from qcportal.dataset_models import BaseDataset
-from qcportal.metadata_models import InsertMetadata
+from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.molecules import Molecule
 from qcportal.internal_jobs import InternalJob
 from qcportal.torsiondrive.record_models import TorsiondriveRecord, TorsiondriveSpecification
@@ -48,6 +48,26 @@ class TorsiondriveDatasetRecordItem(BaseModel):
     specification_name: str
     record_id: int
     record: Optional[TorsiondriveRecord]
+
+
+class TorsiondriveDatasetEntriesFrom(BaseModel):
+
+    dataset_id: Optional[int] = None
+    dataset_type: Optional[str] = None
+    dataset_name: Optional[str] = None
+    specification_name: Optional[str] = None
+
+    @root_validator
+    def validate_input(cls, values):
+        # Dataset id must be specified, or dataset type and name
+        if values.get("dataset_id") is None:
+            if values.get("dataset_type") is None or values.get("dataset_name") is None:
+                raise ValueError("Either dataset_id or dataset_type and dataset_name must be specified.")
+
+        if values.get("dataset_type") == "optimization" and values.get("specification_name") is None:
+            raise ValueError("specification_name must be given for obtaining entries from an optimization dataset")
+
+        return values
 
 
 class TorsiondriveDataset(BaseDataset):
@@ -102,3 +122,25 @@ class TorsiondriveDataset(BaseDataset):
         )
 
         return self.add_entries(ent)
+
+    def add_entries_from(
+        self,
+        *,
+        dataset_type: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        dataset_id: Optional[int] = None,
+        specification_name: Optional[str] = None,
+    ) -> InsertCountsMetadata:
+        body = TorsiondriveDatasetEntriesFrom(
+            dataset_type=dataset_type,
+            dataset_name=dataset_name,
+            dataset_id=dataset_id,
+            specification_name=specification_name,
+        )
+
+        return self._client.make_request(
+            "post",
+            f"api/v1/datasets/{self.dataset_type}/{self.id}/entries/addFrom",
+            InsertCountsMetadata,
+            body=body,
+        )


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

For a torsiondrive dataset, add the `add_entries_from` for a torsiondrive. This allows for a dataset of optmizations to be used to create entries for a torsiondrive dataset.

Only final molecules from completed optimizations will be used to create entries, and entry names will be re-used. Only new entries will be created - existing ones will not be overwritten.

Somewhat quick and dirty, but tested and functional.

## Status
- [X] Code base linted
- [X] Ready to go
