### PR TITLE
Adds ability to generate openapi spec

### DIFF
--- a/qcfractal/qcfractal/components/auth/routes.py
+++ b/qcfractal/qcfractal/components/auth/routes.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union, Dict, Any
+from typing import Any
 
 from flask import g
 from qcfractal.flask_app import storage_socket
@@ -26,7 +26,7 @@ from qcportal.exceptions import (
 ###################################################################
 
 
-def is_same_user(username_or_id: Union[int, str]) -> bool:
+def is_same_user(username_or_id: int | str) -> bool:
     assert isinstance(username_or_id, (int, str))
 
     if isinstance(username_or_id, str) and username_or_id.isdecimal():
@@ -53,28 +53,28 @@ def is_same_user(username_or_id: Union[int, str]) -> bool:
 @api_v1.route("/groups", methods=["GET"])
 @check_permissions("groups", "read", True)
 @serialization()
-def list_groups_v1():
+def list_groups_v1() -> list[dict[str, Any]]:
     return storage_socket.groups.list()
 
 
 @api_v1.route("/groups", methods=["POST"])
 @check_permissions("groups", "add", True)
 @serialization()
-def add_group_v1(body_data: GroupInfo):
+def add_group_v1(body_data: GroupInfo) -> None:
     return storage_socket.groups.add(body_data)
 
 
 @api_v1.route("/groups/<groupname_or_id>", methods=["GET"])
 @check_permissions("groups", "read", True)
 @serialization()
-def get_group_v1(groupname_or_id: Union[int, str]):
+def get_group_v1(groupname_or_id: int | str) -> dict[str, Any]:
     return storage_socket.groups.get(groupname_or_id)
 
 
 @api_v1.route("/groups/<groupname_or_id>", methods=["DELETE"])
 @check_permissions("groups", "delete", True)
 @serialization()
-def delete_group_v1(groupname_or_id: Union[int, str]):
+def delete_group_v1(groupname_or_id: int | str) -> None:
     return storage_socket.groups.delete(groupname_or_id)
 
 
@@ -86,14 +86,14 @@ def delete_group_v1(groupname_or_id: Union[int, str]):
 @api_v1.route("/users", methods=["GET"])
 @check_permissions("users", "read", True)
 @serialization()
-def list_users_v1():
+def list_users_v1() -> list[dict[str, Any]]:
     return storage_socket.users.list()
 
 
 @api_v1.route("/users", methods=["POST"])
 @check_permissions("users", "add", True)
 @serialization()
-def add_user_v1(body_data: Tuple[UserInfo, Optional[str]]):
+def add_user_v1(body_data: tuple[UserInfo, str | None]) -> None:
     user_info, password = body_data
     return storage_socket.users.add(user_info, password)
 
@@ -101,28 +101,28 @@ def add_user_v1(body_data: Tuple[UserInfo, Optional[str]]):
 @api_v1.route("/users/<username_or_id>", methods=["GET"])
 @check_permissions("users", "read", True)
 @serialization()
-def get_user_v1(username_or_id: Union[int, str]):
+def get_user_v1(username_or_id: int | str) -> dict[str, Any]:
     return storage_socket.users.get(username_or_id)
 
 
 @api_v1.route("/me", methods=["GET"])
 @check_permissions("me", "read", True)
 @serialization()
-def get_my_user_v1():
+def get_my_user_v1() -> dict[str, Any]:
     return storage_socket.users.get(g.user_id)
 
 
 @api_v1.route("/users", methods=["PATCH"])
 @check_permissions("users", "modify", True)
 @serialization()
-def modify_user_v1(body_data: UserInfo):
+def modify_user_v1(body_data: UserInfo) -> None:
     return storage_socket.users.modify(body_data, as_admin=True)
 
 
 @api_v1.route("/me", methods=["PATCH"])
 @check_permissions("me", "modify", True)
 @serialization()
-def modify_my_user_v1(body_data: UserInfo):
+def modify_my_user_v1(body_data: UserInfo) -> None:
     if body_data.id is None or body_data.username is None:
         raise UserManagementError("Cannot modify user: id or username is missing")
 
@@ -135,21 +135,21 @@ def modify_my_user_v1(body_data: UserInfo):
 @api_v1.route("/users/<username_or_id>/password", methods=["PUT"])
 @check_permissions("users", "modify", True)
 @serialization()
-def change_password_v1(username_or_id: Union[int, str], body_data: Optional[str]):
+def change_password_v1(username_or_id: int | str, body_data: str | None) -> None:
     return storage_socket.users.change_password(username_or_id, password=body_data)
 
 
 @api_v1.route("/me/password", methods=["PUT"])
 @check_permissions("me", "modify", True)
 @serialization()
-def change_my_password_v1(body_data: Optional[str]):
+def change_my_password_v1(body_data: str | None) -> None:
     return storage_socket.users.change_password(g.user_id, password=body_data)
 
 
 @api_v1.route("/users/<username_or_id>", methods=["DELETE"])
 @check_permissions("users", "delete", True)
 @serialization()
-def delete_user_v1(username_or_id: Union[int, str]):
+def delete_user_v1(username_or_id: int | str) -> None:
     if is_same_user(username_or_id):
         raise UserManagementError("Cannot delete your own user")
 
@@ -162,28 +162,28 @@ def delete_user_v1(username_or_id: Union[int, str]):
 @api_v1.route("/users/<username_or_id>/preferences", methods=["GET"])
 @check_permissions("users", "read", True)
 @serialization()
-def get_user_preferences_v1(username_or_id: Union[int, str]):
+def get_user_preferences_v1(username_or_id: int | str) -> dict[str, Any]:
     return storage_socket.users.get_preferences(username_or_id)
 
 
 @api_v1.route("/me/preferences", methods=["GET"])
 @check_permissions("me", "read", True)
 @serialization()
-def get_my_preferences_v1():
+def get_my_preferences_v1() -> dict[str, Any]:
     return storage_socket.users.get_preferences(g.user_id)
 
 
 @api_v1.route("/users/<username_or_id>/preferences", methods=["PUT"])
 @check_permissions("users", "modify", True)
 @serialization()
-def set_user_preferences_v1(username_or_id: Union[int, str], body_data: Dict[str, Any]):
+def set_user_preferences_v1(username_or_id: int | str, body_data: dict[str, Any]) -> None:
     return storage_socket.users.set_preferences(username_or_id, body_data)
 
 
 @api_v1.route("/me/preferences", methods=["PUT"])
 @check_permissions("me", "modify", True)
 @serialization()
-def set_my_preferences_v1(body_data: Dict[str, Any]):
+def set_my_preferences_v1(body_data: dict[str, Any]) -> None:
     return storage_socket.users.set_preferences(g.user_id, body_data)
 
 
@@ -193,19 +193,19 @@ def set_my_preferences_v1(body_data: Dict[str, Any]):
 @api_v1.route("/sessions", methods=["GET"])
 @check_permissions("users", "read", True)
 @serialization()
-def list_all_user_sessions_v1():
+def list_all_user_sessions_v1() -> list[dict[str, Any]]:
     return storage_socket.auth.list_all_user_sessions()
 
 
 @api_v1.route("/users/<username_or_id>/sessions", methods=["GET"])
 @check_permissions("users", "read", True)
 @serialization()
-def list_user_sessions_v1(username_or_id: Union[int, str]):
+def list_user_sessions_v1(username_or_id: int | str) -> list[dict[str, Any]]:
     return storage_socket.auth.list_user_sessions(username_or_id)
 
 
 @api_v1.route("/me/sessions", methods=["GET"])
 @check_permissions("me", "read", True)
 @serialization()
-def list_my_sessions_v1():
+def list_my_sessions_v1() -> list[dict[str, Any]]:
     return storage_socket.auth.list_user_sessions(g.user_id)

--- a/qcfractal/qcfractal/components/dataset_routes.py
+++ b/qcfractal/qcfractal/components/dataset_routes.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any
 
 from flask import current_app, g
 
@@ -6,6 +6,8 @@ from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.base_models import ProjURLParameters
+from qcportal.record_models import RecordStatusEnum
+from qcportal.metadata_models import InsertCountsMetadata, DeleteMetadata
 from qcportal.dataset_models import (
     DatasetAddBody,
     DatasetQueryModel,
@@ -32,14 +34,14 @@ from qcportal.exceptions import LimitExceededError
 @api_v1.route("/datasets", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def list_dataset_v1():
+def list_dataset_v1() -> list[dict[str, Any]]:
     return storage_socket.datasets.list()
 
 
 @api_v1.route("/datasets/<int:dataset_id>", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_general_dataset_v1(dataset_id: int, url_params: ProjURLParameters):
+def get_general_dataset_v1(dataset_id: int, url_params: ProjURLParameters) -> dict[str, Any]:
     with storage_socket.session_scope(True) as session:
         ds_type = storage_socket.datasets.lookup_type(dataset_id, session=session)
         ds_socket = storage_socket.datasets.get_socket(ds_type)
@@ -56,7 +58,7 @@ def get_general_dataset_v1(dataset_id: int, url_params: ProjURLParameters):
 @api_v1.route("/datasets/query", methods=["POST"])
 @check_permissions("datasets", "read")
 @serialization()
-def query_general_dataset_v1(body_data: DatasetQueryModel):
+def query_general_dataset_v1(body_data: DatasetQueryModel) -> dict[str, Any]:
     with storage_socket.session_scope(True) as session:
         dataset_id = storage_socket.datasets.lookup_id(body_data.dataset_type, body_data.dataset_name, session=session)
         ds_type = storage_socket.datasets.lookup_type(dataset_id, session=session)
@@ -67,7 +69,7 @@ def query_general_dataset_v1(body_data: DatasetQueryModel):
 @api_v1.route("/datasets/queryrecords", methods=["POST"])
 @check_permissions("datasets", "read")
 @serialization()
-def query_dataset_records_v1(body_data: DatasetQueryRecords):
+def query_dataset_records_v1(body_data: DatasetQueryRecords) -> list[dict[str, Any]]:
     return storage_socket.datasets.query_dataset_records(
         record_id=body_data.record_id, dataset_type=body_data.dataset_type
     )
@@ -76,7 +78,7 @@ def query_dataset_records_v1(body_data: DatasetQueryRecords):
 @api_v1.route("/datasets/<int:dataset_id>", methods=["DELETE"])
 @check_permissions("datasets", "delete")
 @serialization()
-def delete_dataset_v1(dataset_id: int, url_params: DatasetDeleteParams):
+def delete_dataset_v1(dataset_id: int, url_params: DatasetDeleteParams) -> None:
     storage_socket.datasets.delete(dataset_id, url_params.delete_records)
 
 
@@ -94,7 +96,7 @@ def delete_dataset_v1(dataset_id: int, url_params: DatasetDeleteParams):
 @api_v1.route("/datasets/<string:dataset_type>", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_dataset_v1(dataset_type: str, body_data: DatasetAddBody):
+def add_dataset_v1(dataset_type: str, body_data: DatasetAddBody) -> int:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.add(
         name=body_data.name,
@@ -116,7 +118,7 @@ def add_dataset_v1(dataset_type: str, body_data: DatasetAddBody):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_dataset_v1(dataset_type: str, dataset_id: int, url_params: ProjURLParameters):
+def get_dataset_v1(dataset_type: str, dataset_id: int, url_params: ProjURLParameters) -> dict[str, Any]:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.get(
         dataset_id,
@@ -128,7 +130,7 @@ def get_dataset_v1(dataset_type: str, dataset_id: int, url_params: ProjURLParame
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/status", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_dataset_status_v1(dataset_type: str, dataset_id: int):
+def get_dataset_status_v1(dataset_type: str, dataset_id: int) -> dict[str, dict[RecordStatusEnum, int]]:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.status(dataset_id)
 
@@ -136,14 +138,14 @@ def get_dataset_status_v1(dataset_type: str, dataset_id: int):
 @api_v1.route("/datasets/<int:dataset_id>/status", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_base_dataset_status_v1(dataset_id: int):
+def get_base_dataset_status_v1(dataset_id: int) -> dict[str, dict[RecordStatusEnum, int]]:
     return storage_socket.datasets.status(dataset_id)
 
 
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/detailed_status", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_dataset_detailed_status_v1(dataset_type: str, dataset_id: int):
+def get_dataset_detailed_status_v1(dataset_type: str, dataset_id: int) -> list[tuple[str, str, RecordStatusEnum]]:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.detailed_status(dataset_id)
 
@@ -151,7 +153,7 @@ def get_dataset_detailed_status_v1(dataset_type: str, dataset_id: int):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/status_by_tag", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_dataset_status_by_tag_v1(dataset_type: str, dataset_id: int):
+def get_dataset_status_by_tag_v1(dataset_type: str, dataset_id: int) -> dict[RecordStatusEnum, int]:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.status_by_compute_tag(dataset_id)
 
@@ -159,7 +161,7 @@ def get_dataset_status_by_tag_v1(dataset_type: str, dataset_id: int):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/record_count", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_dataset_record_count_v1(dataset_type: str, dataset_id: int):
+def get_dataset_record_count_v1(dataset_type: str, dataset_id: int) -> int:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.get_record_count(dataset_id)
 
@@ -167,7 +169,7 @@ def get_dataset_record_count_v1(dataset_type: str, dataset_id: int):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/computed_properties", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_dataset_computed_properties_v1(dataset_type: str, dataset_id: int):
+def get_dataset_computed_properties_v1(dataset_type: str, dataset_id: int) -> dict[str, list[str]]:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.get_computed_properties(dataset_id)
 
@@ -178,7 +180,7 @@ def get_dataset_computed_properties_v1(dataset_type: str, dataset_id: int):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>", methods=["PATCH"])
 @check_permissions("datasets", "modify")
 @serialization()
-def modify_dataset_metadata_v1(dataset_type: str, dataset_id: int, body_data: DatasetModifyMetadata):
+def modify_dataset_metadata_v1(dataset_type: str, dataset_id: int, body_data: DatasetModifyMetadata) -> None:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.update_metadata(dataset_id, new_metadata=body_data)
 
@@ -189,7 +191,7 @@ def modify_dataset_metadata_v1(dataset_type: str, dataset_id: int, body_data: Da
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/create_view", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def create_dataset_view_v1(dataset_type: str, dataset_id: int, body_data: DatasetCreateViewBody):
+def create_dataset_view_v1(dataset_type: str, dataset_id: int, body_data: DatasetCreateViewBody) -> int:
     return storage_socket.datasets.add_create_view_attachment_job(
         dataset_id,
         dataset_type,
@@ -208,7 +210,7 @@ def create_dataset_view_v1(dataset_type: str, dataset_id: int, body_data: Datase
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/submit", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def submit_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubmitBody):
+def submit_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubmitBody) -> InsertCountsMetadata:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.submit(
         dataset_id,
@@ -224,7 +226,7 @@ def submit_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubm
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/background_submit", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def background_submit_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubmitBody):
+def background_submit_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubmitBody) -> int:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.background_submit(
         dataset_id,
@@ -243,7 +245,7 @@ def background_submit_dataset_v1(dataset_type: str, dataset_id: int, body_data: 
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/specification_names", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def fetch_dataset_specification_names_v1(dataset_type: str, dataset_id: int):
+def fetch_dataset_specification_names_v1(dataset_type: str, dataset_id: int) -> list[str]:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.fetch_specification_names(dataset_id)
 
@@ -251,7 +253,7 @@ def fetch_dataset_specification_names_v1(dataset_type: str, dataset_id: int):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/specifications", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def fetch_all_dataset_specifications_v1(dataset_type: str, dataset_id: int):
+def fetch_all_dataset_specifications_v1(dataset_type: str, dataset_id: int) -> dict[str, Any]:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.fetch_specifications(dataset_id)
 
@@ -259,7 +261,7 @@ def fetch_all_dataset_specifications_v1(dataset_type: str, dataset_id: int):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/specifications/bulkFetch", methods=["POST"])
 @check_permissions("datasets", "read")
 @serialization()
-def fetch_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_data: DatasetFetchSpecificationBody):
+def fetch_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_data: DatasetFetchSpecificationBody) -> dict[str, Any]:
     # use the entry limit I guess?
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_dataset_entries
 
@@ -277,7 +279,7 @@ def fetch_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_dat
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/specifications/bulkDelete", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def delete_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_data: DatasetDeleteStrBody):
+def delete_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_data: DatasetDeleteStrBody) -> DeleteMetadata:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.delete_specifications(dataset_id, body_data.names, body_data.delete_records)
 
@@ -285,7 +287,7 @@ def delete_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_da
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/specifications", methods=["PATCH"])
 @check_permissions("datasets", "modify")
 @serialization()
-def rename_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_data: Dict[str, str]):
+def rename_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_data: dict[str, str]) -> None:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.rename_specifications(dataset_id, body_data)
 
@@ -296,7 +298,7 @@ def rename_dataset_specifications_v1(dataset_type: str, dataset_id: int, body_da
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/entry_names", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def fetch_dataset_entry_names_v1(dataset_type: str, dataset_id: int):
+def fetch_dataset_entry_names_v1(dataset_type: str, dataset_id: int) -> list[str]:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.fetch_entry_names(dataset_id)
 
@@ -304,7 +306,7 @@ def fetch_dataset_entry_names_v1(dataset_type: str, dataset_id: int):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/entries/bulkDelete", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def delete_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetDeleteStrBody):
+def delete_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetDeleteStrBody) -> DeleteMetadata:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.delete_entries(dataset_id, body_data.names, body_data.delete_records)
 
@@ -312,7 +314,7 @@ def delete_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dat
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/entries/bulkFetch", methods=["POST"])
 @check_permissions("datasets", "read")
 @serialization()
-def fetch_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetFetchEntryBody):
+def fetch_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetFetchEntryBody) -> dict[str, Any]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_dataset_entries
 
     if len(body_data.names) > limit:
@@ -329,7 +331,7 @@ def fetch_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Data
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/background_add_entries", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def background_add_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubmitBody):
+def background_add_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetSubmitBody) -> int:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.background_submit(
         dataset_id,
@@ -345,7 +347,7 @@ def background_add_entries_v1(dataset_type: str, dataset_id: int, body_data: Dat
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/entries", methods=["PATCH"])
 @check_permissions("datasets", "modify")
 @serialization()
-def rename_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dict[str, str]):
+def rename_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: dict[str, str]) -> None:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.rename_entries(dataset_id, body_data)
 
@@ -353,7 +355,7 @@ def rename_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dic
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/entries/modify", methods=["PATCH"])
 @check_permissions("datasets", "modify")
 @serialization()
-def modify_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetModifyEntryBody):
+def modify_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: DatasetModifyEntryBody) -> None:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.modify_entries(
         dataset_id, body_data.attribute_map, body_data.comment_map, body_data.overwrite_attributes
@@ -366,7 +368,7 @@ def modify_dataset_entries_v1(dataset_type: str, dataset_id: int, body_data: Dat
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/records/bulkFetch", methods=["POST"])
 @check_permissions("datasets", "read")
 @serialization()
-def fetch_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: DatasetFetchRecordsBody):
+def fetch_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: DatasetFetchRecordsBody) -> list[tuple[str, str, int]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
 
     n_requested = len(body_data.entry_names) * len(body_data.specification_names)
@@ -386,7 +388,7 @@ def fetch_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: Data
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/records/bulkDelete", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def remove_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: DatasetRemoveRecordsBody):
+def remove_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: DatasetRemoveRecordsBody) -> DeleteMetadata:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.remove_records(
         dataset_id,
@@ -402,7 +404,7 @@ def remove_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: Dat
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/records", methods=["PATCH"])
 @check_permissions("datasets", "modify")
 @serialization()
-def modify_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: DatasetRecordModifyBody):
+def modify_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: DatasetRecordModifyBody) -> None:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.modify_records(
         dataset_id,
@@ -419,7 +421,7 @@ def modify_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: Dat
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/records/revert", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def revert_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: DatasetRecordRevertBody):
+def revert_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: DatasetRecordRevertBody) -> None:
     ds_socket = storage_socket.datasets.get_socket(dataset_type)
     return ds_socket.revert_records(
         dataset_id,
@@ -435,14 +437,14 @@ def revert_dataset_records_v1(dataset_type: str, dataset_id: int, body_data: Dat
 @api_v1.route("/datasets/<int:dataset_id>/internal_jobs/<int:job_id>", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def get_dataset_internal_job_v1(dataset_id: int, job_id: int):
+def get_dataset_internal_job_v1(dataset_id: int, job_id: int) -> dict[str, Any]:
     return storage_socket.datasets.get_internal_job(dataset_id, job_id)
 
 
 @api_v1.route("/datasets/<int:dataset_id>/internal_jobs", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def list_dataset_internal_jobs_v1(dataset_id: int, url_params: DatasetGetInternalJobParams):
+def list_dataset_internal_jobs_v1(dataset_id: int, url_params: DatasetGetInternalJobParams) -> list[dict[str, Any]]:
     return storage_socket.datasets.list_internal_jobs(dataset_id, status=url_params.status)
 
 
@@ -452,14 +454,14 @@ def list_dataset_internal_jobs_v1(dataset_id: int, url_params: DatasetGetInterna
 @api_v1.route("/datasets/<int:dataset_id>/attachments", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def fetch_dataset_attachments_v1(dataset_id: int):
+def fetch_dataset_attachments_v1(dataset_id: int) -> list[dict[str, Any]]:
     return storage_socket.datasets.get_attachments(dataset_id)
 
 
 @api_v1.route("/datasets/<int:dataset_id>/attachments/<int:attachment_id>", methods=["DELETE"])
 @check_permissions("datasets", "modify")
 @serialization()
-def delete_dataset_attachment_v1(dataset_id: int, attachment_id: int):
+def delete_dataset_attachment_v1(dataset_id: int, attachment_id: int) -> None:
     return storage_socket.datasets.delete_attachment(dataset_id, attachment_id)
 
 
@@ -469,7 +471,7 @@ def delete_dataset_attachment_v1(dataset_id: int, attachment_id: int):
 @api_v1.route("/datasets/<int:dataset_id>/contributed_values", methods=["GET"])
 @check_permissions("datasets", "read")
 @serialization()
-def fetch_dataset_contributed_values_v1(dataset_id: int):
+def fetch_dataset_contributed_values_v1(dataset_id: int) -> list[dict[str, Any]]:
     return storage_socket.datasets.get_contributed_values(dataset_id)
 
 
@@ -479,7 +481,7 @@ def fetch_dataset_contributed_values_v1(dataset_id: int):
 @api_v1.route("/datasets/clone", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def clone_dataset_v1(body_data: DatasetCloneBody):
+def clone_dataset_v1(body_data: DatasetCloneBody) -> int:
     with storage_socket.session_scope(True) as session:
         ds_type = storage_socket.datasets.lookup_type(body_data.source_dataset_id, session=session)
         ds_socket = storage_socket.datasets.get_socket(ds_type)
@@ -489,7 +491,7 @@ def clone_dataset_v1(body_data: DatasetCloneBody):
 @api_v1.route("/datasets/<string:dataset_type>/<int:dataset_id>/copy_from", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def copy_from_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetCopyFromBody):
+def copy_from_dataset_v1(dataset_type: str, dataset_id: int, body_data: DatasetCopyFromBody) -> None:
     # the dataset_id in the URI is the destination dataset
     # (ie, the user has a dataset, then copies FROM another dataset
     with storage_socket.session_scope(True) as session:

--- a/qcfractal/qcfractal/components/external_files/routes.py
+++ b/qcfractal/qcfractal/components/external_files/routes.py
@@ -1,3 +1,4 @@
+from typing import Any
 from flask import redirect, Response, stream_with_context, current_app
 
 from qcfractal.flask_app import storage_socket
@@ -8,14 +9,14 @@ from qcfractal.flask_app.decorators import check_permissions, serialization
 @api_v1.route("/external_files/<int:file_id>", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_external_file_metadata_v1(file_id: int):
+def get_external_file_metadata_v1(file_id: int) -> dict[str, Any]:
     return storage_socket.external_files.get_metadata(file_id)
 
 
 @api_v1.route("/external_files/<int:file_id>/download", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def download_external_file_v1(file_id: int):
+def download_external_file_v1(file_id: int) -> Any:
     passthrough = current_app.config["QCFRACTAL_CONFIG"].s3.passthrough
 
     if passthrough:
@@ -34,7 +35,7 @@ def download_external_file_v1(file_id: int):
 @api_v1.route("/external_files/<int:file_id>/direct_link", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_direct_link_external_file_v1(file_id: int):
+def get_direct_link_external_file_v1(file_id: int) -> str:
     passthrough = current_app.config["QCFRACTAL_CONFIG"].s3.passthrough
 
     if passthrough:

--- a/qcfractal/qcfractal/components/gridoptimization/routes.py
+++ b/qcfractal/qcfractal/components/gridoptimization/routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any
 
 from flask import current_app, g
 
@@ -6,6 +6,7 @@ from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import InsertMetadata
 from qcportal.gridoptimization import (
     GridoptimizationDatasetSpecification,
     GridoptimizationDatasetNewEntry,
@@ -23,7 +24,7 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/records/gridoptimization/bulkCreate", methods=["POST"])
 @check_permissions("records", "add")
 @serialization()
-def add_gridoptimization_records_v1(body_data: GridoptimizationAddBody):
+def add_gridoptimization_records_v1(body_data: GridoptimizationAddBody) -> tuple[InsertMetadata, list[int | None]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.add_records
     if len(body_data.initial_molecules) > limit:
         raise LimitExceededError(
@@ -43,14 +44,14 @@ def add_gridoptimization_records_v1(body_data: GridoptimizationAddBody):
 @api_v1.route("/records/gridoptimization/<int:record_id>/optimizations", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_gridoptimization_optimizations_v1(record_id: int):
+def get_gridoptimization_optimizations_v1(record_id: int) -> list[dict[str, Any]]:
     return storage_socket.records.gridoptimization.get_optimizations(record_id)
 
 
 @api_v1.route("/records/gridoptimization/query", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def query_gridoptimization_v1(body_data: GridoptimizationQueryFilters):
+def query_gridoptimization_v1(body_data: GridoptimizationQueryFilters) -> list[int]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 
@@ -66,15 +67,17 @@ def query_gridoptimization_v1(body_data: GridoptimizationQueryFilters):
 @check_permissions("datasets", "modify")
 @serialization()
 def add_gridoptimization_dataset_specifications_v1(
-    dataset_id: int, body_data: List[GridoptimizationDatasetSpecification]
-):
+    dataset_id: int, body_data: list[GridoptimizationDatasetSpecification]
+) -> InsertMetadata:
     return storage_socket.datasets.gridoptimization.add_specifications(dataset_id, body_data)
 
 
 @api_v1.route("/datasets/gridoptimization/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_gridoptimization_dataset_entries_v1(dataset_id: int, body_data: List[GridoptimizationDatasetNewEntry]):
+def add_gridoptimization_dataset_entries_v1(
+    dataset_id: int, body_data: list[GridoptimizationDatasetNewEntry]
+) -> InsertMetadata:
     return storage_socket.datasets.gridoptimization.add_entries(dataset_id, new_entries=body_data)
 
 
@@ -82,6 +85,6 @@ def add_gridoptimization_dataset_entries_v1(dataset_id: int, body_data: List[Gri
 @check_permissions("datasets", "modify")
 @serialization()
 def background_add_gridoptimization_dataset_entries_v1(
-    dataset_id: int, body_data: List[GridoptimizationDatasetNewEntry]
-):
+    dataset_id: int, body_data: list[GridoptimizationDatasetNewEntry]
+) -> int:
     return storage_socket.datasets.gridoptimization.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/internal_jobs/routes.py
+++ b/qcfractal/qcfractal/components/internal_jobs/routes.py
@@ -1,3 +1,4 @@
+from typing import Any
 from flask import current_app
 
 from qcfractal.flask_app import storage_socket
@@ -11,21 +12,21 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/internal_jobs/<int:job_id>", methods=["GET"])
 @check_permissions("internal_jobs", "read")
 @serialization()
-def get_internal_job_v1(job_id: int):
+def get_internal_job_v1(job_id: int) -> dict[str, Any] | None:
     return storage_socket.internal_jobs.get(job_id=job_id)
 
 
 @api_v1.route("/internal_jobs/<int:job_id>", methods=["DELETE"])
 @check_permissions("internal_jobs", "delete")
 @serialization()
-def delete_internal_job_v1(job_id: int):
+def delete_internal_job_v1(job_id: int) -> bool:
     return storage_socket.internal_jobs.delete(job_id=job_id)
 
 
 @api_v1.route("/internal_jobs/<int:job_id>/status", methods=["PUT"])
 @check_permissions("internal_jobs", "modify")
 @serialization()
-def cancel_internal_job_v1(job_id: int, body_data: InternalJobStatusEnum):
+def cancel_internal_job_v1(job_id: int, body_data: InternalJobStatusEnum) -> None:
     if body_data == InternalJobStatusEnum.cancelled:
         return storage_socket.internal_jobs.cancel(job_id=job_id)
     else:
@@ -35,7 +36,7 @@ def cancel_internal_job_v1(job_id: int, body_data: InternalJobStatusEnum):
 @api_v1.route("/internal_jobs/query", methods=["POST"])
 @check_permissions("internal_jobs", "read")
 @serialization()
-def query_internal_jobs_v1(body_data: InternalJobQueryFilters):
+def query_internal_jobs_v1(body_data: InternalJobQueryFilters) -> list[dict[str, Any]]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_internal_jobs
     body_data.limit = calculate_limit(max_limit, body_data.limit)
     return storage_socket.internal_jobs.query(body_data)

--- a/qcfractal/qcfractal/components/managers/routes.py
+++ b/qcfractal/qcfractal/components/managers/routes.py
@@ -1,3 +1,4 @@
+from typing import Any
 from flask import current_app
 
 from qcfractal.flask_app import storage_socket
@@ -24,7 +25,7 @@ from qcportal.utils import calculate_limit
 @compute_v1.route("/managers", methods=["POST"])
 @check_permissions("managers", "add")
 @serialization()
-def activate_manager_v1(body_data: ManagerActivationBody):
+def activate_manager_v1(body_data: ManagerActivationBody) -> int:
     return storage_socket.managers.activate(
         name_data=body_data.name_data,
         manager_version=body_data.manager_version,
@@ -37,7 +38,7 @@ def activate_manager_v1(body_data: ManagerActivationBody):
 @compute_v1.route("/managers/<string:name>", methods=["PATCH"])
 @check_permissions("managers", "modify")
 @serialization()
-def update_manager_v1(name: str, body_data: ManagerUpdateBody):
+def update_manager_v1(name: str, body_data: ManagerUpdateBody) -> None:
     # This endpoint is used for heartbeats and deactivation
 
     # Will raise an exception if manager is not active
@@ -62,14 +63,14 @@ def update_manager_v1(name: str, body_data: ManagerUpdateBody):
 @api_v1.route("/managers/<string:name>", methods=["GET"])
 @check_permissions("managers", "read")
 @serialization()
-def get_managers_v1(name: str):
+def get_managers_v1(name: str) -> dict[str, Any] | None:
     return storage_socket.managers.get([name])[0]
 
 
 @api_v1.route("/managers/bulkGet", methods=["POST"])
 @check_permissions("managers", "read")
 @serialization()
-def bulk_get_managers_v1(body_data: CommonBulkGetNamesBody):
+def bulk_get_managers_v1(body_data: CommonBulkGetNamesBody) -> list[dict[str, Any] | None]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_managers
     if len(body_data.names) > limit:
         raise LimitExceededError(f"Cannot get {len(body_data.names)} manager records - limit is {limit}")
@@ -80,14 +81,14 @@ def bulk_get_managers_v1(body_data: CommonBulkGetNamesBody):
 @api_v1.route("/managers/<string:name>/log", methods=["GET"])
 @check_permissions("managers", "read")
 @serialization()
-def get_manager_log_v1(name: str):
+def get_manager_log_v1(name: str) -> list[dict[str, Any]]:
     return storage_socket.managers.get_log(name)
 
 
 @api_v1.route("/managers/query", methods=["POST"])
 @check_permissions("managers", "read")
 @serialization()
-def query_managers_v1(body_data: ManagerQueryFilters):
+def query_managers_v1(body_data: ManagerQueryFilters) -> list[dict[str, Any]]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_managers
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 
@@ -97,5 +98,5 @@ def query_managers_v1(body_data: ManagerQueryFilters):
 @api_v1.route("/managers/queryActive", methods=["POST"])
 @check_permissions("managers", "read")
 @serialization()
-def query_active_managers_v1(body_data: ManagerQueryAvailableFilters):
+def query_active_managers_v1(body_data: ManagerQueryAvailableFilters) -> list[str]:
     return storage_socket.managers.query_active(body_data.compute_tag, body_data.programs)

--- a/qcfractal/qcfractal/components/manybody/routes.py
+++ b/qcfractal/qcfractal/components/manybody/routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any
 
 from flask import current_app, g
 
@@ -6,6 +6,7 @@ from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import InsertMetadata
 from qcportal.manybody import (
     ManybodyDatasetSpecification,
     ManybodyDatasetNewEntry,
@@ -23,7 +24,7 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/records/manybody/bulkCreate", methods=["POST"])
 @check_permissions("records", "add")
 @serialization()
-def add_manybody_records_v1(body_data: ManybodyAddBody):
+def add_manybody_records_v1(body_data: ManybodyAddBody) -> tuple[InsertMetadata, list[int | None]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.add_records
     if len(body_data.initial_molecules) > limit:
         raise LimitExceededError(f"Cannot add {len(body_data.initial_molecules)} manybody records - limit is {limit}")
@@ -41,14 +42,14 @@ def add_manybody_records_v1(body_data: ManybodyAddBody):
 @api_v1.route("/records/manybody/<int:record_id>/clusters", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_manybody_clusters_v1(record_id: int):
+def get_manybody_clusters_v1(record_id: int) -> list[dict[str, Any]]:
     return storage_socket.records.manybody.get_clusters(record_id)
 
 
 @api_v1.route("/records/manybody/query", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def query_manybody_v1(body_data: ManybodyQueryFilters):
+def query_manybody_v1(body_data: ManybodyQueryFilters) -> list[int]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 
@@ -63,19 +64,21 @@ def query_manybody_v1(body_data: ManybodyQueryFilters):
 @api_v1.route("/datasets/manybody/<int:dataset_id>/specifications", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_manybody_dataset_specifications_v1(dataset_id: int, body_data: List[ManybodyDatasetSpecification]):
+def add_manybody_dataset_specifications_v1(
+    dataset_id: int, body_data: list[ManybodyDatasetSpecification]
+) -> InsertMetadata:
     return storage_socket.datasets.manybody.add_specifications(dataset_id, body_data)
 
 
 @api_v1.route("/datasets/manybody/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_manybody_dataset_entries_v1(dataset_id: int, body_data: List[ManybodyDatasetNewEntry]):
+def add_manybody_dataset_entries_v1(dataset_id: int, body_data: list[ManybodyDatasetNewEntry]) -> InsertMetadata:
     return storage_socket.datasets.manybody.add_entries(dataset_id, new_entries=body_data)
 
 
 @api_v1.route("/datasets/manybody/<int:dataset_id>/background_add_entries", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def background_add_manybody_dataset_entries_v1(dataset_id: int, body_data: List[ManybodyDatasetNewEntry]):
+def background_add_manybody_dataset_entries_v1(dataset_id: int, body_data: list[ManybodyDatasetNewEntry]) -> int:
     return storage_socket.datasets.manybody.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/molecules/routes.py
+++ b/qcfractal/qcfractal/components/molecules/routes.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Any
 
 from flask import current_app
 
@@ -7,6 +7,7 @@ from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, allow_uploads, serialization
 from qcportal.base_models import CommonBulkGetBody, ProjURLParameters
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import InsertMetadata, DeleteMetadata, UpdateMetadata
 from qcportal.molecules import Molecule, MoleculeQueryFilters, MoleculeModifyBody, MoleculeUploadOptions
 from qcportal.utils import calculate_limit
 
@@ -14,14 +15,14 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/molecules/<int:molecule_id>", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_molecules_v1(molecule_id: int, url_params: ProjURLParameters):
+def get_molecules_v1(molecule_id: int, url_params: ProjURLParameters) -> dict[str, Any] | None:
     return storage_socket.molecules.get([molecule_id], url_params.include, url_params.exclude)[0]
 
 
 @api_v1.route("/molecules/bulkGet", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def bulk_get_molecules_v1(body_data: CommonBulkGetBody):
+def bulk_get_molecules_v1(body_data: CommonBulkGetBody) -> list[dict[str, Any] | None]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_molecules
     if len(body_data.ids) > limit:
         raise LimitExceededError(f"Cannot get {len(body_data.ids)} molecule records - limit is {limit}")
@@ -34,21 +35,21 @@ def bulk_get_molecules_v1(body_data: CommonBulkGetBody):
 @api_v1.route("/molecules/<int:molecule_id>", methods=["DELETE"])
 @check_permissions("records", "delete")
 @serialization()
-def delete_molecules_v1(molecule_id: int):
+def delete_molecules_v1(molecule_id: int) -> DeleteMetadata:
     return storage_socket.molecules.delete([molecule_id])
 
 
 @api_v1.route("/molecules/bulkDelete", methods=["POST"])
 @check_permissions("records", "delete")
 @serialization()
-def bulk_delete_molecules_v1(body_data: List[int]):
+def bulk_delete_molecules_v1(body_data: list[int]) -> DeleteMetadata:
     return storage_socket.molecules.delete(body_data)
 
 
 @api_v1.route("/molecules/<int:molecule_id>", methods=["PATCH"])
 @check_permissions("records", "modify")
 @serialization()
-def modify_molecules_v1(molecule_id: int, body_data: MoleculeModifyBody):
+def modify_molecules_v1(molecule_id: int, body_data: MoleculeModifyBody) -> UpdateMetadata:
     return storage_socket.molecules.modify(
         molecule_id=molecule_id,
         name=body_data.name,
@@ -61,7 +62,7 @@ def modify_molecules_v1(molecule_id: int, body_data: MoleculeModifyBody):
 @api_v1.route("/molecules/bulkCreate", methods=["POST"])
 @check_permissions("records", "add")
 @serialization()
-def add_molecules_v1(body_data: List[Molecule]):
+def add_molecules_v1(body_data: list[Molecule]) -> tuple[InsertMetadata, list[int]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.add_molecules
     if len(body_data) > limit:
         raise LimitExceededError(f"Cannot add {len(body_data)} molecule records - limit is {limit}")
@@ -86,14 +87,16 @@ allowed_extensions = [
 @check_permissions("records", "add")
 @allow_uploads(allowed_extensions)
 @serialization()
-def add_molecules_from_files_v1(body_data: MoleculeUploadOptions, files: List[Tuple[str, str]]):
+def add_molecules_from_files_v1(
+    body_data: MoleculeUploadOptions, files: list[tuple[str, str]]
+) -> tuple[dict[str, list[tuple[str, int]]], list[str]]:
     return storage_socket.molecules.add_from_files(files, body_data)
 
 
 @api_v1.route("/molecules/query", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def query_molecules_v1(body_data: MoleculeQueryFilters):
+def query_molecules_v1(body_data: MoleculeQueryFilters) -> list[int]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_molecules
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 

--- a/qcfractal/qcfractal/components/neb/routes.py
+++ b/qcfractal/qcfractal/components/neb/routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any
 
 from flask import current_app, g
 
@@ -6,6 +6,7 @@ from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import InsertMetadata
 from qcportal.neb import NEBDatasetSpecification, NEBDatasetNewEntry, NEBAddBody, NEBQueryFilters
 from qcportal.utils import calculate_limit
 
@@ -18,7 +19,7 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/records/neb/bulkCreate", methods=["POST"])
 @check_permissions("records", "add")
 @serialization()
-def add_neb_records_v1(body_data: NEBAddBody):
+def add_neb_records_v1(body_data: NEBAddBody) -> tuple[InsertMetadata, list[int | None]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.add_records
     if len(body_data.initial_chains) > limit:
         raise LimitExceededError(f"Cannot add {len(body_data.initial_chains)} neb records - limit is {limit}")
@@ -36,35 +37,35 @@ def add_neb_records_v1(body_data: NEBAddBody):
 @api_v1.route("/records/neb/<int:record_id>/neb_result", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_neb_result_v1(record_id: int):
+def get_neb_result_v1(record_id: int) -> dict[str, Any] | None:
     return storage_socket.records.neb.get_neb_result(record_id)
 
 
 @api_v1.route("/records/neb/<int:record_id>/singlepoints", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_neb_singlepoints_v1(record_id: int):
+def get_neb_singlepoints_v1(record_id: int) -> list[dict[str, Any]]:
     return storage_socket.records.neb.get_singlepoints(record_id)
 
 
 @api_v1.route("/records/neb/<int:record_id>/optimizations", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_neb_optimizations_v1(record_id: int):
+def get_neb_optimizations_v1(record_id: int) -> list[dict[str, Any]]:
     return storage_socket.records.neb.get_optimizations(record_id)
 
 
 @api_v1.route("/records/neb/<int:record_id>/initial_chain", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_neb_initial_chain_molecule_ids_v1(record_id: int):
+def get_neb_initial_chain_molecule_ids_v1(record_id: int) -> list[int]:
     return storage_socket.records.neb.get_initial_molecules_ids(record_id)
 
 
 @api_v1.route("/records/neb/query", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def query_neb_v1(body_data: NEBQueryFilters):
+def query_neb_v1(body_data: NEBQueryFilters) -> list[int]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 
@@ -79,19 +80,19 @@ def query_neb_v1(body_data: NEBQueryFilters):
 @api_v1.route("/datasets/neb/<int:dataset_id>/specifications", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_neb_dataset_specifications_v1(dataset_id: int, body_data: List[NEBDatasetSpecification]):
+def add_neb_dataset_specifications_v1(dataset_id: int, body_data: list[NEBDatasetSpecification]) -> InsertMetadata:
     return storage_socket.datasets.neb.add_specifications(dataset_id, body_data)
 
 
 @api_v1.route("/datasets/neb/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_neb_dataset_entries_v1(dataset_id: int, body_data: List[NEBDatasetNewEntry]):
+def add_neb_dataset_entries_v1(dataset_id: int, body_data: list[NEBDatasetNewEntry]) -> InsertMetadata:
     return storage_socket.datasets.neb.add_entries(dataset_id, new_entries=body_data)
 
 
 @api_v1.route("/datasets/neb/<int:dataset_id>/background_add_entries", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def background_add_neb_dataset_entries_v1(dataset_id: int, body_data: List[NEBDatasetNewEntry]):
+def background_add_neb_dataset_entries_v1(dataset_id: int, body_data: list[NEBDatasetNewEntry]) -> int:
     return storage_socket.datasets.neb.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/optimization/routes.py
+++ b/qcfractal/qcfractal/components/optimization/routes.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from flask import current_app, g
 
@@ -6,6 +5,7 @@ from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import InsertMetadata
 from qcportal.optimization import (
     OptimizationDatasetSpecification,
     OptimizationDatasetNewEntry,
@@ -23,7 +23,7 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/records/optimization/bulkCreate", methods=["POST"])
 @check_permissions("records", "add")
 @serialization()
-def add_optimization_records_v1(body_data: OptimizationAddBody):
+def add_optimization_records_v1(body_data: OptimizationAddBody) -> tuple[InsertMetadata, list[int | None]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.add_records
     if len(body_data.initial_molecules) > limit:
         raise LimitExceededError(
@@ -43,14 +43,14 @@ def add_optimization_records_v1(body_data: OptimizationAddBody):
 @api_v1.route("/records/optimization/<int:record_id>/trajectory", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_optimization_trajectory_ids_v1(record_id: int):
+def get_optimization_trajectory_ids_v1(record_id: int) -> list[int]:
     return storage_socket.records.optimization.get_trajectory_ids(record_id)
 
 
 @api_v1.route("/records/optimization/query", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def query_optimization_v1(body_data: OptimizationQueryFilters):
+def query_optimization_v1(body_data: OptimizationQueryFilters) -> list[int]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 
@@ -65,19 +65,25 @@ def query_optimization_v1(body_data: OptimizationQueryFilters):
 @api_v1.route("/datasets/optimization/<int:dataset_id>/specifications", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_optimization_dataset_specifications_v1(dataset_id: int, body_data: List[OptimizationDatasetSpecification]):
+def add_optimization_dataset_specifications_v1(
+    dataset_id: int, body_data: list[OptimizationDatasetSpecification]
+) -> InsertMetadata:
     return storage_socket.datasets.optimization.add_specifications(dataset_id, body_data)
 
 
 @api_v1.route("/datasets/optimization/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_optimization_dataset_entries_v1(dataset_id: int, body_data: List[OptimizationDatasetNewEntry]):
+def add_optimization_dataset_entries_v1(
+    dataset_id: int, body_data: list[OptimizationDatasetNewEntry]
+) -> InsertMetadata:
     return storage_socket.datasets.optimization.add_entries(dataset_id, new_entries=body_data)
 
 
 @api_v1.route("/datasets/optimization/<int:dataset_id>/background_add_entries", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def background_add_optimization_dataset_entries_v1(dataset_id: int, body_data: List[OptimizationDatasetNewEntry]):
+def background_add_optimization_dataset_entries_v1(
+    dataset_id: int, body_data: list[OptimizationDatasetNewEntry]
+) -> int:
     return storage_socket.datasets.optimization.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/project_routes.py
+++ b/qcfractal/qcfractal/components/project_routes.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from flask import g
 
 from qcfractal.flask_app import storage_socket
@@ -5,6 +7,7 @@ from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization, allow_uploads
 from qcportal.base_models import ProjURLParameters
 from qcportal.exceptions import SingleFileRequiredError
+from qcportal.metadata_models import InsertCountsMetadata
 from qcportal.project_models import (
     ProjectAddBody,
     ProjectQueryModel,
@@ -20,26 +23,27 @@ from qcportal.project_models import (
     ProjectUnlinkRecordsBody,
     ProjectAttachmentUploadBody,
 )
+from qcportal.record_models import RecordStatusEnum
 
 
 @api_v1.route("/projects", methods=["GET"])
 @check_permissions("projects", "read")
 @serialization()
-def list_project_v1():
+def list_project_v1() -> list[dict[str, Any]]:
     return storage_socket.projects.list()
 
 
 @api_v1.route("/projects/<int:project_id>", methods=["GET"])
 @check_permissions("projects", "read")
 @serialization()
-def get_project_v1(project_id: int, url_params: ProjURLParameters):
+def get_project_v1(project_id: int, url_params: ProjURLParameters) -> dict[str, Any] | None:
     return storage_socket.projects.get(project_id, url_params.include, url_params.exclude)
 
 
 @api_v1.route("/projects/query", methods=["POST"])
 @check_permissions("projects", "read")
 @serialization()
-def query_general_project_v1(body_data: ProjectQueryModel):
+def query_general_project_v1(body_data: ProjectQueryModel) -> dict[str, Any] | None:
     with storage_socket.session_scope(True) as session:
         project_id = storage_socket.projects.lookup_id(body_data.project_name, session=session)
         return storage_socket.projects.get(project_id, body_data.include, body_data.exclude, session=session)
@@ -47,21 +51,21 @@ def query_general_project_v1(body_data: ProjectQueryModel):
 @api_v1.route("/projects/queryrecords", methods=["POST"])
 @check_permissions("projects", "read")
 @serialization()
-def query_project_records_v1(body_data: ProjectQueryRecords):
+def query_project_records_v1(body_data: ProjectQueryRecords) -> list[dict[str, Any]]:
     return storage_socket.projects.query_project_records(record_id=body_data.record_id)
 
 
 @api_v1.route("/projects/querydatasets", methods=["POST"])
 @check_permissions("projects", "read")
 @serialization()
-def query_project_datasets_v1(body_data: ProjectQueryDatasets):
+def query_project_datasets_v1(body_data: ProjectQueryDatasets) -> list[dict[str, Any]]:
     return storage_socket.projects.query_project_datasets(dataset_id=body_data.dataset_id)
 
 
 @api_v1.route("/projects/<int:project_id>", methods=["DELETE"])
 @check_permissions("projects", "delete")
 @serialization()
-def delete_project_v1(project_id: int, url_params: ProjectDeleteParams):
+def delete_project_v1(project_id: int, url_params: ProjectDeleteParams) -> None:
     return storage_socket.projects.delete_project(
         project_id,
         delete_records=url_params.delete_records,
@@ -76,7 +80,7 @@ def delete_project_v1(project_id: int, url_params: ProjectDeleteParams):
 @api_v1.route("/projects", methods=["POST"])
 @check_permissions("projects", "add")
 @serialization()
-def add_project_v1(body_data: ProjectAddBody):
+def add_project_v1(body_data: ProjectAddBody) -> int:
     return storage_socket.projects.add(
         name=body_data.name,
         description=body_data.description,
@@ -96,21 +100,21 @@ def add_project_v1(body_data: ProjectAddBody):
 @api_v1.route("/projects/<int:project_id>/status", methods=["GET"])
 @check_permissions("projects", "read")
 @serialization()
-def get_project_status_v1(project_id: int):
+def get_project_status_v1(project_id: int) -> dict[str, dict[RecordStatusEnum, int]]:
     return storage_socket.projects.status(project_id)
 
 
 @api_v1.route("/projects/<int:project_id>/record_metadata", methods=["GET"])
 @check_permissions("projects", "read")
 @serialization()
-def get_project_record_metadata_v1(project_id: int):
+def get_project_record_metadata_v1(project_id: int) -> list[dict[str, Any]]:
     return storage_socket.projects.get_record_metadata(project_id)
 
 
 @api_v1.route("/projects/<int:project_id>/dataset_metadata", methods=["GET"])
 @check_permissions("projects", "read")
 @serialization()
-def get_project_dataset_metadata_v1(project_id: int):
+def get_project_dataset_metadata_v1(project_id: int) -> list[dict[str, Any]]:
     return storage_socket.projects.get_dataset_metadata(project_id)
 
 
@@ -120,7 +124,7 @@ def get_project_dataset_metadata_v1(project_id: int):
 @api_v1.route("/projects/<int:project_id>/datasets", methods=["POST"])
 @check_permissions("projects", "modify")
 @serialization()
-def add_project_dataset_v1(project_id: int, body_data: ProjectDatasetAddBody):
+def add_project_dataset_v1(project_id: int, body_data: ProjectDatasetAddBody) -> int:
     return storage_socket.projects.add_dataset(
         project_id=project_id,
         dataset_type=body_data.dataset_type,
@@ -140,7 +144,7 @@ def add_project_dataset_v1(project_id: int, body_data: ProjectDatasetAddBody):
 @api_v1.route("/projects/<int:project_id>/datasets/link", methods=["POST"])
 @check_permissions("projects", "modify")
 @serialization()
-def project_link_dataset_v1(project_id: int, body_data: ProjectLinkDatasetBody):
+def project_link_dataset_v1(project_id: int, body_data: ProjectLinkDatasetBody) -> None:
     return storage_socket.projects.link_dataset(
         project_id=project_id,
         dataset_id=body_data.dataset_id,
@@ -154,7 +158,7 @@ def project_link_dataset_v1(project_id: int, body_data: ProjectLinkDatasetBody):
 @api_v1.route("/projects/<int:project_id>/datasets/unlink", methods=["POST"])
 @check_permissions("projects", "modify")
 @serialization()
-def project_unlink_datasets_v1(project_id: int, body_data: ProjectUnlinkDatasetsBody):
+def project_unlink_datasets_v1(project_id: int, body_data: ProjectUnlinkDatasetsBody) -> None:
     return storage_socket.projects.unlink_datasets(
         project_id=project_id,
         dataset_ids=body_data.dataset_ids,
@@ -166,7 +170,7 @@ def project_unlink_datasets_v1(project_id: int, body_data: ProjectUnlinkDatasets
 @api_v1.route("/projects/<int:project_id>/datasets/<int:dataset_id>", methods=["GET"])
 @check_permissions("projects", "read")
 @serialization()
-def get_project_dataset_v1(project_id: int, dataset_id: int):
+def get_project_dataset_v1(project_id: int, dataset_id: int) -> dict[str, Any]:
     return storage_socket.projects.get_dataset(project_id, dataset_id)
 
 
@@ -176,7 +180,7 @@ def get_project_dataset_v1(project_id: int, dataset_id: int):
 @api_v1.route("/projects/<int:project_id>/records", methods=["POST"])
 @check_permissions("projects", "modify")
 @serialization()
-def add_project_record_v1(project_id: int, body_data: ProjectRecordAddBody):
+def add_project_record_v1(project_id: int, body_data: ProjectRecordAddBody) -> tuple[InsertCountsMetadata, int]:
     return storage_socket.projects.add_record(
         project_id,
         name=body_data.name,
@@ -193,7 +197,7 @@ def add_project_record_v1(project_id: int, body_data: ProjectRecordAddBody):
 @api_v1.route("/projects/<int:project_id>/records/import", methods=["POST"])
 @check_permissions("projects", "modify")
 @serialization()
-def import_project_record_v1(project_id: int, body_data: ProjectRecordImportBody):
+def import_project_record_v1(project_id: int, body_data: ProjectRecordImportBody) -> int:
     return storage_socket.projects.import_record(
         project_id,
         name=body_data.name,
@@ -207,7 +211,7 @@ def import_project_record_v1(project_id: int, body_data: ProjectRecordImportBody
 @api_v1.route("/projects/<int:project_id>/records/link", methods=["POST"])
 @check_permissions("projects", "modify")
 @serialization()
-def project_link_record_v1(project_id: int, body_data: ProjectLinkRecordBody):
+def project_link_record_v1(project_id: int, body_data: ProjectLinkRecordBody) -> None:
     return storage_socket.projects.link_record(
         project_id=project_id,
         record_id=body_data.record_id,
@@ -220,7 +224,7 @@ def project_link_record_v1(project_id: int, body_data: ProjectLinkRecordBody):
 @api_v1.route("/projects/<int:project_id>/records/unlink", methods=["POST"])
 @check_permissions("projects", "modify")
 @serialization()
-def project_unlink_records_v1(project_id: int, body_data: ProjectUnlinkRecordsBody):
+def project_unlink_records_v1(project_id: int, body_data: ProjectUnlinkRecordsBody) -> None:
     return storage_socket.projects.unlink_records(
         project_id=project_id,
         record_ids=body_data.record_ids,
@@ -231,7 +235,7 @@ def project_unlink_records_v1(project_id: int, body_data: ProjectUnlinkRecordsBo
 @api_v1.route("/projects/<int:project_id>/records/<int:record_id>", methods=["GET"])
 @check_permissions("projects", "read")
 @serialization()
-def get_project_record_v1(project_id: int, record_id: int, url_params: ProjURLParameters):
+def get_project_record_v1(project_id: int, record_id: int, url_params: ProjURLParameters) -> dict[str, Any]:
     return storage_socket.projects.get_record(
         project_id, record_id, include=url_params.include, exclude=url_params.exclude
     )
@@ -254,14 +258,14 @@ def get_project_record_v1(project_id: int, record_id: int, url_params: ProjURLPa
 @api_v1.route("/projects/<int:project_id>/attachments", methods=["GET"])
 @check_permissions("projects", "read")
 @serialization()
-def fetch_project_attachments_v1(project_id: int):
+def fetch_project_attachments_v1(project_id: int) -> list[dict[str, Any]]:
     return storage_socket.projects.get_attachments(project_id)
 
 
 @api_v1.route("/projects/<int:project_id>/attachments/<int:attachment_id>", methods=["DELETE"])
 @check_permissions("projects", "modify")
 @serialization()
-def delete_project_attachment_v1(project_id: int, attachment_id: int):
+def delete_project_attachment_v1(project_id: int, attachment_id: int) -> None:
     return storage_socket.projects.delete_attachment(project_id, attachment_id)
 
 
@@ -269,7 +273,7 @@ def delete_project_attachment_v1(project_id: int, attachment_id: int):
 @check_permissions("projects", "modify")
 @serialization()
 @allow_uploads(allowed_file_extensions=None)
-def upload_project_attachment_v1(project_id: int, body_data: ProjectAttachmentUploadBody, files: list[tuple[str, str]]):
+def upload_project_attachment_v1(project_id: int, body_data: ProjectAttachmentUploadBody, files: list[tuple[str, str]]) -> int:
     if len(files) != 1:
         raise SingleFileRequiredError("Exactly one file must be uploaded for project attachments")
 

--- a/qcfractal/qcfractal/components/reaction/routes.py
+++ b/qcfractal/qcfractal/components/reaction/routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any
 
 from flask import current_app, g
 
@@ -6,6 +6,7 @@ from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import InsertMetadata
 from qcportal.reaction import (
     ReactionDatasetSpecification,
     ReactionDatasetNewEntry,
@@ -23,7 +24,7 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/records/reaction/bulkCreate", methods=["POST"])
 @check_permissions("records", "add")
 @serialization()
-def add_reaction_records_v1(body_data: ReactionAddBody):
+def add_reaction_records_v1(body_data: ReactionAddBody) -> tuple[InsertMetadata, list[int | None]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.add_records
     if len(body_data.stoichiometries) > limit:
         raise LimitExceededError(f"Cannot add {len(body_data.stoichiometries)} reaction records - limit is {limit}")
@@ -41,14 +42,14 @@ def add_reaction_records_v1(body_data: ReactionAddBody):
 @api_v1.route("/records/reaction/<int:record_id>/components", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_reaction_components_v1(record_id: int):
+def get_reaction_components_v1(record_id: int) -> list[dict[str, Any]]:
     return storage_socket.records.reaction.get_components(record_id)
 
 
 @api_v1.route("/records/reaction/query", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def query_reaction_v1(body_data: ReactionQueryFilters):
+def query_reaction_v1(body_data: ReactionQueryFilters) -> list[int]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 
@@ -63,19 +64,21 @@ def query_reaction_v1(body_data: ReactionQueryFilters):
 @api_v1.route("/datasets/reaction/<int:dataset_id>/specifications", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_reaction_dataset_specifications_v1(dataset_id: int, body_data: List[ReactionDatasetSpecification]):
+def add_reaction_dataset_specifications_v1(
+    dataset_id: int, body_data: list[ReactionDatasetSpecification]
+) -> InsertMetadata:
     return storage_socket.datasets.reaction.add_specifications(dataset_id, body_data)
 
 
 @api_v1.route("/datasets/reaction/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_reaction_dataset_entries_v1(dataset_id: int, body_data: List[ReactionDatasetNewEntry]):
+def add_reaction_dataset_entries_v1(dataset_id: int, body_data: list[ReactionDatasetNewEntry]) -> InsertMetadata:
     return storage_socket.datasets.reaction.add_entries(dataset_id, new_entries=body_data)
 
 
 @api_v1.route("/datasets/reaction/<int:dataset_id>/background_add_entries", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def background_add_reaction_dataset_entries_v1(dataset_id: int, body_data: List[ReactionDatasetNewEntry]):
+def background_add_reaction_dataset_entries_v1(dataset_id: int, body_data: list[ReactionDatasetNewEntry]) -> int:
     return storage_socket.datasets.reaction.background_add_entries(dataset_id, new_entries=body_data)

--- a/qcfractal/qcfractal/components/record_routes.py
+++ b/qcfractal/qcfractal/components/record_routes.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any
 
 from flask import current_app, g
 
@@ -7,11 +7,14 @@ from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.base_models import ProjURLParameters, CommonBulkGetBody
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import DeleteMetadata, UpdateMetadata
+from qcportal.compression import CompressionEnum
 from qcportal.record_models import (
     RecordModifyBody,
     RecordQueryFilters,
     RecordDeleteBody,
     RecordRevertBody,
+    RecordStatusEnum,
 )
 
 
@@ -25,21 +28,21 @@ from qcportal.record_models import (
 @api_v1.route("/records/query", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def query_records_v1(body_data: RecordQueryFilters):
+def query_records_v1(body_data: RecordQueryFilters) -> list[int]:
     return storage_socket.records.query(body_data)
 
 
 @api_v1.route("/records/revert", methods=["POST"])
 @check_permissions("records", "modify")
 @serialization()
-def revert_records_v1(body_data: RecordRevertBody):
+def revert_records_v1(body_data: RecordRevertBody) -> UpdateMetadata:
     return storage_socket.records.revert_generic(body_data.record_ids, body_data.revert_status)
 
 
 @api_v1.route("/records", methods=["PATCH"])
 @check_permissions("records", "modify")
 @serialization()
-def modify_records_v1(body_data: RecordModifyBody):
+def modify_records_v1(body_data: RecordModifyBody) -> UpdateMetadata:
     return storage_socket.records.modify_generic(
         body_data.record_ids,
         g.user_id,
@@ -53,14 +56,14 @@ def modify_records_v1(body_data: RecordModifyBody):
 @api_v1.route("/records/<int:record_id>", methods=["DELETE"])
 @check_permissions("records", "delete")
 @serialization()
-def delete_records_v1(record_id: int):
+def delete_records_v1(record_id: int) -> DeleteMetadata:
     return storage_socket.records.delete([record_id], soft_delete=True, delete_children=True)
 
 
 @api_v1.route("/records/bulkDelete", methods=["POST"])
 @check_permissions("records", "delete")
 @serialization()
-def bulk_delete_records_v1(body_data: RecordDeleteBody):
+def bulk_delete_records_v1(body_data: RecordDeleteBody) -> DeleteMetadata:
     return storage_socket.records.delete(
         body_data.record_ids, soft_delete=body_data.soft_delete, delete_children=body_data.delete_children
     )
@@ -69,7 +72,7 @@ def bulk_delete_records_v1(body_data: RecordDeleteBody):
 @api_v1.route("/records/<int:record_id>/waiting_reason", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_waiting_reason_v1(record_id: int):
+def get_record_waiting_reason_v1(record_id: int) -> dict[str, Any]:
     return storage_socket.records.get_waiting_reason(record_id)
 
 
@@ -83,7 +86,7 @@ def get_record_waiting_reason_v1(record_id: int):
 @api_v1.route("/records/<int:record_id>", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_records_v1(record_id: int, url_params: ProjURLParameters, record_type: Optional[str] = None):
+def get_records_v1(record_id: int, url_params: ProjURLParameters, record_type: str | None = None) -> dict[str, Any]:
     if record_type is None:
         return storage_socket.records.get([record_id], url_params.include, url_params.exclude)[0]
     else:
@@ -95,7 +98,7 @@ def get_records_v1(record_id: int, url_params: ProjURLParameters, record_type: O
 @api_v1.route("/records/bulkGet", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def bulk_get_records_v1(body_data: CommonBulkGetBody, record_type: Optional[str] = None):
+def bulk_get_records_v1(body_data: CommonBulkGetBody, record_type: str | None = None) -> list[dict[str, Any] | None]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
     if len(body_data.ids) > limit:
         raise LimitExceededError(f"Cannot get {len(body_data.ids)} records - limit is {limit}")
@@ -113,7 +116,7 @@ def bulk_get_records_v1(body_data: CommonBulkGetBody, record_type: Optional[str]
 @api_v1.route("/records/<int:record_id>", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_general_records_v1(record_id: int, url_params: ProjURLParameters, record_type: Optional[str] = None):
+def get_general_records_v1(record_id: int, url_params: ProjURLParameters, record_type: str | None = None) -> dict[str, Any]:
     # Getting is handled a little differently. If no type specified, use the more generic version
     # in the upper-level record socket
     if record_type is None:
@@ -136,7 +139,7 @@ def get_general_records_v1(record_id: int, url_params: ProjURLParameters, record
 @api_v1.route("/records/<string:record_type>/<int:record_id>/comments", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_comments_v1(record_id: int, record_type: str):
+def get_record_comments_v1(record_id: int, record_type: str) -> list[dict[str, Any]]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_comments(record_id)
 
@@ -144,7 +147,7 @@ def get_record_comments_v1(record_id: int, record_type: str):
 @api_v1.route("/records/<string:record_type>/<int:record_id>/task", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_task_v1(record_id: int, record_type: str):
+def get_record_task_v1(record_id: int, record_type: str) -> dict[str, Any] | None:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_task(record_id)
 
@@ -152,7 +155,7 @@ def get_record_task_v1(record_id: int, record_type: str):
 @api_v1.route("/records/<string:record_type>/<int:record_id>/service", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_service_v1(record_id: int, record_type: str):
+def get_record_service_v1(record_id: int, record_type: str) -> dict[str, Any] | None:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_service(record_id)
 
@@ -160,7 +163,7 @@ def get_record_service_v1(record_id: int, record_type: str):
 @api_v1.route("/records/<string:record_type>/<int:record_id>/compute_history", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_history_v1(record_id: int, record_type: str):
+def get_record_history_v1(record_id: int, record_type: str) -> list[dict[str, Any]]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_all_compute_history(record_id)
 
@@ -168,7 +171,7 @@ def get_record_history_v1(record_id: int, record_type: str):
 @api_v1.route("/records/<string:record_type>/<int:record_id>/compute_history/<int:history_id>", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_history_single_v1(record_id: int, history_id: int, record_type: str):
+def get_record_history_single_v1(record_id: int, history_id: int, record_type: str) -> dict[str, Any]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_single_compute_history(record_id, history_id)
 
@@ -176,7 +179,7 @@ def get_record_history_single_v1(record_id: int, history_id: int, record_type: s
 @api_v1.route("/records/<string:record_type>/<int:record_id>/compute_history/<int:history_id>/outputs", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_outputs_v1(record_id: int, history_id: int, record_type: str):
+def get_record_outputs_v1(record_id: int, history_id: int, record_type: str) -> dict[str, dict[str, Any]]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_all_output_metadata(record_id, history_id)
 
@@ -187,7 +190,7 @@ def get_record_outputs_v1(record_id: int, history_id: int, record_type: str):
 )
 @check_permissions("records", "read")
 @serialization()
-def get_record_outputs_single_v1(record_id: int, history_id: int, output_type: str, record_type: str):
+def get_record_outputs_single_v1(record_id: int, history_id: int, output_type: str, record_type: str) -> dict[str, Any]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_single_output_metadata(record_id, history_id, output_type)
 
@@ -198,7 +201,7 @@ def get_record_outputs_single_v1(record_id: int, history_id: int, output_type: s
 )
 @check_permissions("records", "read")
 @serialization()
-def get_record_outputs_data_v1(record_id: int, history_id: int, output_type: str, record_type: str):
+def get_record_outputs_data_v1(record_id: int, history_id: int, output_type: str, record_type: str) -> tuple[bytes, CompressionEnum]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_single_output_rawdata(record_id, history_id, output_type)
 
@@ -209,7 +212,7 @@ def get_record_outputs_data_v1(record_id: int, history_id: int, output_type: str
 )
 @check_permissions("records", "read")
 @serialization()
-def get_record_outputs_uncompressed_data_v1(record_id: int, history_id: int, output_type: str, record_type: str):
+def get_record_outputs_uncompressed_data_v1(record_id: int, history_id: int, output_type: str, record_type: str) -> Any:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_single_output_uncompressed(record_id, history_id, output_type)
 
@@ -217,7 +220,7 @@ def get_record_outputs_uncompressed_data_v1(record_id: int, history_id: int, out
 @api_v1.route("/records/<string:record_type>/<int:record_id>/native_files", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_native_files_v1(record_id: int, record_type: str):
+def get_record_native_files_v1(record_id: int, record_type: str) -> dict[str, dict[str, Any]]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_all_native_files_metadata(record_id)
 
@@ -225,7 +228,7 @@ def get_record_native_files_v1(record_id: int, record_type: str):
 @api_v1.route("/records/<string:record_type>/<int:record_id>/native_files/<string:name>", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_native_file_single_v1(record_id: int, name: str, record_type: str):
+def get_record_native_file_single_v1(record_id: int, name: str, record_type: str) -> dict[str, Any]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_single_native_file_metadata(record_id, name)
 
@@ -233,7 +236,7 @@ def get_record_native_file_single_v1(record_id: int, name: str, record_type: str
 @api_v1.route("/records/<string:record_type>/<int:record_id>/native_files/<string:name>/data", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_native_file_data_v1(record_id: int, name: str, record_type: str):
+def get_record_native_file_data_v1(record_id: int, name: str, record_type: str) -> tuple[bytes, CompressionEnum]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_single_native_file_rawdata(record_id, name)
 
@@ -243,7 +246,7 @@ def get_record_native_file_data_v1(record_id: int, name: str, record_type: str):
 )
 @check_permissions("records", "read")
 @serialization()
-def get_record_native_file_uncompressed_data_v1(record_id: int, name: str, record_type: str):
+def get_record_native_file_uncompressed_data_v1(record_id: int, name: str, record_type: str) -> Any:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_single_native_file_uncompressed(record_id, name)
 
@@ -251,7 +254,7 @@ def get_record_native_file_uncompressed_data_v1(record_id: int, name: str, recor
 @api_v1.route("/records/<string:record_type>/<int:record_id>/children_status", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_children_status_v1(record_id: int, record_type: str):
+def get_record_children_status_v1(record_id: int, record_type: str) -> dict[RecordStatusEnum, int]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_children_status(record_id)
 
@@ -259,6 +262,6 @@ def get_record_children_status_v1(record_id: int, record_type: str):
 @api_v1.route("/records/<string:record_type>/<int:record_id>/children_errors", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_record_children_errors_v1(record_id: int, record_type: str):
+def get_record_children_errors_v1(record_id: int, record_type: str) -> list[int]:
     record_socket = storage_socket.records.get_socket(record_type)
     return record_socket.get_children_errors(record_id)

--- a/qcfractal/qcfractal/components/serverinfo/routes.py
+++ b/qcfractal/qcfractal/components/serverinfo/routes.py
@@ -1,3 +1,4 @@
+from typing import Any
 from flask import current_app
 
 from qcfractal.flask_app import storage_socket
@@ -16,28 +17,28 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/information", methods=["GET"])
 @check_permissions("information", "read")
 @serialization()
-def get_information():
+def get_information() -> dict[str, Any]:
     return get_public_server_information()
 
 
 @api_v1.route("/motd", methods=["GET"])
 @check_permissions("information", "read")
 @serialization()
-def get_motd():
+def get_motd() -> str:
     return storage_socket.serverinfo.get_motd()
 
 
 @api_v1.route("/motd", methods=["PUT"])
 @check_permissions("information", "modify")
 @serialization()
-def set_motd(body_data: str):
+def set_motd(body_data: str) -> None:
     return storage_socket.serverinfo.set_motd(body_data)
 
 
 @api_v1.route("/access_logs/query", methods=["POST"])
 @check_permissions("access_log", "read")
 @serialization()
-def query_access_log_v1(body_data: AccessLogQueryFilters):
+def query_access_log_v1(body_data: AccessLogQueryFilters) -> list[dict[str, Any]]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_access_logs
     body_data.limit = calculate_limit(max_limit, body_data.limit)
     return storage_socket.serverinfo.query_access_log(body_data)
@@ -46,21 +47,21 @@ def query_access_log_v1(body_data: AccessLogQueryFilters):
 @api_v1.route("/access_logs/bulkDelete", methods=["POST"])
 @check_permissions("access_log", "delete")
 @serialization()
-def delete_access_log_v1(body_data: DeleteBeforeDateBody):
+def delete_access_log_v1(body_data: DeleteBeforeDateBody) -> int:
     return storage_socket.serverinfo.delete_access_logs(before=body_data.before)
 
 
 @api_v1.route("/access_logs/summary", methods=["GET"])
 @check_permissions("access_log", "read")
 @serialization()
-def query_access_summary_v1(url_params: AccessLogSummaryFilters):
+def query_access_summary_v1(url_params: AccessLogSummaryFilters) -> dict[str, Any]:
     return storage_socket.serverinfo.query_access_summary(url_params)
 
 
 @api_v1.route("/server_errors/query", methods=["POST"])
 @check_permissions("server_errors", "read")
 @serialization()
-def query_error_log_v1(body_data: ErrorLogQueryFilters):
+def query_error_log_v1(body_data: ErrorLogQueryFilters) -> list[dict[str, Any]]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_error_logs
     body_data.limit = calculate_limit(max_limit, body_data.limit)
     return storage_socket.serverinfo.query_error_log(body_data)
@@ -69,12 +70,12 @@ def query_error_log_v1(body_data: ErrorLogQueryFilters):
 @api_v1.route("/server_errors/bulkDelete", methods=["POST"])
 @check_permissions("server_errors", "delete")
 @serialization()
-def delete_server_error_log_v1(body_data: DeleteBeforeDateBody):
+def delete_server_error_log_v1(body_data: DeleteBeforeDateBody) -> int:
     return storage_socket.serverinfo.delete_error_logs(before=body_data.before)
 
 
 @api_v1.route("/server_stats", methods=["GET"])
 @check_permissions("information", "read")
 @serialization()
-def get_server_stats_v1():
+def get_server_stats_v1() -> list[dict[str, Any]]:
     return storage_socket.serverinfo.get_server_stats()

--- a/qcfractal/qcfractal/components/singlepoint/routes.py
+++ b/qcfractal/qcfractal/components/singlepoint/routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any
 
 from flask import current_app, g
 
@@ -6,6 +6,8 @@ from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.exceptions import LimitExceededError
+from qcportal.compression import CompressionEnum
+from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.singlepoint import (
     SinglepointDatasetSpecification,
     SinglepointDatasetNewEntry,
@@ -24,7 +26,7 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/records/singlepoint/bulkCreate", methods=["POST"])
 @check_permissions("records", "add")
 @serialization()
-def add_singlepoint_records_v1(body_data: SinglepointAddBody):
+def add_singlepoint_records_v1(body_data: SinglepointAddBody) -> tuple[InsertMetadata, list[int | None]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.add_records
     if len(body_data.molecules) > limit:
         raise LimitExceededError(f"Cannot add {len(body_data.molecules)} singlepoint records - limit is {limit}")
@@ -42,21 +44,21 @@ def add_singlepoint_records_v1(body_data: SinglepointAddBody):
 @api_v1.route("/records/singlepoint/<int:record_id>/wavefunction", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_singlepoint_wavefunction_v1(record_id: int):
+def get_singlepoint_wavefunction_v1(record_id: int) -> dict[str, Any] | None:
     return storage_socket.records.singlepoint.get_wavefunction_metadata(record_id)
 
 
 @api_v1.route("/records/singlepoint/<int:record_id>/wavefunction/data", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_singlepoint_wavefunction_data_v1(record_id: int):
+def get_singlepoint_wavefunction_data_v1(record_id: int) -> tuple[bytes, CompressionEnum]:
     return storage_socket.records.singlepoint.get_wavefunction_rawdata(record_id)
 
 
 @api_v1.route("/records/singlepoint/query", methods=["POST"])
 @check_permissions("records", "read")
 @serialization()
-def query_singlepoint_v1(body_data: SinglepointQueryFilters):
+def query_singlepoint_v1(body_data: SinglepointQueryFilters) -> list[int]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 
@@ -71,28 +73,34 @@ def query_singlepoint_v1(body_data: SinglepointQueryFilters):
 @api_v1.route("/datasets/singlepoint/<int:dataset_id>/specifications", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_singlepoint_dataset_specifications_v1(dataset_id: int, body_data: List[SinglepointDatasetSpecification]):
+def add_singlepoint_dataset_specifications_v1(
+    dataset_id: int, body_data: list[SinglepointDatasetSpecification]
+) -> InsertMetadata:
     return storage_socket.datasets.singlepoint.add_specifications(dataset_id, body_data)
 
 
 @api_v1.route("/datasets/singlepoint/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_singlepoint_dataset_entries_v1(dataset_id: int, body_data: List[SinglepointDatasetNewEntry]):
+def add_singlepoint_dataset_entries_v1(dataset_id: int, body_data: list[SinglepointDatasetNewEntry]) -> InsertMetadata:
     return storage_socket.datasets.singlepoint.add_entries(dataset_id, new_entries=body_data)
 
 
 @api_v1.route("/datasets/singlepoint/<int:dataset_id>/background_add_entries", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def background_add_singlepoint_dataset_entries_v1(dataset_id: int, body_data: List[SinglepointDatasetNewEntry]):
+def background_add_singlepoint_dataset_entries_v1(
+    dataset_id: int, body_data: list[SinglepointDatasetNewEntry]
+) -> int:
     return storage_socket.datasets.singlepoint.background_add_entries(dataset_id, new_entries=body_data)
 
 
 @api_v1.route("/datasets/singlepoint/<int:dataset_id>/entries/addFrom", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_singlepoint_dataset_entries_from_v1(dataset_id: int, body_data: SinglepointDatasetEntriesFrom):
+def add_singlepoint_dataset_entries_from_v1(
+    dataset_id: int, body_data: SinglepointDatasetEntriesFrom
+) -> InsertCountsMetadata:
     return storage_socket.datasets.singlepoint.add_entries_from_ds(
         dataset_id=dataset_id,
         from_dataset_id=body_data.dataset_id,

--- a/qcfractal/qcfractal/components/tasks/routes.py
+++ b/qcfractal/qcfractal/components/tasks/routes.py
@@ -1,9 +1,11 @@
+from typing import Any
 from flask import current_app
 
 from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.compute_v1.blueprint import compute_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import TaskReturnMetadata
 from qcportal.tasks import TaskClaimBody, TaskReturnBody
 from qcportal.utils import calculate_limit
 
@@ -13,7 +15,7 @@ from qcportal.utils import calculate_limit
 @compute_v1.route("/tasks/claim", methods=["POST"])
 @check_permissions("tasks", "claim")
 @serialization()
-def claim_tasks_v1(body_data: TaskClaimBody):
+def claim_tasks_v1(body_data: TaskClaimBody) -> list[dict[str, Any]]:
     """Claims tasks from the task queue"""
 
     # check here, but also in the socket
@@ -30,7 +32,7 @@ def claim_tasks_v1(body_data: TaskClaimBody):
 @compute_v1.route("/tasks/return", methods=["POST"])
 @check_permissions("tasks", "return")
 @serialization()
-def return_tasks_v1(body_data: TaskReturnBody):
+def return_tasks_v1(body_data: TaskReturnBody) -> TaskReturnMetadata:
     """Return finished tasks"""
 
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.manager_tasks_claim

--- a/qcfractal/qcfractal/components/torsiondrive/routes.py
+++ b/qcfractal/qcfractal/components/torsiondrive/routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any
 
 from flask import current_app, g
 
@@ -6,6 +6,7 @@ from qcfractal.flask_app import storage_socket
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcportal.exceptions import LimitExceededError
+from qcportal.metadata_models import InsertMetadata, InsertCountsMetadata
 from qcportal.torsiondrive import (
     TorsiondriveDatasetSpecification,
     TorsiondriveDatasetNewEntry,
@@ -24,7 +25,7 @@ from qcportal.utils import calculate_limit
 @api_v1.route("/records/torsiondrive/bulkCreate", methods=["POST"])
 @check_permissions("records", "add")
 @serialization()
-def add_torsiondrive_records_v1(body_data: TorsiondriveAddBody):
+def add_torsiondrive_records_v1(body_data: TorsiondriveAddBody) -> tuple[InsertMetadata, list[int | None]]:
     limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.add_records
     if len(body_data.initial_molecules) > limit:
         raise LimitExceededError(
@@ -45,28 +46,28 @@ def add_torsiondrive_records_v1(body_data: TorsiondriveAddBody):
 @api_v1.route("/records/torsiondrive/<int:record_id>/optimizations", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_torsiondrive_optimizations_v1(record_id: int):
+def get_torsiondrive_optimizations_v1(record_id: int) -> list[dict[str, Any]]:
     return storage_socket.records.torsiondrive.get_optimizations(record_id)
 
 
 @api_v1.route("/records/torsiondrive/<int:record_id>/minimum_optimizations", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_torsiondrive_minimum_optimizations_v1(record_id: int):
+def get_torsiondrive_minimum_optimizations_v1(record_id: int) -> dict[str, int]:
     return storage_socket.records.torsiondrive.get_minimum_optimizations(record_id)
 
 
 @api_v1.route("/records/torsiondrive/<int:record_id>/initial_molecules", methods=["GET"])
 @check_permissions("records", "read")
 @serialization()
-def get_torsiondrive_initial_molecules_ids_v1(record_id: int):
+def get_torsiondrive_initial_molecules_ids_v1(record_id: int) -> list[int]:
     return storage_socket.records.torsiondrive.get_initial_molecules_ids(record_id)
 
 
 @api_v1.route("/records/torsiondrive/query", methods=["POST"])
 @check_permissions("datasets", "read")
 @serialization()
-def query_torsiondrive_v1(body_data: TorsiondriveQueryFilters):
+def query_torsiondrive_v1(body_data: TorsiondriveQueryFilters) -> list[int]:
     max_limit = current_app.config["QCFRACTAL_CONFIG"].api_limits.get_records
     body_data.limit = calculate_limit(max_limit, body_data.limit)
 
@@ -81,21 +82,27 @@ def query_torsiondrive_v1(body_data: TorsiondriveQueryFilters):
 @api_v1.route("/datasets/torsiondrive/<int:dataset_id>/specifications", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_torsiondrive_dataset_specifications_v1(dataset_id: int, body_data: List[TorsiondriveDatasetSpecification]):
+def add_torsiondrive_dataset_specifications_v1(
+    dataset_id: int, body_data: list[TorsiondriveDatasetSpecification]
+) -> InsertMetadata:
     return storage_socket.datasets.torsiondrive.add_specifications(dataset_id, body_data)
 
 
 @api_v1.route("/datasets/torsiondrive/<int:dataset_id>/entries/bulkCreate", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def add_torsiondrive_dataset_entries_v1(dataset_id: int, body_data: List[TorsiondriveDatasetNewEntry]):
+def add_torsiondrive_dataset_entries_v1(
+    dataset_id: int, body_data: list[TorsiondriveDatasetNewEntry]
+) -> InsertMetadata:
     return storage_socket.datasets.torsiondrive.add_entries(dataset_id, new_entries=body_data)
 
 
 @api_v1.route("/datasets/torsiondrive/<int:dataset_id>/background_add_entries", methods=["POST"])
 @check_permissions("datasets", "modify")
 @serialization()
-def background_add_torsiondrive_dataset_entries_v1(dataset_id: int, body_data: List[TorsiondriveDatasetNewEntry]):
+def background_add_torsiondrive_dataset_entries_v1(
+    dataset_id: int, body_data: list[TorsiondriveDatasetNewEntry]
+) -> int:
     return storage_socket.datasets.torsiondrive.background_add_entries(dataset_id, new_entries=body_data)
 
 

--- a/qcfractal/qcfractal/flask_app/api_v1/routes.py
+++ b/qcfractal/qcfractal/flask_app/api_v1/routes.py
@@ -3,6 +3,7 @@ from flask import jsonify, current_app, g
 
 from qcfractal.flask_app.api_v1.blueprint import api_v1
 from qcfractal.flask_app.decorators import no_permission_required
+from qcfractal.flask_app.openapi import generate_openapi_spec
 
 
 @api_v1.route("/ping", methods=["GET"])
@@ -26,42 +27,11 @@ def ping() -> Any:
     return jsonify(ret)
 
 
-@api_v1.route("/all_routes", methods=["GET"])
+@api_v1.route("/openapi_spec", methods=["GET"])
 @no_permission_required()
-def get_all_routes_v1():
+def get_all_routes_v1() -> dict[str, Any]:
     """
-    Returns a dictionary of all endpoints and their required permissions.
-
-    The return dictionary has keys as the endpoint name, and values representing
-    the required permissions (http method, target, resource, action)
+    Returns an openapi specification for all endpoints on this server
     """
-    permissions = {}
 
-    for rule in current_app.url_map.iter_rules():
-        endpoint = rule.endpoint
-        if endpoint == "static":
-            continue
-
-        view_func = current_app.view_functions[endpoint]
-        if not hasattr(view_func, "_has_permission_check"):
-            continue
-
-        if hasattr(view_func, "_permissions_required"):
-            resource, action = view_func._permissions_required
-        else:
-            resource, action = "none", "none"
-
-        # The required permissions
-        # http method, resource, action (read/write/modify/delete/etc)
-        for method in rule.methods:
-            if method.lower() in {"options", "head"}:
-                continue
-
-            permissions[str(rule)] = {
-                "endpoint": endpoint,
-                "method": method.lower(),
-                "resource": resource,
-                "action": action,
-            }
-
-    return jsonify(permissions)
+    return generate_openapi_spec(current_app)

--- a/qcfractal/qcfractal/flask_app/api_v1/routes.py
+++ b/qcfractal/qcfractal/flask_app/api_v1/routes.py
@@ -27,9 +27,50 @@ def ping() -> Any:
     return jsonify(ret)
 
 
-@api_v1.route("/openapi_spec", methods=["GET"])
+@api_v1.route("/all_routes", methods=["GET"])
 @no_permission_required()
 def get_all_routes_v1() -> dict[str, Any]:
+    """
+    Returns a dictionary of all endpoints and their required permissions.
+
+    The return dictionary has keys as the endpoint name, and values representing
+    the required permissions (http method, target, resource, action)
+    """
+    permissions = {}
+
+    for rule in current_app.url_map.iter_rules():
+        endpoint = rule.endpoint
+        if endpoint == "static":
+            continue
+
+        view_func = current_app.view_functions[endpoint]
+        if not hasattr(view_func, "_has_permission_check"):
+            continue
+
+        if hasattr(view_func, "_permissions_required"):
+            resource, action = view_func._permissions_required
+        else:
+            resource, action = "none", "none"
+
+        # The required permissions
+        # http method, resource, action (read/write/modify/delete/etc)
+        for method in rule.methods:
+            if method.lower() in {"options", "head"}:
+                continue
+
+            permissions[str(rule)] = {
+                "endpoint": endpoint,
+                "method": method.lower(),
+                "resource": resource,
+                "action": action,
+            }
+
+    return jsonify(permissions)
+
+
+@api_v1.route("/openapi_spec", methods=["GET"])
+@no_permission_required()
+def get_openapi_spec_v1() -> dict[str, Any]:
     """
     Returns an openapi specification for all endpoints on this server
     """

--- a/qcfractal/qcfractal/flask_app/api_v1/routes.py
+++ b/qcfractal/qcfractal/flask_app/api_v1/routes.py
@@ -1,3 +1,4 @@
+from typing import Any
 from flask import jsonify, current_app, g
 
 from qcfractal.flask_app.api_v1.blueprint import api_v1
@@ -6,7 +7,7 @@ from qcfractal.flask_app.decorators import no_permission_required
 
 @api_v1.route("/ping", methods=["GET"])
 @no_permission_required()
-def ping():
+def ping() -> Any:
 
     user_id = g.user_id if "user_id" in g else None
 

--- a/qcfractal/qcfractal/flask_app/auth_v1/routes.py
+++ b/qcfractal/qcfractal/flask_app/auth_v1/routes.py
@@ -1,3 +1,4 @@
+from typing import Any
 from flask import jsonify, g
 from flask_jwt_extended import (
     jwt_required,
@@ -20,14 +21,14 @@ from qcfractal.flask_app.helpers import (
 
 @auth_v1.route("/login", methods=["POST"])
 @no_permission_required()
-def login():
+def login() -> tuple[Any, int]:
     access_token, refresh_token = login_and_get_jwt(get_refresh_token=True)
     return jsonify(msg="Login succeeded!", access_token=access_token, refresh_token=refresh_token), 200
 
 
 @auth_v1.route("/session_login", methods=["POST"])
 @no_permission_required()
-def user_session_login():
+def user_session_login() -> tuple[Any, int]:
     user_info = login_user_session()
     response = jsonify(
         msg="Login succeeded!",
@@ -41,7 +42,7 @@ def user_session_login():
 
 @auth_v1.route("/session_logout", methods=["POST"])
 @no_permission_required()
-def user_session_logout():
+def user_session_logout() -> tuple[Any, int]:
     logout_user_session()
     response = jsonify(msg="Logout successful!")
     return response, 200
@@ -50,7 +51,7 @@ def user_session_logout():
 @auth_v1.route("/refresh", methods=["POST"])
 @no_permission_required()
 @jwt_required(refresh=True)
-def refresh():
+def refresh() -> tuple[Any, int]:
     user_id = get_jwt_identity()
 
     user_info = storage_socket.auth.verify(user_id)
@@ -65,7 +66,7 @@ def refresh():
 
 @auth_v1.route("/allowed", methods=["GET"])
 @no_permission_required()
-def get_allowed_actions():
+def get_allowed_actions() -> tuple[Any, int]:
     all_endpoints = get_all_endpoints()
     all_actions = {"READ", "WRITE", "DELETE"}
 

--- a/qcfractal/qcfractal/flask_app/compute_v1/routes.py
+++ b/qcfractal/qcfractal/flask_app/compute_v1/routes.py
@@ -1,3 +1,4 @@
+from typing import Any
 from qcfractal.flask_app.compute_v1.blueprint import compute_v1
 from qcfractal.flask_app.decorators import check_permissions, serialization
 from qcfractal.flask_app.helpers import get_public_server_information
@@ -6,5 +7,5 @@ from qcfractal.flask_app.helpers import get_public_server_information
 @compute_v1.route("/information", methods=["GET"])
 @check_permissions("information", "read")
 @serialization()
-def get_information():
+def get_information() -> dict[str, Any]:
     return get_public_server_information()

--- a/qcfractal/qcfractal/flask_app/decorators.py
+++ b/qcfractal/qcfractal/flask_app/decorators.py
@@ -1,8 +1,9 @@
+import inspect
+import shutil
 import tempfile
 from functools import wraps
 from typing import Callable, Iterable, Optional
 
-import shutil
 from flask import g, request, current_app, Response
 from werkzeug.exceptions import BadRequest
 
@@ -11,6 +12,21 @@ from qcfractal.db_socket import SQLAlchemySocket
 from qcfractal.flask_app import storage_socket
 from qcportal.exceptions import AuthorizationFailure
 from qcportal.serialization import deserialize, serialize
+
+
+def _get_openapi_meta_dict(fn):
+    """
+    Accesses the openapi metadata for a function
+
+    This is required due to nested decorators. This attaches the info to the lowest-level function (via inspect.unwrap)
+    """
+
+    original = inspect.unwrap(fn)
+
+    if not hasattr(original, "__openapi_meta__"):
+        original.__openapi_meta__ = {}
+
+    return original.__openapi_meta__
 
 
 def _get_file_extension(filename, allowed_extensions = None):
@@ -90,6 +106,13 @@ def check_permissions(
     """
 
     def decorate(fn):
+
+        # Attach permissions information for openapi spec generation
+        openapi_meta = _get_openapi_meta_dict(fn)
+        openapi_meta["requested_resource"] = requested_resource
+        openapi_meta["requested_action"] = requested_action
+        openapi_meta["require_security"] = require_security
+
         @wraps(fn)
         def wrapper(*args, **kwargs):
 
@@ -175,6 +198,11 @@ def allow_uploads(allowed_file_extensions: Optional[Iterable[str]]) -> Callable:
     """
 
     def decorate(fn):
+
+        # Attach allowed upload info for openapi spec generation
+        openapi_meta = _get_openapi_meta_dict(fn)
+        openapi_meta["allowed_file_extensions"] = allowed_file_extensions
+
         @wraps(fn)
         def wrapper(*args, **kwargs):
             annotations = fn.__annotations__

--- a/qcfractal/qcfractal/flask_app/home_v1.py
+++ b/qcfractal/qcfractal/flask_app/home_v1.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any
 
 from flask import Blueprint, current_app, redirect, abort, send_from_directory
 from qcfractal.flask_app.decorators import no_permission_required
@@ -9,7 +9,7 @@ home_v1 = Blueprint("home", __name__)
 @home_v1.route("/", methods=["GET"])
 @home_v1.route("/<path:file_path>", methods=["GET"])
 @no_permission_required()
-def homepage(file_path: Optional[str] = None):
+def homepage(file_path: str | None = None) -> Any:
     # If the root is accessed, serve the static homepage site or do a redirect
     # If a specific file is accessed, only try to serve it from the directory
 

--- a/qcfractal/qcfractal/flask_app/openapi.py
+++ b/qcfractal/qcfractal/flask_app/openapi.py
@@ -1,24 +1,15 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Tuple, get_type_hints
+import inspect
+from copy import deepcopy
+from typing import Any, Dict, Iterable, List, Optional, Tuple, get_type_hints, TYPE_CHECKING
 
-import pydantic.v1 as pydantic
+if TYPE_CHECKING:
+    from flask import Flask
 
+import pydantic
 
-@dataclass(frozen=True)
-class OpenAPIRouteInfo:
-    path: str
-    methods: Tuple[str, ...]
-    view_func: Any
-    requested_resource: str
-    requested_action: str
-    require_security: bool
-    allowed_file_extensions: Optional[Tuple[str, ...]]
-
-
-_ROUTES: List[OpenAPIRouteInfo] = []
 
 
 _PATH_PARAM_RE = re.compile(r"<(?:(?P<converter>[^:]+):)?(?P<name>[^>]+)>")
@@ -36,16 +27,18 @@ class SchemaRegistry:
         root_name = f"OpenAPIRoot{self._root_counter}"
         self._root_counter += 1
 
-        root_model = pydantic.create_model(root_name, __root__=(tp, ...))
-        schema = pydantic.schema.schema([root_model], ref_prefix="#/components/schemas/")
-        definitions = schema.get("definitions", {})
-        root_schema = definitions.pop(root_name, None) or {}
+        root_adapter = pydantic.TypeAdapter(tp)
+        schema = root_adapter.json_schema(
+            mode="serialization",
+            ref_template="#/components/schemas/{model}",
+        )
+        definitions = schema.pop("$defs", {})
 
         for name, definition in definitions.items():
             if name not in self.components:
                 self.components[name] = definition
 
-        return root_schema
+        return schema
 
 
 def _normalize_path(rule: str) -> Tuple[str, List[Dict[str, Any]]]:
@@ -75,38 +68,6 @@ def _normalize_path(rule: str) -> Tuple[str, List[Dict[str, Any]]]:
     return normalized, params
 
 
-def _join_paths(prefix: Optional[str], rule: str) -> str:
-    if not prefix:
-        return rule
-    if rule == "/":
-        return prefix
-    return prefix.rstrip("/") + "/" + rule.lstrip("/")
-
-
-def register_route(
-    rule: str,
-    methods: Iterable[str],
-    view_func: Any,
-    url_prefix: Optional[str] = None,
-) -> None:
-    meta = getattr(view_func, "__openapi_meta__", None)
-    if not meta:
-        return
-
-    full_rule = _join_paths(url_prefix, rule)
-
-    info = OpenAPIRouteInfo(
-        path=full_rule,
-        methods=tuple(sorted({m.upper() for m in methods if m})),
-        view_func=view_func,
-        requested_resource=meta["requested_resource"],
-        requested_action=meta["requested_action"],
-        require_security=meta["require_security"],
-        allowed_file_extensions=meta["allowed_file_extensions"],
-    )
-    _ROUTES.append(info)
-
-
 def _query_parameters(model: Any, registry: SchemaRegistry) -> List[Dict[str, Any]]:
     if model is None:
         return []
@@ -115,13 +76,13 @@ def _query_parameters(model: Any, registry: SchemaRegistry) -> List[Dict[str, An
         return []
 
     params: List[Dict[str, Any]] = []
-    for name, field in model.__fields__.items():
-        schema = registry.schema_for_type(field.outer_type_)
+    for name, field in model.model_fields.items():
+        schema = registry.schema_for_type(field.annotation)
         params.append(
             {
                 "name": name,
                 "in": "query",
-                "required": field.required,
+                "required": field.is_required(),
                 "schema": schema,
             }
         )
@@ -130,7 +91,7 @@ def _query_parameters(model: Any, registry: SchemaRegistry) -> List[Dict[str, An
 
 def _request_body(
     body_model: Any,
-    allowed_file_extensions: Optional[Tuple[str, ...]],
+    allowed_file_extensions: Optional[Iterable[str]],
     registry: SchemaRegistry,
 ) -> Optional[Dict[str, Any]]:
     if body_model is None and not allowed_file_extensions:
@@ -146,6 +107,10 @@ def _request_body(
         if body_model is not None:
             properties["body_data"] = registry.schema_for_type(body_model)
 
+        required_properties = ["files"]
+        if body_model is not None:
+            required_properties.append("body_data")
+
         return {
             "required": True,
             "content": {
@@ -153,6 +118,7 @@ def _request_body(
                     "schema": {
                         "type": "object",
                         "properties": properties,
+                        "required": required_properties,
                     }
                 }
             },
@@ -170,33 +136,47 @@ def _request_body(
 
 
 def generate_openapi_spec(
+    app: Flask,
     title: str = "QCFractal API",
     version: str = "0.0.0",
 ) -> Dict[str, Any]:
     registry = SchemaRegistry()
     paths: Dict[str, Any] = {}
+    security_required = False
 
-    for route in _ROUTES:
-        path, path_params = _normalize_path(route.path)
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint == "static":
+            continue
+
+        view_func = app.view_functions[rule.endpoint]
+
+        # Use inspect.unwrap to get the original function that has the metadata and annotations
+        unwrapped_view_func = inspect.unwrap(view_func)
+        meta = getattr(unwrapped_view_func, "__openapi_meta__", {})
+
+        requested_resource = meta.get("requested_resource")
+        require_security = meta.get("require_security", False)
+        allowed_file_extensions = meta.get("allowed_file_extensions")
+
+        path, path_params = _normalize_path(rule.rule)
         try:
-            hints = get_type_hints(route.view_func)
+            hints = get_type_hints(unwrapped_view_func)
         except Exception:
-            hints = route.view_func.__annotations__
+            hints = getattr(unwrapped_view_func, "__annotations__", {})
 
         body_model = hints.get("body_data")
         url_params_model = hints.get("url_params")
         response_model = hints.get("return")
 
         query_params = _query_parameters(url_params_model, registry)
-        request_body = _request_body(body_model, route.allowed_file_extensions, registry)
+        request_body = _request_body(body_model, allowed_file_extensions, registry)
 
-        for method in route.methods:
+        for method in rule.methods:
             if method in {"HEAD", "OPTIONS"}:
                 continue
 
             operation = {
-                "summary": route.view_func.__name__,
-                "tags": [route.requested_resource],
+                "summary": unwrapped_view_func.__name__,
                 "parameters": [*path_params, *query_params],
                 "responses": {
                     "200": {
@@ -204,6 +184,9 @@ def generate_openapi_spec(
                     }
                 },
             }
+
+            if requested_resource:
+                operation["tags"] = [requested_resource]
 
             if request_body is not None:
                 operation["requestBody"] = request_body
@@ -215,8 +198,9 @@ def generate_openapi_spec(
                     }
                 }
 
-            if route.require_security:
+            if require_security:
                 operation["security"] = [{"bearerAuth": []}]
+                security_required = True
 
             paths.setdefault(path, {})[method.lower()] = operation
 
@@ -226,13 +210,19 @@ def generate_openapi_spec(
         "paths": paths,
     }
 
-    if registry.components:
-        spec["components"] = {"schemas": registry.components}
-        spec["components"]["securitySchemes"] = {
-            "bearerAuth": {
-                "type": "http",
-                "scheme": "bearer",
+    if registry.components or security_required:
+        components: Dict[str, Any] = {}
+        if registry.components:
+            components["schemas"] = deepcopy(registry.components)
+
+        if security_required:
+            components["securitySchemes"] = {
+                "bearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer",
+                }
             }
-        }
+
+        spec["components"] = components
 
     return spec

--- a/qcfractal/qcfractal/flask_app/openapi.py
+++ b/qcfractal/qcfractal/flask_app/openapi.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple, get_type_hints
+
+import pydantic.v1 as pydantic
+
+
+@dataclass(frozen=True)
+class OpenAPIRouteInfo:
+    path: str
+    methods: Tuple[str, ...]
+    view_func: Any
+    requested_resource: str
+    requested_action: str
+    require_security: bool
+    allowed_file_extensions: Optional[Tuple[str, ...]]
+
+
+_ROUTES: List[OpenAPIRouteInfo] = []
+
+
+_PATH_PARAM_RE = re.compile(r"<(?:(?P<converter>[^:]+):)?(?P<name>[^>]+)>")
+
+
+class SchemaRegistry:
+    def __init__(self) -> None:
+        self.components: Dict[str, Dict[str, Any]] = {}
+        self._root_counter = 0
+
+    def schema_for_type(self, tp: Any) -> Dict[str, Any]:
+        if tp is None or tp is type(None):
+            return {"type": "null"}
+
+        root_name = f"OpenAPIRoot{self._root_counter}"
+        self._root_counter += 1
+
+        root_model = pydantic.create_model(root_name, __root__=(tp, ...))
+        schema = pydantic.schema.schema([root_model], ref_prefix="#/components/schemas/")
+        definitions = schema.get("definitions", {})
+        root_schema = definitions.pop(root_name, None) or {}
+
+        for name, definition in definitions.items():
+            if name not in self.components:
+                self.components[name] = definition
+
+        return root_schema
+
+
+def _normalize_path(rule: str) -> Tuple[str, List[Dict[str, Any]]]:
+    params: List[Dict[str, Any]] = []
+
+    def replace(match: re.Match[str]) -> str:
+        converter = match.group("converter") or "string"
+        name = match.group("name")
+        schema = {"type": "string"}
+
+        if converter in {"int", "integer"}:
+            schema = {"type": "integer"}
+        elif converter in {"float", "number"}:
+            schema = {"type": "number"}
+
+        params.append(
+            {
+                "name": name,
+                "in": "path",
+                "required": True,
+                "schema": schema,
+            }
+        )
+        return "{" + name + "}"
+
+    normalized = _PATH_PARAM_RE.sub(replace, rule)
+    return normalized, params
+
+
+def _join_paths(prefix: Optional[str], rule: str) -> str:
+    if not prefix:
+        return rule
+    if rule == "/":
+        return prefix
+    return prefix.rstrip("/") + "/" + rule.lstrip("/")
+
+
+def register_route(
+    rule: str,
+    methods: Iterable[str],
+    view_func: Any,
+    url_prefix: Optional[str] = None,
+) -> None:
+    meta = getattr(view_func, "__openapi_meta__", None)
+    if not meta:
+        return
+
+    full_rule = _join_paths(url_prefix, rule)
+
+    info = OpenAPIRouteInfo(
+        path=full_rule,
+        methods=tuple(sorted({m.upper() for m in methods if m})),
+        view_func=view_func,
+        requested_resource=meta["requested_resource"],
+        requested_action=meta["requested_action"],
+        require_security=meta["require_security"],
+        allowed_file_extensions=meta["allowed_file_extensions"],
+    )
+    _ROUTES.append(info)
+
+
+def _query_parameters(model: Any, registry: SchemaRegistry) -> List[Dict[str, Any]]:
+    if model is None:
+        return []
+
+    if not isinstance(model, type) or not issubclass(model, pydantic.BaseModel):
+        return []
+
+    params: List[Dict[str, Any]] = []
+    for name, field in model.__fields__.items():
+        schema = registry.schema_for_type(field.outer_type_)
+        params.append(
+            {
+                "name": name,
+                "in": "query",
+                "required": field.required,
+                "schema": schema,
+            }
+        )
+    return params
+
+
+def _request_body(
+    body_model: Any,
+    allowed_file_extensions: Optional[Tuple[str, ...]],
+    registry: SchemaRegistry,
+) -> Optional[Dict[str, Any]]:
+    if body_model is None and not allowed_file_extensions:
+        return None
+
+    if allowed_file_extensions:
+        properties: Dict[str, Any] = {
+            "files": {
+                "type": "array",
+                "items": {"type": "string", "format": "binary"},
+            }
+        }
+        if body_model is not None:
+            properties["body_data"] = registry.schema_for_type(body_model)
+
+        return {
+            "required": True,
+            "content": {
+                "multipart/form-data": {
+                    "schema": {
+                        "type": "object",
+                        "properties": properties,
+                    }
+                }
+            },
+        }
+
+    schema = registry.schema_for_type(body_model)
+    return {
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": schema,
+            }
+        },
+    }
+
+
+def generate_openapi_spec(
+    title: str = "QCFractal API",
+    version: str = "0.0.0",
+) -> Dict[str, Any]:
+    registry = SchemaRegistry()
+    paths: Dict[str, Any] = {}
+
+    for route in _ROUTES:
+        path, path_params = _normalize_path(route.path)
+        try:
+            hints = get_type_hints(route.view_func)
+        except Exception:
+            hints = route.view_func.__annotations__
+
+        body_model = hints.get("body_data")
+        url_params_model = hints.get("url_params")
+        response_model = hints.get("return")
+
+        query_params = _query_parameters(url_params_model, registry)
+        request_body = _request_body(body_model, route.allowed_file_extensions, registry)
+
+        for method in route.methods:
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+
+            operation = {
+                "summary": route.view_func.__name__,
+                "tags": [route.requested_resource],
+                "parameters": [*path_params, *query_params],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                    }
+                },
+            }
+
+            if request_body is not None:
+                operation["requestBody"] = request_body
+
+            if response_model is not None:
+                operation["responses"]["200"]["content"] = {
+                    "application/json": {
+                        "schema": registry.schema_for_type(response_model),
+                    }
+                }
+
+            if route.require_security:
+                operation["security"] = [{"bearerAuth": []}]
+
+            paths.setdefault(path, {})[method.lower()] = operation
+
+    spec: Dict[str, Any] = {
+        "openapi": "3.0.3",
+        "info": {"title": title, "version": version},
+        "paths": paths,
+    }
+
+    if registry.components:
+        spec["components"] = {"schemas": registry.components}
+        spec["components"]["securitySchemes"] = {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+            }
+        }
+
+    return spec

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -218,6 +218,17 @@ class PortalClient(PortalClientBase):
         # Request the info, and store here for later use
         return self.make_request("get", "api/v1/information", Dict[str, Any])
 
+    def get_server_openapi_spec(self) -> Dict[str, Any]:
+        """Request the OpenAPI specification for the server
+
+        Returns
+        -------
+        :
+            OpenAPI specification.
+        """
+
+        return self.make_request("get", "api/v1/openapi_spec", Dict[str, Any])
+
     def get_server_stats(self) -> List[ServerStatsEntry]:
         """Request statistics about the server
 

--- a/server_admin/generate_openapi_spec.py
+++ b/server_admin/generate_openapi_spec.py
@@ -1,0 +1,9 @@
+from qcfractal.snowflake import FractalSnowflake
+import json
+
+if __name__ == "__main__":
+
+    snowflake = FractalSnowflake(compute_workers=0)
+    client = snowflake.client()
+
+    print(json.dumps(client.get_server_openapi_spec(), indent=2, sort_keys=True))


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

This adds endpoints and functions to generate an openapi specification. This also adds (often useless) type hints to flask routes to aid in creating that specification.

The function for generating the openapi spec is AI written. The output is probably not 100% correct (nor very readable), but it is useful to pass to other AI to determine appropriate endpoints and what to send/receive.

## Status
- [ ] Code base linted
- [ ] Ready to go
