### PR TITLE
Improve JWT Security for disabling/downgrading accounts

### DIFF
--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -280,8 +280,8 @@ class WebAPIConfig(QCFConfigBase):
     jwt_secret_key: str
     """Secret key for web tokens. See documentation"""
 
-    jwt_access_token_expires: int = 60 * 60
-    """The time (in seconds) an access token is valid for. Default is 1 hour"""
+    jwt_access_token_expires: int = 15 * 60
+    """The time (in seconds) an access token is valid for. Default is 15 minutes"""
 
     jwt_refresh_token_expires: int = 60 * 60 * 24
     """The time (in seconds) a refresh token is valid for. Default is 1 day"""

--- a/qcfractal/qcfractal/flask_app/auth_v1/test_auth_jwt.py
+++ b/qcfractal/qcfractal/flask_app/auth_v1/test_auth_jwt.py
@@ -6,6 +6,7 @@ import pytest
 from qcarchivetesting.testing_classes import (
     QCATestingSnowflake,
 )
+from qcportal import PortalRequestError
 from qcportal.exceptions import AuthenticationFailure
 
 
@@ -50,6 +51,77 @@ def test_jwt_refresh_user_disabled(secure_snowflake):
 
     with pytest.raises(AuthenticationFailure, match="User account has been disabled"):
         client.list_datasets()
+
+
+@pytest.mark.slow
+def test_jwt_disabled_before_refresh(postgres_server, pytestconfig):
+    # Disabling an account must take effect within the server-side re-verify cache lifetime (~5s),
+    # not only after the access token expires and is refreshed. Use a long access-token lifetime
+    # so the token is still valid (and no refresh happens) when we make the post-disable request.
+    pg_harness = postgres_server.get_new_harness("jwt_disabled_before_refresh")
+    encoding = pytestconfig.getoption("--client-encoding")
+    with QCATestingSnowflake(
+        pg_harness,
+        encoding=encoding,
+        create_users=True,
+        enable_security=True,
+        allow_unauthenticated_read=False,
+        extra_config={"api": {"jwt_access_token_expires": 60}},
+    ) as snowflake:
+        admin_client = snowflake.user_client("admin_user")
+        client = snowflake.user_client("submit_user")
+
+        # Works to start with
+        client.list_datasets()
+
+        uinfo = admin_client.get_user("submit_user")
+        uinfo.enabled = False
+        admin_client.modify_user(uinfo)
+
+        # Wait past the re-verify cache lifetime. The access token is still valid, so the client
+        # does not refresh -- the server must reject the request based on the disabled account.
+        time.sleep(7)
+        assert client._jwt_access_exp - time.time() > 5  # token still valid; this is not the refresh path
+
+        with pytest.raises(PortalRequestError, match="is disabled"):
+            client.list_datasets()
+
+
+@pytest.mark.slow
+def test_jwt_role_downgrade_before_refresh(postgres_server, pytestconfig):
+    # Downgrading a user's role must take effect within the re-verify cache lifetime, even though
+    # the still-valid access token carries the old (higher) role in its claims.
+    pg_harness = postgres_server.get_new_harness("jwt_role_downgrade_before_refresh")
+    encoding = pytestconfig.getoption("--client-encoding")
+    with QCATestingSnowflake(
+        pg_harness,
+        encoding=encoding,
+        create_users=True,
+        enable_security=True,
+        allow_unauthenticated_read=False,
+        extra_config={"api": {"jwt_access_token_expires": 60}},
+    ) as snowflake:
+        admin_client = snowflake.user_client("admin_user")
+        client = snowflake.user_client("submit_user")
+
+        # The submit role can add datasets
+        client.add_dataset("singlepoint", "ds_before_downgrade")
+
+        uinfo = admin_client.get_user("submit_user")
+        uinfo.role = "read"
+        admin_client.modify_user(uinfo)
+
+        # The token still carries role=submit
+        decoded = jwt.decode(client._jwt_access_token, algorithms=["HS256"], options={"verify_signature": False})
+        assert decoded["role"] == "submit"
+
+        # Wait past the re-verify cache lifetime without letting the token expire
+        time.sleep(7)
+        assert client._jwt_access_exp - time.time() > 5  # token still valid; this is not the refresh path
+
+        # The read role cannot add datasets, so the downgrade must be enforced despite the stale claim
+        with pytest.raises(PortalRequestError, match="Forbidden"):
+            client.add_dataset("singlepoint", "ds_after_downgrade")
 
 
 @pytest.mark.slow

--- a/qcfractal/qcfractal/flask_app/load_user.py
+++ b/qcfractal/qcfractal/flask_app/load_user.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from flask import session, g
-from flask_jwt_extended import verify_jwt_in_request, get_jwt_identity, get_jwt
+from flask_jwt_extended import verify_jwt_in_request, get_jwt_identity
 from jwt.exceptions import ExpiredSignatureError
 from werkzeug.exceptions import InternalServerError
 
@@ -10,7 +10,7 @@ from qcportal.exceptions import AuthorizationFailure, AuthenticationFailure
 from qcportal.utils import time_based_cache
 
 
-@time_based_cache(seconds=3, maxsize=256)
+@time_based_cache(seconds=5, maxsize=256)
 def _cached_verify(user_id: int):
     return storage_socket.auth.verify(user_id=user_id)
 
@@ -42,12 +42,15 @@ def load_logged_in_user():
                 # user_id is stored in the JWT as a string
                 user_id = int(user_id)
 
-                # Get from JWT in header
-                # TODO - some of these may not be None in the future
-                claims = get_jwt()
-                username = claims.get("username", None)
-                role = claims.get("role", None)
-                groups = claims.get("groups", [])
+                # Re-verify the user against the database rather than trusting the
+                # authorization attributes copied into the JWT. This ensures that
+                # disabling an account or changing its role/groups takes effect within
+                # the cache lifetime, rather than persisting until the token expires.
+                # The (short) cache keeps this from hitting the database on every request.
+                user_info = _cached_verify(user_id=user_id)
+                username = user_info.username
+                role = user_info.role
+                groups = user_info.groups
     except (AuthorizationFailure, AuthenticationFailure):
         raise
     except ExpiredSignatureError as e:


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

Right now, the server uses the claims (user id, role) present in the JWT without validating against the database. This was by design, as verifying this information for every request (at 10-100/second) starts to add up, but is also nearly 100% unneeded as account info rarely changes.

However, combined with the default JWT access token expiration of 1 hour, this does create a bit of an issue where a disabled user has <=1 hour where the server will still consider them enabled (as long as they have an active JWT). That is too long - I use 5 minutes on the instances I run. This is unlikely to really be a problem at the moment, as users are added manually by a server admin and should be trusted. Nevertheless, it could cause problems in the future if instances have open registration.

So the fix is two fold:

1. Shorten the default in the config file to 15 minutes.
2. Validate the info server side, but use the existing cached validation mechanism, modified to hold for 5 seconds. This will effectively ignore the info in the JWT, although that info is useful to the end user so is kept.

Checking once every 5 seconds is enough that it won't burden the server (could be every 50-1000 requests or so), but short enough that the delay is negligible in an account doing some damage after being disabled.

There should be no user-facing changes.

## Status
- [X] Code base linted
- [X] Ready to go
