### PR TITLE
Use simpler/faster query for compute_history manager_name query

### DIFF
--- a/qcfractal/qcfractal/components/record_socket.py
+++ b/qcfractal/qcfractal/components/record_socket.py
@@ -289,8 +289,7 @@ class RecordSocket:
 
         if query_data.history_manager_name is not None:
             stmt = stmt.join(RecordComputeHistoryORM, RecordComputeHistoryORM.record_id == orm_type.id, isouter=True)
-            and_query.append(or_(RecordComputeHistoryORM.manager_name.in_(query_data.history_manager_name),
-            orm_type.manager_name.in_(query_data.history_manager_name)))
+            and_query.append(RecordComputeHistoryORM.manager_name.in_(query_data.history_manager_name))
 
         if query_data.creator_user is not None:
             stmt = stmt.join(UserIDMapSubquery)

--- a/qcfractal/qcfractal/components/test_record_client_query.py
+++ b/qcfractal/qcfractal/components/test_record_client_query.py
@@ -101,7 +101,7 @@ def test_record_client_query(queryable_records_client: PortalClient):
 
     query_res = queryable_records_client.query_records(history_manager_name=manager.name)
     query_res_l = list(query_res)
-    assert len(query_res_l) == 4
+    assert len(query_res_l) == 3
 
     # Querying based on status
     query_res = queryable_records_client.query_records(status=[RecordStatusEnum.error])


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

The query for records whose compute_history was computed by a particular manager was very slow. The `or` that was being used caused the query planner to not use the index on `record_compute_history`. So now the query really only searches the compute history, and the user would need to do a second query to obtain records where the `base_record.manager_name` was that manager.

On a test query, reduces the time from 47,000ms to 20ms.

## Status
- [X] Code base linted
- [X] Ready to go
