### PR TITLE
Fix default arg in NEB query model

### DIFF
--- a/qcportal/qcportal/neb/record_models.py
+++ b/qcportal/qcportal/neb/record_models.py
@@ -122,7 +122,7 @@ class NEBAddBody(RecordAddBodyBase, NEBMultiInput):
 
 
 class NEBQueryFilters(RecordQueryFilters):
-    program: list[str] | None = "geometric"
+    program: list[str] | None = None
     qc_program: list[LowerStr] | None = None
     qc_method: list[LowerStr] | None = None
     qc_basis: list[LowerStr | None] | None = None


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->
Very small - fixes the default value for `program` NEBQueryFilters (should be a list, or None).

I noticed some errors on our instance related to this.

## Status
- [X] Code base linted
- [X] Ready to go
