### PR TITLE
Update server stats logic

### DIFF
--- a/qcfractal/qcfractal/alembic/versions/2026-05-30-7952618c1c43_add_server_stats.py
+++ b/qcfractal/qcfractal/alembic/versions/2026-05-30-7952618c1c43_add_server_stats.py
@@ -43,7 +43,6 @@ def upgrade():
                   INNER JOIN base_record br ON rch.record_id = br.id
          WHERE rch.status = 'complete'
            AND br.status = 'complete'
-           AND br.record_type = 'singlepoint'
          GROUP BY DATE(rch.modified_on)
     """))
 

--- a/qcfractal/qcfractal/components/serverinfo/socket.py
+++ b/qcfractal/qcfractal/components/serverinfo/socket.py
@@ -666,7 +666,6 @@ class ServerInfoSocket:
                     INNER JOIN base_record br ON rch.record_id = br.id
                 WHERE rch.status = 'complete'
                   AND br.status = 'complete'
-                  AND br.record_type = 'singlepoint'
                   AND rch.modified_on > (CURRENT_DATE - INTERVAL '3 days')
                 GROUP BY DATE(rch.modified_on)
             ON CONFLICT (date)


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

There was a small issue with the server stats not counting all record types. CPU hours may still be incorrect, but it's just an estimate anyway.

It might be incorrect due to sometimes double counting geometry optimization time + singlepoint trajectory cpu time. We will probably want to look into that in the future.

## Status
- [X] Code base linted
- [X] Ready to go
