### PR TITLE
Added roles to the docs

### DIFF
--- a/docs/source/admin_guide/cli_admin.rst
+++ b/docs/source/admin_guide/cli_admin.rst
@@ -30,6 +30,30 @@ Security
 Users and Passwords
 ---------------------
 
+The ``qcfractal-server user`` command allows management of users for the server.
+To list the current users, use the ``qcfractal-server user list`` subcommand.
+To add a new user, use the ``qcfractal-server user add`` command. To add a user,
+a role needs to be set for them. The following roles are accepted by QCFractal:
+
++-----------+-----------------------------------------------------------------+
+| Role      | Description                                                     |
++===========+=================================================================+
+| admin     | Administer and manage the server.                               |
++-----------+-----------------------------------------------------------------+
+| maintain  | Similar to admin, but with some restrictions.                   |
++-----------+-----------------------------------------------------------------+
+| monitor   | User is allowed to read information, but not submit jobs.       |
++-----------+-----------------------------------------------------------------+
+| submit    | User is allowed to read information and submit jobs.            |
++-----------+-----------------------------------------------------------------+
+| read      | User is allowed to read job information, but not server         |
+|           | information.                                                    |
++-----------+-----------------------------------------------------------------+
+| anonymous | Same as read, but does not have access to user information.     |
++-----------+-----------------------------------------------------------------+
+| compute   | User can pull jobs off the manager to run them.                 |
++-----------+-----------------------------------------------------------------+
+
 
 .. _server_admin_accesslog:
 


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
The roles were missing from documentation. I added them to make it easier to find. Previously, users would have to look in the configuration file for the role permissions to find which roles they were allowed to use. Solves #1017 

## Status
- [x] Code base linted
- [x] Ready to go
