### PR TITLE
Greatly clean up & expand docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ sphinx_design
 sphinx-copybutton
 pydata_sphinx_theme
 myst-nb
+sphinxcontrib-pydantic
 nglview
 -e ../qcportal
 -e ../qcfractalcompute

--- a/docs/source/_ext/configtable.py
+++ b/docs/source/_ext/configtable.py
@@ -1,0 +1,291 @@
+"""
+A ``config-table`` directive for documenting pydantic settings in prose.
+
+The server and manager configuration pages are organised into thematic groups
+("Logging", "Heartbeats", ...) that do not correspond to pydantic classes. This
+directive lets a prose section render a table of just the options it is talking
+about, with the type, default, and summary read out of the model at build time.
+
+With no body, every field of the model is rendered, in declaration order::
+
+    .. config-table:: qcfractal.config.CORSconfig
+
+That is what you want whenever a model is documented by a single table. Give a body only
+to split a model across several prose sections - ``FractalConfig`` is spread over eight -
+in which case the body lists the fields for that one table, in the order they appear::
+
+    .. config-table:: qcfractal.config.FractalConfig
+
+       service_frequency
+       max_active_services
+
+A field's summary is the first paragraph of its description, so a description can
+be as long as it needs to be: the table stays scannable and the full text shows up
+in the generated reference section further down the page.
+
+Two checks make the tables self-maintaining, which is the point of the whole
+exercise - a hand-written option list drifts silently, and this cannot:
+
+* Naming a field the model does not have is an error, so a renamed or removed option
+  breaks the build rather than rotting in the prose.
+* Every model referenced by a ``config-table`` must be *fully* covered: any field not in
+  one of its tables is reported at the end of the build, so a newly added option cannot
+  go undocumented. A body-less table satisfies this by construction.
+
+Two escape hatches, both declared at the table rather than in ``conf.py`` so they sit
+next to the thing they describe:
+
+``:omit:``
+    Fields deliberately left undocumented - typically ones a user cannot usefully set.
+    Omissions are pooled across all of a model's tables, so it does not matter which one
+    carries the option. Naming a field the model does not have is reported, so an
+    omission cannot outlive the field it refers to.
+
+``:partial:``
+    Skip the completeness check for this model. For a page mid-conversion, so that
+    unfinished work does not fail the build.
+
+Defaults come from the model. Where the real default is computed at runtime (the
+paths that default to ``[base_folder]/...``), override it with ``=``::
+
+    .. config-table:: qcfractal.config.FractalConfig
+
+       geoip2_dir = [base_folder]/geoip2
+       geoip2_filename
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import StringList
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+# What each document contributed, kept on the build environment rather than in module
+# state so that it survives an incremental build. With module state, a rebuild that
+# re-reads only some of the documents sees only their tables, and a model whose tables are
+# split across pages gets falsely reported as incompletely documented.
+#
+#   env.configtable_data = {docname: {model path: {"seen", "omitted", "partial"}}}
+_ENV_ATTR = "configtable_data"
+
+
+def _doc_data(env, docname: str) -> dict:
+    store = getattr(env, _ENV_ATTR, None)
+    if store is None:
+        store = {}
+        setattr(env, _ENV_ATTR, store)
+    return store.setdefault(docname, {})
+
+_SCALAR_NAMES = {
+    "str": "string",
+    "int": "int",
+    "bool": "bool",
+    "float": "float",
+    "NoneType": "null",
+}
+
+
+def _import_model(path: str) -> Any:
+    module_name, _, class_name = path.rpartition(".")
+    if not module_name:
+        raise ValueError(f"'{path}' is not a dotted path to a class")
+    return getattr(importlib.import_module(module_name), class_name)
+
+
+def _type_name(annotation: Any) -> str:
+    text = str(annotation)
+    text = text.replace("typing.", "")
+    # str(int) is "<class 'int'>"
+    text = text.replace("<class '", "").replace("'>", "")
+    for long, short in _SCALAR_NAMES.items():
+        text = text.replace(long, short)
+    text = text.replace(" | null", " or null")
+    # Annotated[...] reprs are unreadable in a table; the bare type is enough here
+    # and the reference section shows the full annotation.
+    if text.startswith("Annotated["):
+        text = text[len("Annotated[") :].split(",", 1)[0]
+    if "." in text and "[" not in text:
+        text = text.rsplit(".", 1)[-1]
+    return text
+
+
+def _default_text(field: Any) -> str:
+    if field.is_required():
+        return "*required*"
+    default = field.default
+    if default is None:
+        # A default_factory means the real default is built at runtime
+        if getattr(field, "default_factory", None) is not None:
+            return "*see below*"
+        return "``null``"
+    if isinstance(default, bool):
+        return f"``{str(default).lower()}``"
+    if isinstance(default, str):
+        return '``""``' if default == "" else f'``"{default}"``'
+    if isinstance(default, (list, dict)) and not default:
+        return f"``{default!r}``"
+    return f"``{default!r}``"
+
+
+def _summary(field: Any, name: str, model_path: str) -> str:
+    description = (field.description or "").strip()
+    if not description:
+        logger.warning(
+            f"config-table: {model_path}.{name} has no description. Add an attribute "
+            f"docstring (or Field(description=...)) in the model.",
+            type="configtable",
+            subtype="nodescription",
+        )
+        return "\\-"
+    # First paragraph only. The generated reference section carries the whole thing.
+    summary = description.split("\n\n")[0].strip()
+    return " ".join(summary.split())
+
+
+class ConfigTable(Directive):
+    required_arguments = 1
+    has_content = True
+    option_spec = {
+        "omit": lambda arg: [n.strip() for n in (arg or "").replace(",", " ").split()],
+        "partial": lambda arg: True,
+    }
+
+    def run(self):
+        model_path = self.arguments[0].strip()
+        try:
+            model = _import_model(model_path)
+        except Exception as exc:
+            raise self.error(f"config-table: cannot import '{model_path}': {exc}")
+
+        fields = getattr(model, "model_fields", None)
+        if not fields:
+            raise self.error(f"config-table: '{model_path}' has no model_fields")
+
+        names: list[str] = []
+        overrides: dict[str, str] = {}
+        for line in self.content:
+            line = line.strip()
+            if not line:
+                continue
+            name, sep, override = line.partition("=")
+            name = name.strip()
+            names.append(name)
+            if sep:
+                overrides[name] = override.strip()
+
+        # No body means the whole model, in declaration order.
+        if not names:
+            names = list(fields)
+
+        omitted = self.options.get("omit", [])
+
+        unknown = [n for n in names + omitted if n not in fields]
+        if unknown:
+            raise self.error(
+                f"config-table: {model_path} has no field(s) {', '.join(unknown)}. "
+                f"Available: {', '.join(sorted(fields))}"
+            )
+
+        # An omitted field should not also be rendered; that would be contradictory.
+        both = sorted(set(names) & set(omitted))
+        if both:
+            raise self.error(
+                f"config-table: {model_path} field(s) {', '.join(both)} are listed in "
+                f"the table and in :omit: at the same time"
+            )
+        names = [n for n in names if n not in omitted]
+
+        env = self.state.document.settings.env
+        entry = _doc_data(env, env.docname).setdefault(
+            model_path, {"seen": set(), "omitted": set(), "partial": False}
+        )
+        entry["seen"].update(names)
+        entry["omitted"].update(omitted)
+        entry["partial"] = entry["partial"] or ("partial" in self.options)
+
+        rows = [
+            ".. list-table::",
+            "   :header-rows: 1",
+            "   :widths: 30 20 50",
+            "",
+            "   * - Option",
+            "     - Default",
+            "     - Description",
+        ]
+        for name in names:
+            field = fields[name]
+            default = overrides.get(name)
+            default = f"``{default}``" if default else _default_text(field)
+            rows.append(f"   * - ``{name}``")
+            rows.append(f"       *({_type_name(field.annotation)})*")
+            rows.append(f"     - {default}")
+            rows.append(f"     - {_summary(field, name, model_path)}")
+
+        node = nodes.container()
+        source = self.state_machine.get_source_and_line(self.lineno)[0]
+        self.state.nested_parse(StringList(rows, source=source), self.content_offset, node)
+        return node.children
+
+
+def _purge_doc(app, env, docname: str) -> None:
+    """Drop a document's contribution before it is re-read."""
+    getattr(env, _ENV_ATTR, {}).pop(docname, None)
+
+
+def _merge_info(app, env, docnames, other) -> None:
+    """Merge contributions gathered by a parallel-read worker."""
+    getattr(env, _ENV_ATTR, {}).update(getattr(other, _ENV_ATTR, {}))
+
+
+def _check_coverage(app, env) -> None:
+    """Report options of a documented model that appear in none of its tables.
+
+    Every model referenced by a config-table is checked - referencing a model is the
+    claim that the documentation covers it. Coverage is pooled across every document, so
+    a model may legitimately be split over several pages. Use ``:partial:`` to waive the
+    check while converting.
+    """
+
+    pooled: dict[str, dict] = {}
+    for per_model in getattr(env, _ENV_ATTR, {}).values():
+        for model_path, entry in per_model.items():
+            acc = pooled.setdefault(model_path, {"seen": set(), "omitted": set(), "partial": False})
+            acc["seen"] |= entry["seen"]
+            acc["omitted"] |= entry["omitted"]
+            acc["partial"] = acc["partial"] or entry["partial"]
+
+    for model_path, entry in sorted(pooled.items()):
+        if entry["partial"]:
+            continue
+        try:
+            model = _import_model(model_path)
+        except Exception:  # pragma: no cover - the directive already errored
+            continue
+
+        missing = sorted(set(model.model_fields) - entry["seen"] - entry["omitted"])
+        if missing:
+            logger.warning(
+                f"config-table: these options of {model_path} are in no table: "
+                f"{', '.join(missing)}. Add them to a table, list them in :omit:, or "
+                f"mark the table :partial: while converting.",
+                type="configtable",
+                subtype="coverage",
+            )
+
+
+def setup(app):
+    app.add_directive("config-table", ConfigTable)
+    app.connect("env-purge-doc", _purge_doc)
+    app.connect("env-merge-info", _merge_info)
+    app.connect("env-check-consistency", _check_coverage)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/_ext/configtable.py
+++ b/docs/source/_ext/configtable.py
@@ -118,11 +118,13 @@ def _type_name(annotation: Any) -> str:
 def _default_text(field: Any) -> str:
     if field.is_required():
         return "*required*"
+    # A default_factory means the real default is built at runtime. Pydantic leaves
+    # .default as PydanticUndefined (not None) for these, so this has to be checked
+    # before looking at .default at all.
+    if getattr(field, "default_factory", None) is not None:
+        return "*see below*"
     default = field.default
     if default is None:
-        # A default_factory means the real default is built at runtime
-        if getattr(field, "default_factory", None) is not None:
-            return "*see below*"
         return "``null``"
     if isinstance(default, bool):
         return f"``{str(default).lower()}``"

--- a/docs/source/admin_guide/cli_admin.rst
+++ b/docs/source/admin_guide/cli_admin.rst
@@ -1,61 +1,396 @@
-Administration & maintenance
-=====================================
+Server administration via the CLI
+=================================
 
-.. _server_admin_startstop:
+This page documents the qcfractal-server command line interface used to
+initialize, start, and administer a QCFractal server. The CLI is implemented in
+qcfractal/qcfractal/qcfractal_server_cli.py and uses argparse.
 
-Starting and Stopping
----------------------
+Quick start
+-----------
 
+- Create an initial configuration with secrets:
 
-.. _server_admin_backup:
+  .. code-block:: bash
 
-Backup and Restore
----------------------
+     qcfractal-server init-config --config /srv/qcfractal/server.yaml
 
+- Initialize the database (creates DB and tables; starts managed Postgres if applicable):
 
-.. _server_admin_upgrade:
+  .. code-block:: bash
 
-Upgrading
----------------------
+     qcfractal-server init-db --config /srv/qcfractal/server.yaml
 
+- Start the server (API + internal job runner):
 
-.. _server_admin_security:
+  .. code-block:: bash
 
-Security
----------------------
+     qcfractal-server start --config /srv/qcfractal/server.yaml -v
 
+Getting help
+------------
+
+- Top-level help and version:
+
+  .. code-block:: bash
+
+     qcfractal-server --help
+     qcfractal-server --version
+
+- Help for a subcommand (eg, user):
+
+  .. code-block:: bash
+
+     qcfractal-server user --help
+
+Global options
+--------------
+
+These options can be provided before any subcommand, or after the subcommand when
+shown as part of a subcommand’s help.
+
+- ``--config PATH``
+  Path to a QCFractal YAML configuration. See :ref:`server_configuration`.
+- ``-v/--verbose``
+  Increase logging verbosity for the command itself. Use ``-vv`` for debug output.
+
+Subcommands
+-----------
+
+init-config
+~~~~~~~~~~~
+
+Create an initial configuration file, generating secure random secrets and writing
+an example configuration you can edit.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server init-config --config /path/to/server.yaml [--full] [-v]
+
+Options:
+
+- ``--full``
+  Include all available configuration fields with their default values.
+
+Notes:
+
+- The file is created or overwritten at the path given to ``--config``.
+- You will likely want to edit the file (database credentials, API host/port, etc.)
+  before initializing the database or starting the server.
+
+init-db
+~~~~~~~
+
+Initialize the PostgreSQL database described in the configuration. If QCFractal is
+configured to manage its own Postgres instance (``database.own: true``), this command
+will initialize that instance and create the target database and tables. If using an
+external Postgres, the database must exist and be reachable; this command will create
+tables within it.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server init-db --config /path/to/server.yaml [-v]
+
+start
+~~~~~
+
+Start a QCFractal server, running both the HTTP API and the internal job runner
+(service updates and manager cleanup). This command will ensure Postgres is alive and
+that the database schema is up-to-date before starting.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server start --config /path/to/server.yaml \
+                          [--host HOST] [--port PORT] \
+                          [--logfile PATH] [--loglevel LEVEL] \
+                          [--enable-security {true,false}] \
+                          [--disable-job-runner] [-v]
+
+Useful options (override configuration values):
+
+- ``--host`` / ``--port``
+  Bind address and port for the HTTP API (same keys as ``api.host`` and ``api.port``).
+- ``--logfile``
+  File to write server logs to; if omitted, logs are written to stdout.
+- ``--loglevel``
+  One of DEBUG, INFO, WARNING, ERROR, CRITICAL.
+- ``--enable-security``
+  Override the configuration’s security toggle at startup.
+- ``--disable-job-runner``
+  Expert: start only the API and skip the internal job-runner processes.
+
+Signals and shutdown:
+
+- Press Ctrl+C or send SIGTERM to stop. The CLI will terminate child processes cleanly.
+
+start-job-runner
+~~~~~~~~~~~~~~~~
+
+Start only the internal job runner (background processes that advance services and
+perform manager cleanup). This is primarily useful in advanced deployments where
+API and job runner are separated.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server start-job-runner --config /path/to/server.yaml \
+                                     [--logfile PATH] [--loglevel LEVEL] [-v]
+
+start-api
+~~~~~~~~~
+
+Start only the HTTP API server. As with ``start``, the command checks connectivity
+to Postgres before launching the API.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server start-api --config /path/to/server.yaml \
+                              [--logfile PATH] [--loglevel LEVEL] [-v]
+
+upgrade-db
+~~~~~~~~~~
+
+Upgrade the QCFractal database schema to the latest version. Use this after updating
+QCFractal to a newer release when migration is required.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server upgrade-db --config /path/to/server.yaml [-v]
+
+If the database cannot be upgraded (eg, incompatible or missing revisions), an error
+is printed and the command exits non-zero.
+
+upgrade-config
+~~~~~~~~~~~~~~
+
+Upgrade an older QCFractal configuration file to the current format. The original file
+is backed up to ``<path>.backup`` (or ``.backup.N`` if needed), and a new file is written
+with converted settings and fresh secrets.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server upgrade-config --config /path/to/old_server.yaml [-v]
+
+info
+~~~~
+
+Display server and environment information, or show Alembic CLI invocation used for DB
+migrations.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server info --config /path/to/server.yaml [server|alembic]
+
+- ``server`` (default)
+  Prints Python executable, QCFractal version, Postgres server version, and the active
+  QCFractal configuration rendered in YAML.
+- ``alembic``
+  Prints the exact Alembic CLI command QCFractal would use to operate on the database.
 
 .. _server_admin_users:
 
-Users and Passwords
----------------------
+user
+~~~~
 
-The ``qcfractal-server user`` command allows management of users for the server.
-To list the current users, use the ``qcfractal-server user list`` subcommand.
-To add a new user, use the ``qcfractal-server user add`` command. To add a user,
-a role needs to be set for them. The following roles are accepted by QCFractal:
+Manage users in the QCFractal database. All user operations require database access via
+``--config``.
 
-+-----------+-----------------------------------------------------------------+
-| Role      | Description                                                     |
-+===========+=================================================================+
-| admin     | Administer and manage the server.                               |
-+-----------+-----------------------------------------------------------------+
-| maintain  | Similar to admin, but with some restrictions.                   |
-+-----------+-----------------------------------------------------------------+
-| monitor   | User is allowed to read information, but not submit jobs.       |
-+-----------+-----------------------------------------------------------------+
-| submit    | User is allowed to read information and submit jobs.            |
-+-----------+-----------------------------------------------------------------+
-| read      | User is allowed to read job information, but not server         |
-|           | information.                                                    |
-+-----------+-----------------------------------------------------------------+
-| anonymous | Same as read, but does not have access to user information.     |
-+-----------+-----------------------------------------------------------------+
-| compute   | User can pull jobs off the manager to run them.                 |
-+-----------+-----------------------------------------------------------------+
+Synopsis:
 
+.. code-block:: bash
 
-.. _server_admin_accesslog:
+   qcfractal-server user [list | info USERNAME | add USERNAME --role ROLE [--password PW]
+                                    [--fullname NAME] [--organization ORG] [--email EMAIL]
+                         | modify USERNAME [--fullname NAME] [--organization ORG]
+                                    [--email EMAIL] [--role ROLE]
+                                    [--enable | --disable]
+                                    [--password PW | --reset-password]
+                         | delete USERNAME [--no-prompt]] --config /path/to/server.yaml [-v]
 
-Access Logs and Geoip
----------------------
+Subcommands and options:
+
+- ``list``
+  Show a table of all users (username, role, auth type, enabled, fullname).
+
+- ``info USERNAME``
+  Show details for one user.
+
+- ``add USERNAME --role ROLE [--password PW] [--fullname ...] [--organization ...] [--email ...]``
+  Create a new user with the given role. If ``--password`` is omitted, a secure password
+  is generated and printed once. The new user is enabled by default.
+
+- ``modify USERNAME`` with flags:
+  - ``--fullname``, ``--organization``, ``--email``: Update profile fields.
+  - ``--role``: Change the user role.
+  - ``--enable`` / ``--disable``: Toggle enabled state (mutually exclusive).
+  - Password management:
+
+    - ``--password PW``: Set a specific password.
+    - ``--reset-password``: Generate and print a new random password.
+
+- ``delete USERNAME [--no-prompt]``
+  Delete the user. Without ``--no-prompt``, a confirmation is required.
+
+Note on roles: the available roles are built into the server and cannot be customized.
+Valid values for ``--role`` are ``admin``, ``maintain``, ``monitor``, ``submit``, ``read``,
+``compute``, and ``anonymous``; anything else is rejected. See :ref:`server_admin_roles`
+for what each one permits.
+
+backup
+~~~~~~
+
+Create a PostgreSQL backup (logical dump) of the current database to a file.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server backup --config /path/to/server.yaml /path/to/backup.dump [-v]
+
+The filename is required and may be absolute or relative to the current shell.
+
+restore
+~~~~~~~
+
+Restore the database from a backup file created by ``backup``. The target database
+must be reachable and empty or suitable for restore per your Postgres setup.
+
+Synopsis:
+
+.. code-block:: bash
+
+   qcfractal-server restore --config /path/to/server.yaml /path/to/backup.dump [-v]
+
+Common tasks and examples
+-------------------------
+
+Fresh installation
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # 1) Create a config (edit afterwards as needed)
+   qcfractal-server init-config --config /srv/qcfractal/server.yaml --full
+
+   # 2) Edit /srv/qcfractal/server.yaml (db credentials, host/port, etc.)
+
+   # 3) Initialize the database
+   qcfractal-server init-db --config /srv/qcfractal/server.yaml
+
+   # 4) Start the server
+   qcfractal-server start --config /srv/qcfractal/server.yaml -v
+
+External Postgres example
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   # server.yaml (excerpt)
+   database:
+     own: false
+     host: db.example.org
+     port: 5432
+     database_name: qcarchive
+     username: qcfractal
+     password: "<secret>"
+
+.. code-block:: bash
+
+   # Ensure the database exists and credentials work, then:
+   qcfractal-server init-db --config server.yaml
+   qcfractal-server start --config server.yaml
+
+User management
+~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Add an admin user with a generated password
+   qcfractal-server user add admin --role admin --fullname "QC Admin" --email admin@example.org \
+       --config server.yaml
+
+   # List users
+   qcfractal-server user list --config server.yaml
+
+   # Show user info
+   qcfractal-server user info admin --config server.yaml
+
+   # Change role and reset password
+   qcfractal-server user modify admin --role maintain --reset-password --config server.yaml
+
+   # Disable a user
+   qcfractal-server user modify alice --disable --config server.yaml
+
+   # Delete a user (with confirmation)
+   qcfractal-server user delete temp_user --config server.yaml
+
+Upgrading QCFractal and the database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # After upgrading the QCFractal package, upgrade DB schema
+   qcfractal-server upgrade-db --config server.yaml
+
+   # If you have an older config file, upgrade it
+   qcfractal-server upgrade-config --config old_server.yaml
+
+Backups and restore
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Create a backup (logical dump)
+   qcfractal-server backup --config server.yaml /backups/qcfractal_$(date +%F).dump
+
+   # Restore from a backup
+   qcfractal-server restore --config server.yaml /backups/qcfractal_2025-10-01.dump
+
+Running API and job runner separately
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Terminal 1: API only
+   qcfractal-server start-api --config server.yaml --loglevel INFO
+
+   # Terminal 2: job runner only
+   qcfractal-server start-job-runner --config server.yaml --loglevel INFO
+
+Logging and verbosity
+~~~~~~~~~~~~~~~~~~~~~
+
+- ``-v`` increases the CLI’s verbosity; ``-vv`` enables debug-level messages.
+- ``--logfile`` and ``--loglevel`` control server process logging during ``start``,
+  ``start-api``, and ``start-job-runner``.
+
+Troubleshooting
+---------------
+
+- Use ``qcfractal-server info server --config server.yaml`` to print environment and
+  the fully merged configuration.
+- If a child process dies shortly after ``start``, check the server logs (stdout or
+  the file specified by ``--logfile``) for stack traces.
+- For database connection issues, verify credentials and reachability, and try
+  ``psql`` to the configured host/port/database.
+
+See also
+--------
+
+- :ref:`server_configuration` for the full configuration reference.
+- User and dataset administration via the SDK and API is covered elsewhere in the
+  admin guide.

--- a/docs/source/admin_guide/cli_admin.rst
+++ b/docs/source/admin_guide/cli_admin.rst
@@ -247,8 +247,11 @@ Subcommands and options:
 
 Note on roles: the available roles are built into the server and cannot be customized.
 Valid values for ``--role`` are ``admin``, ``maintain``, ``monitor``, ``submit``, ``read``,
-``compute``, and ``anonymous``; anything else is rejected. See :ref:`server_admin_roles`
-for what each one permits.
+``compute``, and ``anonymous``; anything else is rejected. See
+:ref:`Users, Roles, and Groups <overview_roles>` for what each one permits.
+
+Groups have no CLI subcommand - manage them with a client
+(:meth:`~qcportal.client.PortalClient.add_group` and friends).
 
 backup
 ~~~~~~

--- a/docs/source/admin_guide/configuration.rst
+++ b/docs/source/admin_guide/configuration.rst
@@ -3,13 +3,603 @@
 Server Configuration
 ====================
 
+This page documents the QCFractal server configuration file format and all available options.
+Configuration is defined in YAML and mirrors the Pydantic settings in
+``qcfractal/qcfractal/config.py``. Options are grouped by sections according to the
+configuration hierarchy shown in that file.
 
-Server configuration here
+Quick start
+-----------
 
+- Create a configuration file (for example ``server.yaml``).
+- Run ``qcfractal-server init-config --config server.yaml`` to create an example config with secrets.
+- Start the server: ``qcfractal-server start --config server.yaml``.
+
+How configuration is loaded
+---------------------------
+
+QCFractal merges configuration from multiple sources (later items have higher priority):
+
+1. YAML files passed to ``--config`` in the order given (earlier files are lower priority).
+2. ``extra_config`` from tooling (eg, CLI flags) if provided.
+3. Environment variables. Environment variables override values provided by files.
+
+Base folder detection
+~~~~~~~~~~~~~~~~~~~~~
+
+Many options are paths that can be relative. Relative paths are resolved against a
+"base folder" using the following order:
+
+1. ``QCF_BASE_FOLDER`` environment variable, if set.
+2. ``base_folder`` key in the YAML.
+3. The directory containing the last (highest-priority) config file passed to ``--config``.
+
+Durations and retention windows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Options documented as "seconds" accept either integers (seconds) or duration strings
+  like ``"1h"``, ``"30m"``, ``"2d 6h"``. They are converted internally.
+- Retention windows (eg, ``access_log_keep``) accept days as integers or as duration strings
+  (eg, ``7`` or ``"7d"``).
+
+Environment variables
+---------------------
+
+You can set or override any option via environment variables. Every variable starts with the
+``QCF_`` prefix, followed by the name of the option in the YAML file (case does not matter).
+
+For options at the root of the YAML document, that is all you need:
+
+.. tab-set::
+
+  .. tab-item:: SHELL
+
+    .. code-block:: bash
+
+      export QCF_LOGLEVEL=DEBUG
+      export QCF_BASE_FOLDER=/srv/qcfractal
+      export QCF_MAX_ACTIVE_SERVICES=50
+
+Options that live inside a nested section (``database``, ``api``, ``api_limits``, ``cors``,
+``auto_reset``, ``s3``) are reached by joining the section name and the option name with a
+**double underscore**. The section name is spelled exactly as it appears in the YAML - so
+``api_limits`` becomes ``QCF_API_LIMITS__``, not ``QCF_APILIMIT_``.
+
+.. tab-set::
+
+  .. tab-item:: SHELL
+
+    .. code-block:: bash
+
+      export QCF_DATABASE__HOST=db.example.org
+      export QCF_DATABASE__PORT=5432
+      export QCF_API__PORT=7777
+      export QCF_API_LIMITS__GET_RECORDS=2000
+      export QCF_AUTO_RESET__ENABLED=true
+      export QCF_S3__ENABLED=true
+      export QCF_CORS__ENABLED=true
+
+.. warning::
+
+  Earlier versions of QCFractal used a separate flat prefix for each section
+  (``QCF_DB_``, ``QCF_API_``, ``QCF_APILIMIT_``, ``QCF_AUTORESET_``, ``QCF_S3_``).
+  None of these work any more, and rather than being ignored they are rejected - the
+  server refuses to start and names the replacement:
+
+  .. tab-set::
+
+    .. tab-item:: SHELL
+
+      .. code-block:: bash
+
+        $ export QCF_DB_HOST=db.example.org
+        $ qcfractal-server start --config server.yaml
+        RuntimeError: Environment variable QCF_DB_HOST is deprecated. Use QCF_DATABASE__HOST instead.
+
+  The replacements are ``QCF_DB_`` → ``QCF_DATABASE__``,
+  ``QCF_API_`` → ``QCF_API__``, ``QCF_APILIMIT_`` → ``QCF_API_LIMITS__``,
+  ``QCF_AUTORESET_`` → ``QCF_AUTO_RESET__``, and ``QCF_S3_`` → ``QCF_S3__``.
+  The check is case-insensitive, so a lowercase ``qcf_db_host`` is caught too.
+
+Top-level settings (FractalConfig)
+----------------------------------
+
+These settings live at the root of the YAML document.
+
+Required
+~~~~~~~~
+
+.. config-table:: qcfractal.config.FractalConfig
+
+   base_folder
+
+If omitted from the file it is inferred, as described under
+:ref:`base folder detection <server_configuration>` above.
+
+General
+~~~~~~~
+
+.. config-table:: qcfractal.config.FractalConfig
+
+   name
+   enable_security
+   allow_unauthenticated_read
+   strict_compute_tags
+
+The old name ``strict_queue_tags`` is still accepted for ``strict_compute_tags``, but
+logs a deprecation warning.
+
+Logging
+~~~~~~~
+
+.. config-table:: qcfractal.config.FractalConfig
+
+   logfile
+   loglevel
+   hide_internal_errors
+
+``loglevel`` is one of ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``,
+case-insensitive. A relative ``logfile`` is resolved against ``base_folder``; leaving it
+unset logs to standard output.
+
+Background operations and heartbeats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. config-table:: qcfractal.config.FractalConfig
+
+   service_frequency
+   max_active_services
+   heartbeat_frequency
+   heartbeat_frequency_jitter
+   heartbeat_max_missed
+
+A manager is considered dead after ``heartbeat_max_missed`` consecutive missed
+heartbeats - by default five checks at 1800 seconds, so about 2.5 hours. Its running
+tasks are returned to ``waiting`` to be claimed by another manager.
+
+Access logging and internal jobs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. config-table:: qcfractal.config.FractalConfig
+
+   log_access
+   access_log_keep
+   internal_job_processes
+   internal_job_keep
+
+Both retention windows are in days, or a duration string, and ``0`` means keep
+indefinitely.
+
+GeoIP2 (optional)
+~~~~~~~~~~~~~~~~~
+
+.. config-table:: qcfractal.config.FractalConfig
+
+   maxmind_license_key
+   geoip2_dir = [base_folder]/geoip2
+   geoip2_filename
+
+Static homepage and uploads (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. config-table:: qcfractal.config.FractalConfig
+
+   homepage_redirect_url
+   homepage_directory
+   upload_directory
+   temporary_dir = [base_folder]/qcf_tmp
+
+If ``base_folder`` cannot be used, ``temporary_dir`` falls back to a ``qcf_tmp``
+directory under the system temporary directory. It is created if it does not exist.
+
+Nested sections
+~~~~~~~~~~~~~~~
+
+The remaining top-level keys are the nested sections documented below.
+
+.. config-table:: qcfractal.config.FractalConfig
+
+   database
+   api
+   api_limits
+   cors
+   auto_reset
+   s3
+
+Database (database)
+-------------------
+
+Settings for the Postgres database connection and, optionally, managing the server’s own DB.
+Environment variable prefix: ``QCF_DATABASE__``.
+
+Connection
+~~~~~~~~~~
+
+.. config-table:: qcfractal.config.DatabaseConfig
+   :omit: base_folder
+
+   full_uri
+   host
+   port
+   database_name
+   username
+   password
+   query
+
+``query`` holds extra connection parameters appended to the URI, such as
+``sslmode: require``. Note that ``port`` is ignored when ``host`` is a Unix socket
+directory, though it is still used when rendering the URI.
+
+Server-managed database
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. config-table:: qcfractal.config.DatabaseConfig
+
+   own
+   data_directory = [base_folder]/postgres
+   logfile = [base_folder]/qcfractal_database.log
+   pg_tool_dir
+   pool_size
+   maintenance_db
+   echo_sql
+
+The two path defaults apply when ``own`` is true. ``base_folder`` is inherited from the
+top level and is not set in this section.
+
+Examples
+~~~~~~~~
+
+Minimal, managed Postgres (auto-start):
+
+.. code-block:: yaml
+
+  base_folder: /srv/qcfractal
+  database:
+    own: true
+    username: qcfractal
+    password: "<generated>"
+
+External Postgres:
+
+.. code-block:: yaml
+
+  database:
+    own: false
+    host: db.example.org
+    port: 5432
+    database_name: qcarchive
+    username: qcfractal
+    password: "<secret>"
+
+Using a Unix domain socket directory:
+
+.. code-block:: yaml
+
+  database:
+    host: /var/run/postgresql
+    port: 5432
+    database_name: qcarchive
+    username: qcfractal
+    password: "<secret>"
+
+Web API (api)
+-------------
+
+Settings for the HTTP API server. Environment variable prefix: ``QCF_API__``.
+
+Runtime
+~~~~~~~
+
+.. config-table:: qcfractal.config.WebAPIConfig
+
+   host
+   port
+   num_threads_per_worker
+   worker_timeout
+
+Security and sessions
+~~~~~~~~~~~~~~~~~~~~~
+
+Both secret keys are required, and ``qcfractal-server init-config`` generates them for
+you.
+
+.. config-table:: qcfractal.config.WebAPIConfig
+
+   secret_key
+   jwt_secret_key
+   jwt_access_token_expires
+   jwt_refresh_token_expires
+   user_session_max_age
+   user_session_cookie_name
+   user_session_cookie_domain
+   user_session_cookie_samesite
+   user_session_cookie_partitioned
+   user_session_cookie_secure
+   user_session_cookie_httponly
+
+For cross-site cookie behaviour set ``user_session_cookie_samesite`` to ``Lax`` or
+``None`` as needed. ``user_session_cookie_partitioned`` sets the Partitioned flag, for
+CHIPS-style storage partitioning in modern browsers.
+
+Advanced
+~~~~~~~~
+
+.. config-table:: qcfractal.config.WebAPIConfig
+
+   extra_flask_options
+   extra_waitress_options
+
+These are passed straight through to Flask and to the waitress ``serve`` function
+respectively, so anything those accept is valid here and nothing is validated by
+QCFractal.
+
+API limits (api_limits)
+-----------------------
+
+Limits on sizes and pagination for common API calls. Environment variable prefix: ``QCF_API_LIMITS__``.
+
+Every option here is an integer, and every one is a hard ceiling: a request asking for
+more than the limit is not an error, it is silently truncated to the limit. Clients page
+through the results, so raising these mainly trades server memory for fewer round trips.
+
+.. config-table:: qcfractal.config.APILimitConfig
 
 .. _server_configuration_autoreset_error:
 
-autoreset error
----------------
+Automatic resets (auto_reset)
+-----------------------------
 
-Autoresetting errors
+Limits on how often tasks may be automatically retried based on error type. Environment variable prefix: ``QCF_AUTO_RESET__``.
+
+.. config-table:: qcfractal.config.AutoResetConfig
+
+The counts are per record: once a record has been auto-reset that many times for that
+category of error, it is left in ``error`` for a human to look at. See
+:ref:`troubleshooting_errors`.
+
+CORS (cors)
+-----------
+
+Cross-Origin Resource Sharing settings for the API. Configure in YAML.
+
+.. config-table:: qcfractal.config.CORSconfig
+
+Example:
+
+.. code-block:: yaml
+
+  cors:
+    enabled: true
+    origins: ["https://example.org", "http://localhost:3000"]
+    supports_credentials: true
+    headers: ["Content-Type", "Authorization"]
+    methods: ["GET", "POST", "OPTIONS"]
+
+S3 external files (s3)
+----------------------
+
+Settings for storing large external files in S3-compatible storage. Environment variable prefix: ``QCF_S3__``.
+
+.. config-table:: qcfractal.config.S3Config
+
+``bucket_map`` maps each logical file type to a bucket name:
+
+.. config-table:: qcfractal.config.S3BucketMap
+
+.. note::
+
+  Bucket names must be valid S3 bucket names: 3-63 characters, lowercase letters, digits and
+  hyphens only, ending in a letter or digit. Underscores are **not** allowed, so a value like
+  ``dataset_attachment`` will be rejected at startup.
+
+If ``enabled: true`` you must specify ``endpoint_url``, ``access_key_id``, and ``secret_access_key``.
+
+Example:
+
+.. code-block:: yaml
+
+  s3:
+    enabled: true
+    endpoint_url: https://s3.us-west-2.amazonaws.com
+    access_key_id: ${AWS_ACCESS_KEY_ID}
+    secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+    verify: true
+    bucket_map:
+      dataset_attachment: qcarchive-attachments
+      project_attachment: qcarchive-projects
+
+Minimal and full configuration examples
+---------------------------------------
+
+Minimal (sensible defaults; secrets generated by ``qcfractal-server init-config``):
+
+.. code-block:: yaml
+
+  base_folder: /srv/qcfractal
+  name: QCFractal Server
+  enable_security: true
+  allow_unauthenticated_read: true
+
+  database:
+    own: true
+    username: qcfractal
+    password: "<generated>"
+
+  api:
+    host: 0.0.0.0
+    port: 7777
+    secret_key: "<generated>"
+    jwt_secret_key: "<generated>"
+
+  api_limits: {}
+  cors: {}
+  auto_reset: {}
+
+Full skeleton (all options with defaults; adjust as needed):
+
+.. code-block:: yaml
+
+  base_folder: /srv/qcfractal
+  name: QCFractal Server
+  enable_security: true
+  allow_unauthenticated_read: true
+  strict_compute_tags: false
+  logfile: null
+  loglevel: INFO
+  hide_internal_errors: true
+  service_frequency: 60
+  max_active_services: 20
+  heartbeat_frequency: 1800
+  heartbeat_frequency_jitter: 0.1
+  heartbeat_max_missed: 5
+  log_access: false
+  access_log_keep: 0
+  internal_job_processes: 1
+  internal_job_keep: 0
+  maxmind_license_key: null
+  geoip2_dir: geoip2
+  geoip2_filename: GeoLite2-City.mmdb
+  homepage_redirect_url: null
+  homepage_directory: null
+  upload_directory: null
+  temporary_dir: null
+
+  database:
+    full_uri: null
+    host: localhost
+    port: 5432
+    database_name: qcfractal_default
+    username: qcfractal
+    password: "<secret>"
+    query: {}
+    own: true
+    data_directory: postgres
+    logfile: qcfractal_database.log
+    echo_sql: false
+    pg_tool_dir: null
+    pool_size: 5
+    maintenance_db: postgres
+
+  api:
+    num_threads_per_worker: 4
+    worker_timeout: 120
+    host: localhost
+    port: 7777
+    secret_key: "<secret>"
+    jwt_secret_key: "<secret>"
+    jwt_access_token_expires: 3600
+    jwt_refresh_token_expires: 86400
+    user_session_max_age: 86400
+    user_session_cookie_name: qcf_session
+    user_session_cookie_domain: null
+    user_session_cookie_samesite: null
+    user_session_cookie_partitioned: false
+    user_session_cookie_secure: false
+    user_session_cookie_httponly: false
+    extra_flask_options: null
+    extra_waitress_options: null
+
+  api_limits:
+    get_records: 1000
+    add_records: 500
+    get_dataset_entries: 2000
+    get_molecules: 1000
+    add_molecules: 1000
+    get_managers: 1000
+    manager_tasks_claim: 200
+    manager_tasks_return: 10
+    get_access_logs: 1000
+    get_error_logs: 100
+    get_internal_jobs: 1000
+
+  cors:
+    enabled: false
+    origins: []
+    supports_credentials: false
+    headers: []
+    methods: []
+
+  auto_reset:
+    enabled: false
+    unknown_error: 2
+    compute_lost: 5
+    random_error: 5
+
+  s3:
+    enabled: false
+    verify: true
+    passthrough: false
+    endpoint_url: null
+    access_key_id: null
+    secret_access_key: null
+    auto_create_buckets: false
+    bucket_map:
+      dataset_attachment: dataset-attachments
+      project_attachment: project-attachments
+
+Environment variable examples
+-----------------------------
+
+- Override the base folder and database host on the fly:
+
+  .. code-block:: bash
+
+     export QCF_BASE_FOLDER=/srv/qcfractal
+     export QCF_DATABASE__HOST=db.internal
+     qcfractal-server start --config server.yaml
+
+- Bind the API to a different port and enable verbose logging:
+
+  .. code-block:: bash
+
+     export QCF_API__PORT=8888
+     export QCF_LOGLEVEL=DEBUG
+     qcfractal-server start --config server.yaml
+
+Notes on path handling
+----------------------
+
+- Paths that are not absolute are resolved relative to ``base_folder``.
+- If a path option is ``null`` and a default is described as ``[base_folder]/...``, QCFractal will apply that default at runtime.
+- ``temporary_dir`` is created automatically if it does not exist.
+
+
+.. _server_configuration_reference:
+
+Generated reference
+-------------------
+
+The sections above are the documentation for these options - they explain what the
+options are for, how they interact, and what sensible values look like. What follows is
+generated directly from the pydantic models in ``qcfractal/qcfractal/config.py``, and is
+here as a cross-check: it is guaranteed to list every option that actually exists, with
+its real type and default.
+
+Where the two disagree, this section is right about *what* the code accepts and the prose
+above is right about *why*.
+
+.. note::
+
+  A few defaults are shown here as ``None`` but are filled in at runtime - ``geoip2_dir``,
+  ``temporary_dir``, the database ``data_directory`` and ``logfile``. The prose above gives
+  the effective values (``[base_folder]/...``). Likewise, options described above as
+  accepting duration strings appear here as ``int``, since that is the type they are
+  converted to.
+
+.. autoclass:: qcfractal.config.FractalConfig
+   :exclude-members: settings_customise_sources, __init__
+
+.. autoclass:: qcfractal.config.DatabaseConfig
+
+.. autoclass:: qcfractal.config.WebAPIConfig
+
+.. autoclass:: qcfractal.config.APILimitConfig
+
+.. autoclass:: qcfractal.config.AutoResetConfig
+
+.. autoclass:: qcfractal.config.CORSconfig
+
+.. autoclass:: qcfractal.config.S3Config
+
+.. autoclass:: qcfractal.config.S3BucketMap
+

--- a/docs/source/admin_guide/index.rst
+++ b/docs/source/admin_guide/index.rst
@@ -8,5 +8,6 @@ QCFractal Server User Guide
    setup
    configuration
    cli_admin
+   portal_admin
    monitoring
    managers/index

--- a/docs/source/admin_guide/managers/index.rst
+++ b/docs/source/admin_guide/managers/index.rst
@@ -49,7 +49,7 @@ For this example, we are assuming a cluster using LSF as the scheduler; for othe
         request_by_nodes: false
         scheduler_options:            # add additional options for submission command
           - "-R fscratch"
-        queue_tags:                   # only claim tasks with these tags; '*' means all tags accepted
+        compute_tags:                 # only claim tasks with these tags; '*' means all tags accepted
           - '*'
         environments:
           use_manager_environment: False   # don't use the manager environment for task execution
@@ -110,7 +110,7 @@ Set the name of this conda env (``qcfractal-worker-psi4-18.1``) in the line ``- 
 
 Finally, start up the compute manager::
 
-    $ qcfractal-compute-manager --config config.yml
+    $ qcfractal-compute-manager --config qcfractal-manager-config.yml
 
 The compute manager will read its config file, communicate with the QCFractal server to claim tasks, and launch jobs to the HPC scheduler as needed to execute those tasks using the worker conda environment.
 To keep it running beyond your current session if connected via SSH, consider running the compute manager under `tmux`_ or `screen`_.
@@ -127,6 +127,15 @@ Configuration for different HPC schedulers
 ------------------------------------------
 HPC cluster schedulers vary in behavior, so you will need to adapt your ``qcfractal-manager-config.yml`` to the scheduler of the HPC cluster you intend to use.
 The configuration keys available for each ``type`` of record in the ``executors`` list are referenced here.
+
+Every executor, whatever its ``type``, accepts the keys on ``ExecutorConfig`` below - including
+``compute_tags``, ``cores_per_worker``, ``memory_per_worker``, ``worker_init``, and the nested
+``environments`` block. The scheduler-specific classes that follow add their own keys on top.
+
+.. autoclass:: qcfractalcompute.config.ExecutorConfig
+
+
+.. autoclass:: qcfractalcompute.config.PackageEnvironmentSettings
 
 
 .. autoclass:: qcfractalcompute.config.SlurmExecutorConfig
@@ -151,7 +160,7 @@ If leaving a long-running process running on the head node is undesirable, then 
         max_workers: 4                # max number of workers to spawn
         cores_per_worker: 16          # cores per worker
         memory_per_worker: 96         # memory per worker, in GiB
-        queue_tags:
+        compute_tags:
           - '*'
         environments:
           use_manager_environment: False

--- a/docs/source/admin_guide/portal_admin.rst
+++ b/docs/source/admin_guide/portal_admin.rst
@@ -1,0 +1,346 @@
+Administering a QCFractal server with PortalClient
+==================================================
+
+This page shows how to administer a running QCFractal server programmatically
+using the Python client API provided by qcportal's PortalClient.
+
+The examples below assume you can connect to the server with an administrative
+account (or a user granted the appropriate permissions for the action).
+
+.. note::
+
+   These administrative APIs correspond to the same capabilities exposed by the
+   command-line interface described in :doc:`cli_admin` but are accessible from
+   Python for scripting and automation.
+
+
+Getting started: connecting and authentication
+----------------------------------------------
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      from qcportal import PortalClient
+
+      # Connect with an admin-capable account
+      client = PortalClient(
+          "http://localhost:7777",
+          username="admin",
+          password="your-admin-password",
+      )
+
+
+Users: add, list, enable/disable, change passwords, delete
+----------------------------------------------------------
+
+User objects are represented by :class:`~qcportal.auth.models.UserInfo`.
+
+.. _server_admin_roles:
+
+User roles
+^^^^^^^^^^
+
+Every user is assigned exactly one *role*, which determines what that user is permitted to do.
+The set of roles is built into the server and cannot be customized; assigning any other name
+raises an error.
+
+.. table::
+
+  ==============  =============================================================================
+   Role            Description
+  ==============  =============================================================================
+   ``admin``       Unrestricted access to everything, including user management
+   ``maintain``    Full access to records, datasets, projects, groups, logs and internal jobs.
+                   Can read users, but not create or modify them
+   ``monitor``     Read-only, and additionally can read access logs, server errors,
+                   and internal jobs
+   ``submit``      Read, add, modify and delete records, datasets and projects.
+                   The usual role for a working user
+   ``read``        Read-only access to records, datasets, projects and manager information
+   ``compute``     Reserved for compute managers claiming and returning tasks
+   ``anonymous``   Applied to unauthenticated access when ``allow_unauthenticated_read``
+                   is enabled
+  ==============  =============================================================================
+
+.. note::
+
+  These roles are not scoped by ownership - a user with the ``submit`` role may modify or
+  delete any record or dataset on the server, not only the ones they created.
+
+List users and view details
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      from qcportal.auth import UserInfo
+
+      # List all users
+      users = client.list_users()
+      for u in users:
+          print(u.username, u.role, u.enabled, u.groups)
+
+      # Get a specific user (by username or id)
+      alice = client.get_user("alice")
+      print(alice)
+
+Add a new user
+^^^^^^^^^^^^^^
+
+When creating a user you provide a UserInfo (without id) and optionally an initial password.
+If you omit the password, the server will generate one and return it.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      from qcportal.auth import UserInfo
+
+      # Minimal required fields: username, role, enabled
+      new_user = UserInfo(
+          username="alice",
+          role="submit",         # see the list of roles above
+          groups=["chemistry"],  # optional group memberships
+          enabled=True,
+          fullname="Alice Example",
+          email="alice@example.org",
+      )
+
+      # Let the server generate a password
+      generated_pw = client.add_user(new_user)
+      print("Generated password:", generated_pw)
+
+      # Or specify an initial password yourself
+      client.add_user(new_user, password="ChangeMe123")
+
+Enable/disable a user or update fields
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use modify_user with a UserInfo that includes the user's id (you can obtain it via get_user).
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      # Disable a user account
+      bob = client.get_user("bob")
+      bob.enabled = False
+      bob = client.modify_user(bob)
+      print("Bob enabled?", bob.enabled)
+
+      # Change role or groups
+      bob.role = "maintain"
+      bob.groups = sorted(set(bob.groups + ["theory"]))
+      bob = client.modify_user(bob)
+
+Change a user's password
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Admins can change any user's password. Users can also change their own
+password by omitting the username.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      # Admin changes a user's password (returns the new password)
+      new_pw = client.change_user_password("alice", new_password="BetterPW!1")
+
+      # Ask the server to generate a random password
+      random_pw = client.change_user_password("alice")
+
+      # User changes their own password (assumes logged in as alice)
+      # client = PortalClient(..., username="alice", password="old")
+      # new_pw = client.change_user_password(new_password="my-new-secret")
+
+Delete a user
+^^^^^^^^^^^^^
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      client.delete_user("alice")
+
+
+Groups: create, list, get, delete
+---------------------------------
+
+Groups are described by :class:`~qcportal.auth.models.GroupInfo` and can be used
+for organization and authorization policies.
+
+List and get groups
+^^^^^^^^^^^^^^^^^^^
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      from qcportal.auth import GroupInfo
+
+      groups = client.list_groups()
+      for g in groups:
+          print(g.groupname, g.description)
+
+      chem = client.get_group("chemistry")
+      print(chem)
+
+Create and delete groups
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      from qcportal.auth import GroupInfo
+
+      new_group = GroupInfo(groupname="chemistry", description="Chemistry users")
+      client.add_group(new_group)
+
+      # Remove a group (users will have it removed from their memberships)
+      client.delete_group("chemistry")
+
+.. note::
+
+   Adding/removing users to groups is done by updating the user's ``groups`` field
+   via :meth:`~qcportal.client.PortalClient.modify_user`.
+
+
+Compute managers: viewing manager information
+---------------------------------------------
+
+You can query compute manager registrations and see their status and capabilities.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      # List all managers (iterator yields ComputeManager models)
+      it = client.query_managers(limit=100)
+      managers = list(it)
+      for m in managers:
+          print(m.name, m.status, m.cluster, m.hostname, m.compute_tags)
+
+      # Filter by name or status. Managers are either 'active' or 'inactive'
+      for m in client.query_managers(name=["my_manager"], status=["active"]):
+          print(m)
+
+      # Ask which managers could handle a task with certain tags/programs
+      possible = client.query_active_managers(
+          compute_tag=["cpu-ephemeral", "bigmem"],
+          programs={"psi4": ["1.8"], "torchani": ["2.2"]},
+      )
+      print("Candidate managers:", possible)
+
+
+Access log: view and clear
+--------------------------
+
+The server access log tracks who accessed which API, and when.
+
+Query access logs
+^^^^^^^^^^^^^^^^^
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      from datetime import timedelta
+
+      from qcportal.utils import now_at_utc
+
+      # Recent entries for a specific user
+      one_day_ago = now_at_utc() - timedelta(days=1)
+      for entry in client.query_access_log(user=["alice"], after=one_day_ago, limit=100):
+          print(entry.timestamp, entry.user, entry.module, entry.method, entry.full_uri)
+
+      # Summarize accesses per day
+      summary = client.query_access_summary(group_by="day", after=one_day_ago)
+      for day, entries in summary.entries.items():
+          print(day, sum(x.count for x in entries))
+
+Delete old access logs
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. danger::
+
+   Deleting log entries is permanent. Consider exporting before deletion.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      from datetime import timedelta
+
+      from qcportal.utils import now_at_utc
+
+      cutoff = now_at_utc() - timedelta(days=30)
+      deleted = client.delete_access_log(before=cutoff)
+      print("Deleted entries:", deleted)
+
+
+Internal jobs: view, cancel, delete
+-----------------------------------
+
+Internal jobs are server-maintained background jobs. You can query their status,
+request cancellation, or delete completed/error entries.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      from qcportal.internal_jobs import InternalJobStatusEnum
+
+      # Query internal jobs (iterator)
+      jobs = list(client.query_internal_jobs(status=[InternalJobStatusEnum.running], limit=50))
+      for j in jobs:
+          print(j.id, j.name, j.status, j.modified_on)
+
+      # Get a specific job
+      job = client.get_internal_job(job_id=123)
+      print(job)
+
+      # Cancel a job (asks server to stop it)
+      client.cancel_internal_job(job_id=123)
+
+      # Delete a finished/failed job entry
+      client.delete_internal_job(job_id=123)
+
+
+Tips and notes
+--------------
+
+- Permissions: Some actions require elevated privileges. Ensure the account you
+  authenticate with has the necessary role/policies on the server.
+- Validation: Helper functions like :func:`~qcportal.auth.models.is_valid_username`,
+  :func:`~qcportal.auth.models.is_valid_password`, and
+  :func:`~qcportal.auth.models.is_valid_groupname` validate inputs and are invoked
+  by client methods. Errors will be raised if inputs are invalid.
+- Pagination: Many query methods return iterators (eg, managers, access logs,
+  internal jobs). Iterate or cast to ``list`` to pull results.

--- a/docs/source/admin_guide/portal_admin.rst
+++ b/docs/source/admin_guide/portal_admin.rst
@@ -38,37 +38,14 @@ Users: add, list, enable/disable, change passwords, delete
 
 User objects are represented by :class:`~qcportal.auth.models.UserInfo`.
 
-.. _server_admin_roles:
-
-User roles
-^^^^^^^^^^
-
-Every user is assigned exactly one *role*, which determines what that user is permitted to do.
-The set of roles is built into the server and cannot be customized; assigning any other name
-raises an error.
-
-.. table::
-
-  ==============  =============================================================================
-   Role            Description
-  ==============  =============================================================================
-   ``admin``       Unrestricted access to everything, including user management
-   ``maintain``    Full access to records, datasets, projects, groups, logs and internal jobs.
-                   Can read users, but not create or modify them
-   ``monitor``     Read-only, and additionally can read access logs, server errors,
-                   and internal jobs
-   ``submit``      Read, add, modify and delete records, datasets and projects.
-                   The usual role for a working user
-   ``read``        Read-only access to records, datasets, projects and manager information
-   ``compute``     Reserved for compute managers claiming and returning tasks
-   ``anonymous``   Applied to unauthenticated access when ``allow_unauthenticated_read``
-                   is enabled
-  ==============  =============================================================================
+For what users, roles, and groups *are* - the list of roles and what each permits, what
+happens on a server with security disabled, and how unauthenticated access works - see
+:doc:`../overview/users_groups`. This section covers the administrative operations.
 
 .. note::
 
-  These roles are not scoped by ownership - a user with the ``submit`` role may modify or
-  delete any record or dataset on the server, not only the ones they created.
+  Roles are not scoped by ownership. A user with the ``submit`` role may modify or delete
+  any record or dataset on the server, not only the ones they created.
 
 List users and view details
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,8 @@
 
 # Other packages
 import datetime
+import os
+import sys
 
 # Import the package for version info
 import qcfractal
@@ -16,9 +18,9 @@ import qcfractal
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+# Local extensions live in _ext (see the `config-table` directive used by the
+# configuration pages).
+sys.path.insert(0, os.path.abspath("_ext"))
 
 
 # -- Project information -----------------------------------------------------
@@ -53,6 +55,8 @@ extensions = [
     "sphinxcontrib.pydantic",
     "sphinx_copybutton",
     "myst_nb",
+    # Local, in _ext/
+    "configtable",
 ]
 
 # Some options

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,24 +50,23 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx_design",
-#    "sphinxcontrib.autodoc_pydantic",
+    "sphinxcontrib.pydantic",
     "sphinx_copybutton",
     "myst_nb",
 ]
 
 # Some options
 add_module_names = False
-autoclass_content = "both"
 autodoc_typehints = "description"
+autodoc_class_signature = "separated"
 autodoc_default_options = {
     "members": True,
     "undoc-members": True,
     "inherited-members": "BaseModel,str,int,float,bool",
     "show-inheritance": True,
     "member-order": "bysource",
+    "exclude-members": "__new__",
 }
-#autodoc_pydantic_model_show_json = False
-#autodoc_pydantic_settings_show_json = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
     "sphinx_design",
 #    "sphinxcontrib.autodoc_pydantic",
     "sphinx_copybutton",
@@ -121,3 +122,18 @@ extlinks = {
     "pr": ("https://github.com/MolSSI/QCFractal/pull/%s", "PR %s"),
     "contrib": ("https://github.com/%s", "@%s"),
 }
+
+# -- intersphinx extension -------------------------------------------------
+
+# Lets type annotations pulled in by autodoc (datetime, Iterable, pydantic
+# BaseModel, and so on) link to the upstream documentation instead of
+# rendering as plain text.
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    # docs.pydantic.dev/latest redirects here; use the target directly
+    "pydantic": ("https://pydantic.dev/docs/validation/latest", None),
+    "qcelemental": ("https://molssi.github.io/QCElemental/dev", None),
+    "pandas": ("https://pandas.pydata.org/docs", None),
+}
+
+intersphinx_timeout = 30

--- a/docs/source/overview/glossary.rst
+++ b/docs/source/overview/glossary.rst
@@ -133,6 +133,22 @@ form :ref:`records <glossary_record>` that are associated with the dataset.
 See :doc:`../user_guide/datasets/index`
 
 
+.. _glossary_project:
+
+project
+--------------------------
+
+A *project* is a named container that groups together the :ref:`records <glossary_record>` and
+:ref:`datasets <glossary_dataset>` belonging to a single piece of work, along with any files
+you want to keep with them.
+
+Within a project, records and datasets are given names, so they can be referred to by name
+rather than by ID. A record or dataset may be created directly in a project, or an existing
+one that already lives on the server may be linked into it.
+
+See :doc:`../user_guide/projects/index`
+
+
 .. _glossary_dataset_view:
 
 dataset view

--- a/docs/source/overview/glossary.rst
+++ b/docs/source/overview/glossary.rst
@@ -28,7 +28,7 @@ specification
 --------------------------
 
 A *specification* details how a computation should be run. For example, an
-:class:`~qcportal.optimization.OptimizationSpecification` contains
+:class:`~qcportal.optimization.record_models.OptimizationSpecification` contains
 information about the program used to run the optimization, which method or basis, and other
 input information.
 

--- a/docs/source/overview/index.rst
+++ b/docs/source/overview/index.rst
@@ -10,6 +10,7 @@ QCArchive Overview
    glossary
    tasks_services
    internal_jobs
+   users_groups
    snowflake
 
 Introduction

--- a/docs/source/overview/users_groups.rst
+++ b/docs/source/overview/users_groups.rst
@@ -1,0 +1,190 @@
+.. _overview_users_groups:
+
+Users, Roles, and Groups
+========================
+
+A QCArchive server can require users to log in, and controls what each of them may do. This
+page describes how that works from a user's point of view. For the commands to actually
+create and modify users, see :ref:`the CLI <server_admin_users>` or
+:doc:`the PortalClient <../admin_guide/portal_admin>`.
+
+Not every server enables this. See :ref:`overview_security_disabled` below.
+
+
+.. _overview_users:
+
+Users
+-----
+
+A user is identified by a **username** and authenticates with a **password**. Beyond that,
+a user record carries a small amount of descriptive information (full name, organization,
+email), an **enabled** flag, exactly one :ref:`role <overview_roles>`, and a list of
+:ref:`groups <overview_groups>`.
+
+Usernames may not be empty, contain spaces, or consist only of digits. Passwords must be at
+least six characters. Both are rejected by the server rather than silently altered.
+
+Disabling a user is the reversible alternative to deleting one: a disabled user still exists
+and still owns whatever they created, but cannot log in. Records and datasets record the
+user who created them in their ``creator_user`` field, so deleting a user is not something
+to do casually.
+
+.. note::
+
+  A user's own information is available through :meth:`~qcportal.client.PortalClient.get_user`
+  with no arguments. Changing your own password does not require an administrative role -
+  every role except ``anonymous`` may read and modify its own account.
+
+
+.. _overview_roles:
+
+Roles
+-----
+
+Every user has exactly **one** role, and that role alone determines what the user may do.
+Roles are built into the server: the set is fixed, and assigning any other name is an error.
+
+.. table::
+
+  ==============  =============================================================================
+   Role            What it permits
+  ==============  =============================================================================
+   ``admin``       Everything, including managing users and groups
+   ``maintain``    Full access to records, datasets, projects, groups, logs and internal jobs,
+                   and can change the server information and message of the day. Can read
+                   users, but not create or modify them
+   ``monitor``     Read-only, and additionally can read access logs, server errors,
+                   and internal jobs
+   ``submit``      Read, add, modify and delete records, datasets and projects.
+                   The usual role for a working user
+   ``read``        Read-only access to records, datasets, projects, managers and server
+                   information
+   ``compute``     Reserved for compute managers claiming and returning tasks
+   ``anonymous``   The same read-only access as ``read``, minus the ability to see or change
+                   an account. Applied to unauthenticated connections when
+                   ``allow_unauthenticated_read`` is enabled - see
+                   :ref:`overview_unauthenticated_read`
+  ==============  =============================================================================
+
+Two things about roles are worth knowing up front, because they surprise people:
+
+**Roles are not scoped by ownership.** A user with the ``submit`` role may modify or delete
+*any* record, dataset, or project on the server, not only the ones they created. There is no
+per-object permission; if someone can delete records, they can delete everyone's records.
+
+**Permissions are per resource and action, not per object.** The server asks a single
+question - "may this role perform this action on this kind of thing?" - and the answer does
+not depend on which particular record or dataset is involved.
+
+If you get an unexpected ``403``, it is because your role does not permit that action at
+all. See :ref:`troubleshooting_connection`.
+
+
+.. _overview_groups:
+
+Groups
+------
+
+A server may define **groups**, and users may be members of any number of them. A group has
+a name and a description.
+
+Group membership is visible on a user's own information and is included in the session token,
+so an application built against the web API can read it and use it for its own purposes.
+
+
+.. _overview_security_disabled:
+
+Servers with security disabled
+------------------------------
+
+Authentication is optional. A server started with ``enable_security: false`` does not
+authenticate anyone, and every user-facing operation is permitted without logging in -
+reading and submitting records, creating datasets and projects, viewing managers and logs.
+
+This is the default for a :doc:`snowflake <snowflake>`, which is why nothing in the
+quickstart asks you for a password.
+
+The exception is user and group management itself. Those endpoints require security to be
+enabled, and refuse to run otherwise:
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> client.list_users()
+      qcportal.client_base.PortalRequestError: Request failed: Cannot access 'users' with security disabled
+
+This covers listing, adding, modifying and deleting users and groups, and the "my own
+account" endpoints. Everything else behaves normally.
+
+
+.. _overview_unauthenticated_read:
+
+Read-only access without logging in
+-----------------------------------
+
+A server with security *enabled* can still allow anonymous browsing, controlled by
+``allow_unauthenticated_read``:
+
+.. table::
+
+  ==================================  ==========================================================
+   ``allow_unauthenticated_read``      Connecting without credentials
+  ==================================  ==========================================================
+   ``true`` (the default)              Permitted, with the ``anonymous`` role - read-only access
+                                       to records, datasets, projects, managers, and server
+                                       information
+   ``false``                           Refused, with ``Server requires login``
+  ==================================  ==========================================================
+
+The ``anonymous`` role is read-only. Submitting anything, or modifying anything, requires
+logging in as a user whose role permits it.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> # No credentials - works if the server allows unauthenticated read
+      >>> client = PortalClient("https://ml.qcarchive.molssi.org")
+
+      >>> # With credentials
+      >>> client = PortalClient("https://ml.qcarchive.molssi.org",
+      ...                       username="ben", password="<password>")
+
+See :doc:`../user_guide/client_setup` for keeping credentials out of your scripts, and
+:ref:`server_configuration` for the two settings above.
+
+
+Managing users and groups
+-------------------------
+
+Creating and modifying users requires the ``admin`` role, and can be done either way:
+
+* :ref:`From the command line <server_admin_users>`, with ``qcfractal-server user``. This is
+  the usual route, and the only one available before any user exists - it runs against the
+  database directly rather than through the API.
+* :doc:`From a PortalClient <../admin_guide/portal_admin>`, which is more convenient for
+  scripting against a running server.
+
+**Groups can only be managed through a client.** There is no ``qcfractal-server group``
+subcommand; use :meth:`~qcportal.client.PortalClient.add_group` and friends.
+
+
+Users and Groups API Reference
+------------------------------
+
+* :class:`qcportal.auth.models.UserInfo`
+* :class:`qcportal.auth.models.GroupInfo`
+
+* PortalClient methods
+
+  * :meth:`~qcportal.client.PortalClient.get_user`, :meth:`~qcportal.client.PortalClient.list_users`
+  * :meth:`~qcportal.client.PortalClient.add_user`, :meth:`~qcportal.client.PortalClient.modify_user`,
+    :meth:`~qcportal.client.PortalClient.delete_user`
+  * :meth:`~qcportal.client.PortalClient.change_user_password`
+  * :meth:`~qcportal.client.PortalClient.list_groups`, :meth:`~qcportal.client.PortalClient.get_group`,
+    :meth:`~qcportal.client.PortalClient.add_group`, :meth:`~qcportal.client.PortalClient.delete_group`

--- a/docs/source/quickstart/qca_15min.ipynb
+++ b/docs/source/quickstart/qca_15min.ipynb
@@ -418,7 +418,7 @@
     "Instead of submitting these computations separately, we could have grouped them together in a dataset. \n",
     "This would allow us to more easily retrieve the results together.\n",
     "\n",
-    "To create a dataset, you use the `create_dataset` method.\n",
+    "To create a dataset, you use the `add_dataset` method.\n",
     "\n",
     "```python\n",
     "\n",

--- a/docs/source/user_guide/datasets/basics.rst
+++ b/docs/source/user_guide/datasets/basics.rst
@@ -240,6 +240,79 @@ If you are in an interactive session or notebook, or just want a prettier versio
   local caching.
 
 
+.. _dataset_status_by_compute_tag:
+
+Status by Compute Tag
+---------------------
+
+:meth:`~qcportal.dataset_models.BaseDataset.status_by_compute_tag` breaks the status of the dataset's
+computations down by :ref:`compute tag <compute_tags>` rather than by specification. This answers a
+different question than :meth:`~qcportal.dataset_models.BaseDataset.status` does: not "how far along
+is each column of my dataset", but "which of my queues is this dataset waiting on".
+
+It returns a list of ``(compute tag, status, count)`` tuples.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> ds.status_by_compute_tag()
+      [('large_mem', <RecordStatusEnum.waiting: 'waiting'>, 12),
+       ('large_mem', <RecordStatusEnum.error: 'error'>, 2),
+       ('*', <RecordStatusEnum.running: 'running'>, 4)]
+
+This is useful when a dataset has been submitted under more than one tag - for example, if part of it
+was submitted with a tag that no compute manager is currently claiming, this is how that shows up.
+It is also the quickest way to see which tag a dataset's outstanding work is actually sitting under,
+which is not always the dataset's ``default_compute_tag``:
+:meth:`~qcportal.dataset_models.BaseDataset.submit` can override the tag for individual submissions,
+and records can be retagged afterwards.
+
+.. important::
+
+  **Only records that still have a task or service queue entry are counted.** A record's task is
+  removed from the queue once it completes, so completed records never appear here, and the counts
+  will not add up to the counts from :meth:`~qcportal.dataset_models.BaseDataset.status`. In practice
+  this method reports waiting, running, and errored records.
+
+  This is a feature rather than a limitation - the point of the method is to show outstanding work -
+  but it does mean an empty list means "nothing is queued", not "nothing exists".
+
+  Records whose computation type is a :ref:`service <glossary_service>` (torsiondrive, gridoptimization,
+  NEB, manybody, and reaction) keep their queue entry when they are cancelled, deleted, or
+  invalidated, since it holds the service's state. Those statuses can therefore appear for datasets of
+  those types, but not for singlepoint or optimization datasets.
+
+The returned list is neither sorted nor aggregated any further, so sort it yourself if you want stable
+output:
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> from collections import defaultdict
+
+      >>> by_tag = defaultdict(dict)
+      >>> for tag, status, count in ds.status_by_compute_tag():
+      ...     by_tag[tag][status.value] = count
+
+      >>> for tag in sorted(by_tag):
+      ...     print(tag, dict(sorted(by_tag[tag].items())))
+      * {'running': 4}
+      large_mem {'error': 2, 'waiting': 12}
+
+.. note::
+
+  A related method, :meth:`~qcportal.dataset_models.BaseDataset.detailed_status`, returns a list of
+  ``(entry name, specification name, status)`` tuples - one per record in the dataset, with no
+  grouping. It is the right tool when you need to know *which* entries are in a given state rather
+  than how many.
+
+
 Specifications and Entries
 --------------------------
 

--- a/docs/source/user_guide/datasets/basics.rst
+++ b/docs/source/user_guide/datasets/basics.rst
@@ -125,7 +125,7 @@ Dataset Metadata
 
 Datasets have some useful metadata and properties
 
-* **name**, **description**, **tagline**, **group**, and **tags** are user-defined metadata that categorize this dataset
+* **name**, **description**, **tagline**, and **tags** are user-defined metadata that categorize this dataset
   among the other datasets
 * **default_compute_tag** and **default_compute_priority** are the defaults used when submitting new computations (can be overridden
   in :meth:`~qcportal.dataset_models.BaseDataset.submit`, see :ref:`dataset_submission`).
@@ -290,7 +290,7 @@ You can obtain a full entry from its name with :meth:`~qcportal.dataset_models.B
 
     .. code-block:: py3
 
-      >>> print(ds.get_entry)
+      >>> print(ds.get_entry('H2'))
       OptimizationDatasetEntry(name='H2', initial_molecule=Molecule(name='H2', formula='H2', hash='7746e69'),
       additional_keywords={}, attributes={}, comment=None)
 

--- a/docs/source/user_guide/datasets/caching.rst
+++ b/docs/source/user_guide/datasets/caching.rst
@@ -122,7 +122,7 @@ Creating Views
 
 Views can be created on the server :meth:`~qcportal.dataset_models.BaseDataset.create_view`. This
 creates a background :ref:`internal job <dataset_internal_jobs>` which creates the view, and returns
-the :class:`~qcportal.internal_jobs.models.InternalJob>` object that can be used to query the progress.
+the :class:`~qcportal.internal_jobs.models.InternalJob` object that can be used to query the progress.
 
 
 .. tab-set::

--- a/docs/source/user_guide/datasets/creating.rst
+++ b/docs/source/user_guide/datasets/creating.rst
@@ -85,7 +85,7 @@ Now our dataset has three entries
       ['carbon monoxide', 'difluorine', 'dibromine']
 
 Next, we will add some specifications. For an optimization dataset, this is an
-:class:`~qcportal.optimization.OptimizationSpecification`.
+:class:`~qcportal.optimization.record_models.OptimizationSpecification`.
 
 .. tab-set::
 

--- a/docs/source/user_guide/datasets/maintenance.rst
+++ b/docs/source/user_guide/datasets/maintenance.rst
@@ -7,7 +7,7 @@ Modifying metadata and defaults
 -------------------------------
 
 Various parameters that are set when :ref:`creating a dataset <creating_datasets>` can be later
-modified. These include the name, description, tags, tagline, and the default routing tag & priority.
+modified. These include the name, description, tags, tagline, and the default compute tag & priority.
 See the following functions:
 
 * :meth:`~qcportal.dataset_models.BaseDataset.set_name`
@@ -15,7 +15,7 @@ See the following functions:
 * :meth:`~qcportal.dataset_models.BaseDataset.set_tags`
 * :meth:`~qcportal.dataset_models.BaseDataset.set_tagline`
 * :meth:`~qcportal.dataset_models.BaseDataset.set_provenance`
-* :meth:`~qcportal.dataset_models.BaseDataset.set_metadata`
+* :meth:`~qcportal.dataset_models.BaseDataset.set_extras`
 * :meth:`~qcportal.dataset_models.BaseDataset.set_default_compute_tag`
 * :meth:`~qcportal.dataset_models.BaseDataset.set_default_compute_priority`
 
@@ -26,31 +26,14 @@ See the following functions:
 
     .. code-block:: py3
 
-          >>> ds = get_dataset_by_id(123)
-          >>> ds.set_default_compute_priority("low")
-          >>> ds.set_name("New Dataset Name")
-          >>> print(ds.name)
-          New Dataset Name
-
-          >>> print(ds.default_priority)
-          PriorityEnum.low
-
-          >>> ds = get_dataset_by_id(123)
-          >>> ds.set_default_compute_priority("low")
-          >>> ds.set_name("New Dataset Name")
-          >>> print(ds.name)
-          New Dataset Name
-
-          >>> print(ds.default_priority)
-          PriorityEnum.low
-
-      >>> ds = get_dataset_by_id(123)
-      >>> ds.set_default_priority("low")
+      >>> ds = client.get_dataset_by_id(123)
+      >>> ds.set_default_compute_priority("low")
       >>> ds.set_name("New Dataset Name")
+
       >>> print(ds.name)
       New Dataset Name
 
-      >>> print(ds.default_priority)
+      >>> print(ds.default_compute_priority)
       PriorityEnum.low
 
 

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -22,5 +22,6 @@ If you are interested in running your own QCArchive server, please see :doc:`../
    record_management
    troubleshooting
    datasets/index
+   projects/index
    records/index
    qcportal_reference/index

--- a/docs/source/user_guide/molecule.rst
+++ b/docs/source/user_guide/molecule.rst
@@ -56,7 +56,7 @@ with more):
       ...   O   0.000000 0.000000 0.000000
       ... """
       >>> water = Molecule.from_data(mol_xyz)
-      >>> print(water2)
+      >>> print(water)
       Molecule(name='H2O', formula='H2O', hash='246998b')
 
 Note that in the case of XYZ files, the units are angstroms.
@@ -66,7 +66,7 @@ Similarly, you can construct the molecule from a file. If the above XYZ data was
 .. code-block:: py3
 
   >>> water = Molecule.from_file('water.xyz')
-  >>> print(water2)
+  >>> print(water)
   Molecule(name='H2O', formula='H2O', hash='246998b')
 
 
@@ -80,7 +80,8 @@ Adding molecules to the server
   :meth:`~qcportal.client.PortalClient.add_singlepoints` and they will be automatically added
   to the database as needed. However, in some cases, this may be useful.
 
-Molecules can be added to the server database with `~qcportal.client.PortalClient.add_molecules`. This returns
+Molecules can be added to the server database with
+:meth:`~qcportal.client.PortalClient.add_molecules`. This returns
 some metadata about the insertion, and the molecule IDs.
 
 .. tab-set::

--- a/docs/source/user_guide/projects/datasets.rst
+++ b/docs/source/user_guide/projects/datasets.rst
@@ -1,0 +1,305 @@
+Datasets in a Project
+=====================
+
+A project holds :ref:`datasets <glossary_dataset>` under project-local names, in the same way it
+holds records. Every method here that takes a dataset accepts either the name or the ID.
+
+A dataset in a project is an ordinary dataset. Everything in :doc:`../datasets/index` applies to it
+unchanged - entries, specifications, submission, caching, and views all work the same way. What
+the project adds is the grouping and the name.
+
+
+.. _project_add_datasets:
+
+Creating datasets
+-----------------
+
+:meth:`~qcportal.project_models.Project.add_dataset` creates a new dataset in the project. It takes
+the same arguments as :meth:`~qcportal.client.PortalClient.add_dataset` - see
+:ref:`creating_datasets` - with the dataset type and name required and the rest optional.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> ds = proj.add_dataset("singlepoint", "b3lyp barriers")
+      >>> print(ds.id, ds.name)
+      377 b3lyp barriers
+
+      >>> ds.add_specification("psi4/b3lyp/def2-svp", spec)
+      >>> ds.add_entry("hooh", hooh_mol)
+      >>> ds.submit()
+
+The dataset that comes back is a normal dataset of the appropriate type - a
+:class:`~qcportal.singlepoint.dataset_models.SinglepointDataset` here.
+
+Two defaults are inherited from the project unless given explicitly:
+``default_compute_tag`` and ``default_compute_priority``. This is the main practical benefit of
+creating a dataset inside a project rather than alongside it - the routing settings are set once,
+on the project.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj = client.add_project("Peroxide barrier heights",
+      ...                           default_compute_tag="big_mem",
+      ...                           default_compute_priority="low")
+
+      >>> ds = proj.add_dataset("optimization", "geometries")
+      >>> print(ds.default_compute_tag, ds.default_compute_priority)
+      big_mem PriorityEnum.low
+
+      >>> # Or override for this one dataset
+      >>> ds2 = proj.add_dataset("optimization", "quick geometries",
+      ...                        default_compute_tag="small_mem",
+      ...                        default_compute_priority="high")
+
+The name must be unique within the project - reusing a name raises a
+:class:`~qcportal.client_base.PortalRequestError`.
+
+.. note::
+
+  Dataset names must be unique both within the project and, for a given dataset type, across the
+  server. The two checks are separate and ``existing_ok`` only affects the second one.
+
+  ``existing_ok=True`` means "if a dataset of this type and name already exists on the server, add
+  *that* dataset to the project instead of creating a new one". It does **not** suppress the error
+  from a name that is already used within this project - that check happens first and is
+  unconditional. To make a script re-runnable, check
+  :attr:`~qcportal.project_models.Project.dataset_metadata` before adding.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> existing = {dm.name for dm in proj.dataset_metadata}
+        >>> if "b3lyp barriers" not in existing:
+        ...     ds = proj.add_dataset("singlepoint", "b3lyp barriers")
+        ... else:
+        ...     ds = proj.get_dataset("b3lyp barriers")
+
+
+.. _project_link_datasets:
+
+Linking existing datasets
+-------------------------
+
+:meth:`~qcportal.project_models.Project.link_dataset` associates a dataset that already exists on
+the server with the project. Nothing is copied - the project gains a reference to it.
+
+Only the ID is required. By default the dataset keeps its existing name, description, tagline, and
+tags.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> ds = proj.link_dataset(381)
+      >>> print(ds.name)
+      Diatomic geometries
+
+Any of those four can be given to store a project-local value instead.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> ds = proj.link_dataset(381,
+      ...                        name="reference geometries",
+      ...                        description="Diatomic geometries, used as a reference set",
+      ...                        tagline="Reference geometries",
+      ...                        tags=["reference"])
+
+      >>> print(ds.name)
+      reference geometries
+
+.. important::
+
+  These overrides belong to the project, not to the dataset. The dataset's own name, description,
+  tagline, and tags are unchanged, and the project's values are substituted in only when the
+  dataset is fetched *through* the project.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> # Through the project - the project's name
+        >>> print(proj.get_dataset(381).name)
+        reference geometries
+
+        >>> # Directly from the server - the dataset's own name
+        >>> print(client.get_dataset_by_id(381).name)
+        Diatomic geometries
+
+  A consequence is that the two can drift: renaming the dataset itself with
+  :meth:`~qcportal.dataset_models.BaseDataset.set_name` does not update the project's name for it,
+  and vice versa. The same applies to records, whose project-local ``name``, ``description``, and
+  ``tags`` exist only within the project.
+
+Linking a dataset that is already in this project is an error.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.link_dataset(381)
+      ---------------------------------------------------------------------------
+      PortalRequestError                        Traceback (most recent call last)
+
+      ...
+
+      PortalRequestError: Request failed: Dataset 381 already linked to project 7 (HTTP status 400)
+
+
+.. _project_get_datasets:
+
+Getting datasets
+----------------
+
+:meth:`~qcportal.project_models.Project.get_dataset` fetches a dataset from the project, by
+project-local name or by ID.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> ds = proj.get_dataset("b3lyp barriers")
+      >>> print(ds.id)
+      377
+
+      >>> # By ID works too
+      >>> ds = proj.get_dataset(377)
+
+      >>> print(ds.status())
+      {'psi4/b3lyp/def2-svp': {<RecordStatusEnum.complete: 'complete'>: 20}}
+
+From here on it is an ordinary dataset - see :doc:`../datasets/basics`.
+
+.. note::
+
+  Datasets obtained through a project are cached in the same way as those obtained through the
+  client. If the client was created with a ``cache_dir``, the dataset's cache file lives there.
+  See :doc:`../datasets/caching`.
+
+
+.. _project_dataset_metadata:
+
+Listing datasets
+----------------
+
+The :attr:`~qcportal.project_models.Project.dataset_metadata` property lists the datasets in the
+project without fetching them. Each entry is a
+:class:`~qcportal.project_models.ProjectDatasetMetadata` object.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for dm in proj.dataset_metadata:
+      ...     print(dm.dataset_id, dm.dataset_type, dm.name, dm.tags)
+      377 singlepoint b3lyp barriers []
+      381 optimization reference geometries ['reference']
+
+This is fetched from the server the first time it is accessed and then cached. Call
+:meth:`~qcportal.project_models.Project.fetch_dataset_metadata` to refresh it.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.fetch_dataset_metadata()
+
+Note that, unlike :class:`~qcportal.project_models.ProjectRecordMetadata`, there is no status
+field here - a dataset does not have a single status. Use
+:meth:`~qcportal.project_models.Project.status` for a project-wide summary
+(:ref:`project_status`), or the dataset's own
+:meth:`~qcportal.dataset_models.BaseDataset.status` for a per-specification breakdown.
+
+
+.. _project_unlink_datasets:
+
+Removing datasets
+-----------------
+
+:meth:`~qcportal.project_models.Project.unlink_datasets` removes datasets from the project. By
+default the datasets stay on the server and only the association with the project is dropped.
+
+It accepts a single name or ID, or a list, and the two may be mixed.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.unlink_datasets("b3lyp barriers")
+
+      >>> proj.unlink_datasets(["reference geometries", 377])
+
+Two flags control how much else goes with it:
+
+- ``delete_datasets`` - also delete the datasets themselves from the server
+- ``delete_dataset_records`` - also delete the records held by those datasets
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> # Remove from the project and delete the dataset, but keep its records
+      >>> proj.unlink_datasets("b3lyp barriers", delete_datasets=True)
+
+      >>> # Remove from the project and delete the dataset and its records
+      >>> proj.unlink_datasets("b3lyp barriers",
+      ...                      delete_datasets=True,
+      ...                      delete_dataset_records=True)
+
+.. warning::
+
+  These deletions are permanent and affect the server, not just the project.
+
+  If the dataset is linked into another project as well, ``delete_datasets=True`` does not quietly
+  skip it - it fails with an internal server error, because the dataset is still referenced.
+  Check with :meth:`~qcportal.client.PortalClient.query_project_datasets` first when a dataset may
+  be shared.
+
+  ``delete_dataset_records=True`` is best effort in the same way as for records: entries whose
+  records are also used by another dataset or project are protected by the database and survive,
+  silently. See :ref:`project_deletion_shared`.
+
+
+Datasets QCPortal API
+---------------------
+
+* :class:`~qcportal.project_models.Project`
+
+  * :meth:`~qcportal.project_models.Project.add_dataset`
+  * :meth:`~qcportal.project_models.Project.link_dataset`
+  * :meth:`~qcportal.project_models.Project.get_dataset`
+  * :meth:`~qcportal.project_models.Project.unlink_datasets`
+  * :attr:`~qcportal.project_models.Project.dataset_metadata`
+  * :meth:`~qcportal.project_models.Project.fetch_dataset_metadata`
+
+* :class:`~qcportal.project_models.ProjectDatasetMetadata`

--- a/docs/source/user_guide/projects/index.rst
+++ b/docs/source/user_guide/projects/index.rst
@@ -455,7 +455,7 @@ Permissions
 Reading projects requires the ``read`` role; creating, modifying, and deleting them requires
 ``submit`` (or higher). As with records and datasets, these permissions are not scoped by
 ownership - a user with the ``submit`` role may modify or delete any project on the server, not
-only their own. See :ref:`server_admin_roles`.
+only their own. See :ref:`overview_roles`.
 
 
 .. _project_qcportal_api:

--- a/docs/source/user_guide/projects/index.rst
+++ b/docs/source/user_guide/projects/index.rst
@@ -1,0 +1,476 @@
+Projects
+========
+
+A :ref:`project <glossary_project>` is a named container that holds the
+:ref:`records <glossary_record>` and :ref:`datasets <glossary_dataset>` belonging to a single
+piece of work, together with any files you want to keep alongside them.
+
+Projects are organizational, not computational. Putting a record in a project does not change
+how it is computed, and a record or dataset in a project is an ordinary record or dataset -
+it can still be retrieved, queried, and managed through the usual client methods. What a project
+adds is a place to collect them and a local name for each one, so you can write
+``proj.get_record("water_scan")`` instead of remembering that it is record 118326390.
+
+There are two ways something gets into a project. It can be **created** in the project
+(:meth:`~qcportal.project_models.Project.add_record`,
+:meth:`~qcportal.project_models.Project.add_dataset`), or an existing record or dataset already on
+the server can be **linked** into it (:meth:`~qcportal.project_models.Project.link_record`,
+:meth:`~qcportal.project_models.Project.link_dataset`). Linking does not copy anything, and the
+same record may be linked into more than one project.
+
+.. note::
+
+  Projects were introduced in 0.61 (:pr:`944`) as a beta feature, and the interface is still
+  evolving. Record importing (:ref:`project_import_records`) arrived later, in 0.63 (:pr:`972`).
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   records
+   datasets
+
+
+.. _project_creating:
+
+Creating a project
+------------------
+
+Projects are created with :meth:`~qcportal.client.PortalClient.add_project`. Only a name is
+required. Project names must be unique across the whole server, and are compared
+case-insensitively.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj = client.add_project("Peroxide barrier heights")
+      >>> print(proj.id)
+      7
+
+      >>> print(proj.name)
+      Peroxide barrier heights
+
+The remaining arguments are all optional metadata:
+
+- ``description`` - A longer description of the project
+- ``tagline`` - A short, one-line description
+- ``tags`` - A list of strings for categorizing the project
+- ``default_compute_tag`` - The default :ref:`compute tag <glossary_tag>` for computations
+  created within this project (defaults to ``*``)
+- ``default_compute_priority`` - The default priority for computations created within this
+  project (defaults to ``normal``)
+- ``extras`` - A dictionary of arbitrary additional information
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> from qcportal.record_models import PriorityEnum
+
+      >>> proj = client.add_project(
+      ...     "Peroxide barrier heights",
+      ...     description="Barrier heights for a set of peroxides, at several levels of theory",
+      ...     tagline="Peroxide barriers",
+      ...     tags=["peroxide", "barriers"],
+      ...     default_compute_tag="big_mem",
+      ...     default_compute_priority=PriorityEnum.low,
+      ...     extras={"grant": "OAC-1547580"},
+      ... )
+
+The ``default_compute_tag`` and ``default_compute_priority`` are inherited by records and datasets
+created in the project, which saves passing them on every call. They can still be overridden per
+record or per dataset. Note that compute tags are lowercased by the server.
+
+Adding a project whose name already exists raises an error. Pass ``existing_ok=True`` to get the
+existing project back instead - useful in a script that may be run more than once.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj = client.add_project("Peroxide barrier heights")
+      ---------------------------------------------------------------------------
+      PortalRequestError                        Traceback (most recent call last)
+
+      ...
+
+      PortalRequestError: Request failed: Project with name='Peroxide barrier heights' already exists (HTTP status 400)
+
+      >>> proj = client.add_project("Peroxide barrier heights", existing_ok=True)
+      >>> print(proj.id)
+      7
+
+
+.. _project_retrieval:
+
+Getting an existing project
+---------------------------
+
+A project can be retrieved by name with :meth:`~qcportal.client.PortalClient.get_project`, or by
+ID with :meth:`~qcportal.client.PortalClient.get_project_by_id`. Names are matched
+case-insensitively.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj = client.get_project("peroxide BARRIER heights")
+      >>> print(proj.id)
+      7
+
+      >>> proj = client.get_project_by_id(7)
+      >>> print(proj.name)
+      Peroxide barrier heights
+
+The project's metadata is available as attributes.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> print(proj.tagline)
+      Peroxide barriers
+
+      >>> print(proj.tags)
+      ['peroxide', 'barriers']
+
+      >>> print(proj.default_compute_tag, proj.default_compute_priority)
+      big_mem PriorityEnum.low
+
+      >>> print(proj.owner_user)
+      ben
+
+.. note::
+
+  Projects use ``owner_user`` for the user that created them. This is unlike records and
+  datasets, where the equivalent field was renamed to ``creator_user`` in 0.61 (:pr:`931`).
+
+
+.. _project_listing:
+
+Listing projects
+----------------
+
+:meth:`~qcportal.client.PortalClient.list_projects` returns a summary of every project on the
+server, without fetching the projects themselves. Each entry is a dictionary containing the
+project ID and metadata, plus a count of the records and datasets it holds.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for p in client.list_projects():
+      ...     print(p["id"], p["record_count"], p["dataset_count"], p["project_name"])
+      6 0 3 Diatomic geometries
+      7 12 2 Peroxide barrier heights
+
+The keys of each entry are ``id``, ``project_name``, ``tagline``, ``tags``, ``description``,
+``record_count``, ``dataset_count``, ``owner_user``, and ``creator_user`` (which currently
+duplicates ``owner_user``).
+
+.. note::
+
+  The key holding the name is ``project_name``, not ``name``.
+
+
+.. _project_status:
+
+Project status
+--------------
+
+:meth:`~qcportal.project_models.Project.status` summarizes the state of everything in the project.
+It returns a dictionary with two keys - ``records`` and ``datasets`` - each mapping
+:class:`record statuses <qcportal.record_models.RecordStatusEnum>` to a count.
+
+The ``records`` entry counts only the records added directly to the project. The ``datasets``
+entry counts the records of every dataset in the project, summed together.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.status()
+      {'records': {<RecordStatusEnum.complete: 'complete'>: 10,
+                   <RecordStatusEnum.error: 'error'>: 2},
+       'datasets': {<RecordStatusEnum.complete: 'complete'>: 340,
+                    <RecordStatusEnum.waiting: 'waiting'>: 60}}
+
+For a per-dataset breakdown, use the :meth:`~qcportal.dataset_models.BaseDataset.status` method
+of the individual dataset instead. See :doc:`datasets`.
+
+
+.. _project_attachments:
+
+Attachments
+-----------
+
+Arbitrary files can be uploaded to a project - notes, plots, input archives, analysis scripts, and
+so on. Upload a file with :meth:`~qcportal.project_models.Project.upload_attachment`, which returns
+the ID of the new attachment.
+
+The ``attachment_type`` and ``tags`` arguments are both required. Currently the only available
+attachment type is ``other``; tags may be an empty list.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> file_id = proj.upload_attachment("./barriers.csv", "other", ["analysis"])
+      >>> print(file_id)
+      14
+
+      >>> # With a description, and stored under a different name
+      >>> proj.upload_attachment("./notes.md", "other", [],
+      ...                        description="Working notes",
+      ...                        new_file_name="lab_notes.md")
+      15
+
+The :attr:`~qcportal.project_models.Project.attachments` property lists the files that have been
+uploaded. These are :class:`~qcportal.project_models.ProjectAttachment` objects, which contain the
+file metadata but not the contents.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for att in proj.attachments:
+      ...     print(att.id, att.file_size, att.file_name, att.tags)
+      14 20418 barriers.csv ['analysis']
+      15 1044 lab_notes.md []
+
+Download the contents with :meth:`~qcportal.external_files.models.ExternalFile.download`, and
+remove an attachment with :meth:`~qcportal.project_models.Project.delete_attachment`.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.attachments[0].download("/path/to/barriers.csv")
+
+      >>> proj.delete_attachment(15)
+
+.. note::
+
+  The file size and checksum are verified against the metadata stored on the server when
+  downloading. Downloading will not overwrite an existing file unless ``overwrite=True``
+  is passed.
+
+.. important::
+
+  Attachments require the server to have file storage (S3) configured. On a server without it,
+  uploading will fail.
+
+
+.. _project_finding:
+
+Finding the project something belongs to
+----------------------------------------
+
+Given a record or dataset ID, the
+:class:`~qcportal.client.PortalClient` contains the methods :meth:`~qcportal.client.PortalClient.query_project_records` and
+:meth:`~qcportal.client.PortalClient.query_project_datasets`. These report which project it is in, and
+under what name.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> client.query_project_records(118326390)
+      [{'record_id': 118326390, 'project_id': 7, 'project_name': 'Peroxide barrier heights',
+        'record_name': 'water_scan'}]
+
+      >>> client.query_project_datasets([377, 381])
+      [{'record_id': 377, 'project_id': 7, 'project_name': 'Peroxide barrier heights',
+        'dataset_name': 'b3lyp barriers'},
+       {'record_id': 381, 'project_id': 6, 'project_name': 'Diatomic geometries',
+        'dataset_name': 'geometries'}]
+
+Both methods accept a single ID or a list. Records and datasets that are not in any project are
+simply absent from the result, so the returned list may be shorter than the list of IDs given.
+
+.. note::
+
+  In the result of :meth:`~qcportal.client.PortalClient.query_project_datasets`, the dataset ID
+  is under the key ``record_id``, not ``dataset_id``.
+
+Going the other way, the ``query_*`` methods of the client take a ``project_id`` argument to
+restrict a record query to a single project. See :doc:`../record_retrieval`.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for r in client.query_singlepoints(project_id=7, status='error'):
+      ...     print(r.id, r.status)
+      118326391 RecordStatusEnum.error
+      118326404 RecordStatusEnum.error
+
+
+.. _project_deleting:
+
+Deleting a project
+------------------
+
+:meth:`~qcportal.client.PortalClient.delete_project` deletes the project. By default this deletes
+*only* the project - the records and datasets it contained are left on the server, and are
+afterwards reachable in the usual way by ID.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> client.delete_project(7)
+
+The contents can be deleted along with the project using three separate flags:
+
+- ``delete_records`` - also delete the records added directly to the project
+- ``delete_datasets`` - also delete the datasets in the project
+- ``delete_dataset_records`` - also delete the records held by those datasets
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> # Delete the project and everything in it
+      >>> client.delete_project(7,
+      ...                       delete_records=True,
+      ...                       delete_datasets=True,
+      ...                       delete_dataset_records=True)
+
+The project itself is always deleted permanently and cannot be recovered. What happens to its
+contents when those flags are set is more subtle, and is described next.
+
+
+.. _project_deletion_shared:
+
+Shared records and datasets when deleting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``delete_records``, ``delete_datasets``, and ``delete_dataset_records`` request a **hard delete**
+(see :ref:`record_status`), not the reversible soft delete. Hard deletes are constrained by the
+database: a record cannot be removed while anything still refers to it - another project, a
+dataset, or a parent record. This is the same protection described in :doc:`../record_management`.
+
+The practical consequence is that these flags are **best effort**, and they fail quietly:
+
+- A record that is also in another project or in a dataset is **not** deleted. It is unlinked from
+  this project and stays on the server.
+- You are not told when this happens. The server does determine which records it could not remove,
+  but that information is discarded on this code path - the endpoint returns nothing either way.
+
+So a project holding a record that is also used elsewhere cannot take that record away from
+everyone else. But equally, do not treat ``delete_records=True`` as a guarantee that the records
+are gone.
+
+To confirm what actually happened, look afterwards:
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> client.delete_project(7, delete_records=True)
+
+      >>> # Was record 118326390 really removed?
+      >>> client.get_records(118326390, missing_ok=True)
+      None
+
+If you need a definite answer up front, delete the records yourself with
+:meth:`~qcportal.client.PortalClient.delete_records` before deleting the project. That method
+returns :class:`~qcportal.metadata_models.DeleteMetadata`, which reports the records it could not
+remove.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj = client.get_project_by_id(7)
+      >>> ids = [rm.record_id for rm in proj.record_metadata]
+
+      >>> meta = client.delete_records(ids, soft_delete=False)
+      >>> print(meta.deleted_idx)
+      [0, 1, 2]
+
+      >>> print(meta.errors)
+      [(3, 'Integrity Error - may still be referenced')]
+
+      >>> client.delete_project(7)
+
+.. warning::
+
+  Deleting a dataset that is linked into **more than one project** behaves differently, and worse.
+  The dataset row itself is protected by the same kind of constraint, but that failure is not
+  handled - it surfaces as an internal server error rather than being skipped. Check with
+  :meth:`~qcportal.client.PortalClient.query_project_datasets` first if a dataset may be shared.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> client.query_project_datasets(381)
+        [{'record_id': 381, 'project_id': 6, ...}, {'record_id': 381, 'project_id': 7, ...}]
+
+        >>> # Dataset 381 is in two projects - do not use delete_datasets=True here
+
+
+.. _project_permissions:
+
+Permissions
+-----------
+
+Reading projects requires the ``read`` role; creating, modifying, and deleting them requires
+``submit`` (or higher). As with records and datasets, these permissions are not scoped by
+ownership - a user with the ``submit`` role may modify or delete any project on the server, not
+only their own. See :ref:`server_admin_roles`.
+
+
+.. _project_qcportal_api:
+
+Projects QCPortal API
+---------------------
+
+* :mod:`Project models <qcportal.project_models>`
+
+* PortalClient methods
+
+  * :meth:`~qcportal.client.PortalClient.add_project`
+  * :meth:`~qcportal.client.PortalClient.get_project`
+  * :meth:`~qcportal.client.PortalClient.get_project_by_id`
+  * :meth:`~qcportal.client.PortalClient.list_projects`
+  * :meth:`~qcportal.client.PortalClient.delete_project`
+  * :meth:`~qcportal.client.PortalClient.query_project_records`
+  * :meth:`~qcportal.client.PortalClient.query_project_datasets`

--- a/docs/source/user_guide/projects/records.rst
+++ b/docs/source/user_guide/projects/records.rst
@@ -1,0 +1,307 @@
+Records in a Project
+====================
+
+A project holds :ref:`records <glossary_record>` under project-local names, so that a record can
+be referred to as ``"water_scan"`` rather than by its ID. Every method here that takes a record
+accepts either the name or the ID.
+
+There are three ways a record ends up in a project:
+
+- :ref:`Adding <project_add_records>` - a new computation is created and submitted to be run
+- :ref:`Linking <project_link_records>` - a record that already exists on the server is
+  associated with the project
+- :ref:`Importing <project_import_records>` - a computation that was run elsewhere is ingested
+  into the server
+
+
+.. _project_add_records:
+
+Adding records
+--------------
+
+:meth:`~qcportal.project_models.Project.add_record` creates a new record in the project and
+submits it for computation.
+
+This differs from the client's ``add_*`` methods (see :doc:`../record_submission`) in two ways.
+It creates exactly one record rather than one per molecule, and it takes the specification and
+input molecule together as a single *record input* object rather than as separate arguments.
+The input types are :class:`~qcportal.singlepoint.record_models.SinglepointInput`,
+:class:`~qcportal.optimization.record_models.OptimizationInput`, and the equivalent for each
+of the other :doc:`computation types <../records/index>`.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> from qcportal.singlepoint import SinglepointInput
+
+      >>> inp = SinglepointInput(
+      ...     molecule=Molecule(symbols=['h', 'h'], geometry=[0, 0, 0, 0, 0, 1.5]),
+      ...     specification={
+      ...         "program": "psi4",
+      ...         "driver": "energy",
+      ...         "method": "b3lyp",
+      ...         "basis": "def2-svp",
+      ...     },
+      ... )
+
+      >>> r = proj.add_record("hydrogen", inp)
+      >>> print(r.id, r.status)
+      118326390 RecordStatusEnum.waiting
+
+Unlike the client's ``add_*`` methods, this returns the record itself rather than metadata and a
+list of IDs.
+
+The name must be unique within the project - reusing a name raises a
+:class:`~qcportal.client_base.PortalRequestError`. There is no ``existing_ok`` equivalent here,
+so check :attr:`~qcportal.project_models.Project.record_metadata` first if a script may be run
+more than once.
+
+The optional arguments are keyword-only:
+
+- ``description`` - A longer description of this record within the project
+- ``tags`` - A list of strings for categorizing this record within the project
+- ``compute_tag`` - The :ref:`compute tag <glossary_tag>` to run with. Defaults to the project's
+  ``default_compute_tag``
+- ``compute_priority`` - The priority to run at. Defaults to the project's
+  ``default_compute_priority``
+- ``find_existing`` - If False, always create a new record rather than reusing a matching
+  existing one. See :ref:`record_submit_dedup`
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> r = proj.add_record("hydrogen_fresh", inp,
+      ...                     description="Same computation, deliberately not deduplicated",
+      ...                     tags=["scratch"],
+      ...                     compute_tag="small_mem",
+      ...                     compute_priority="high",
+      ...                     find_existing=False)
+
+.. note::
+
+  Deduplication applies as usual. With the default ``find_existing=True``, adding a record whose
+  computation already exists on the server links the project to that existing record instead of
+  running it again - so the returned record may already be ``complete``.
+
+
+.. _project_link_records:
+
+Linking existing records
+------------------------
+
+:meth:`~qcportal.project_models.Project.link_record` associates a record that already exists on
+the server with the project. Nothing is copied and the record itself is unchanged; the project
+gains a reference to it plus a project-local name, description, and tags. All four arguments are
+required.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> meta, ids = client.add_singlepoints(mol, 'psi4', 'energy', 'hf', 'sto-3g')
+      >>> r = proj.link_record(ids[0], "reference_hf", "HF reference for comparison", ["reference"])
+      >>> print(r.id)
+      118326412
+
+The same record may be linked into more than one project. Linking a record that is already in
+*this* project is an error.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.link_record(ids[0], "reference_hf_again", "", [])
+      ---------------------------------------------------------------------------
+      PortalRequestError                        Traceback (most recent call last)
+
+      ...
+
+      PortalRequestError: Request failed: Record 118326412 already linked to project 7 (HTTP status 400)
+
+
+.. _project_import_records:
+
+Importing records
+-----------------
+
+:meth:`~qcportal.project_models.Project.import_record` ingests a computation that was run
+somewhere else - on another QCArchive server, or by hand - and stores its results as a record on
+this server. The computation is not run again; the results are stored as they are given.
+
+This is the only way to get externally-computed records onto a server, and it works only into a
+project.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> # A record retrieved from some other server
+      >>> other_client = PortalClient("https://ml.qcarchive.molssi.org")
+      >>> external = other_client.get_singlepoints(123, include=['**'])
+
+      >>> r = proj.import_record("imported_hf", external,
+      ...                        description="Imported from the ML server",
+      ...                        tags=["imported"])
+
+      >>> print(r.status)
+      RecordStatusEnum.complete
+
+      >>> print(r.creator_user)
+      ben
+
+The imported record is a normal record on this server afterwards, with a new ID. The importing
+user becomes its ``creator_user``.
+
+.. note::
+
+  Fetch the source record with ``include=['**']`` before importing it. Only the data actually
+  present on the object is transferred, so a partially-fetched record imports partial results.
+
+Records of every computation type can be imported, as can the raw QCSchema results that a compute
+manager would return (``AtomicResult``, ``OptimizationResult``, and ``FailedOperation`` from
+``qcportal.qcschema_v1``).
+
+.. important::
+
+  Importing is new and still limited. Only individual records can be imported - there is no
+  facility for importing a whole dataset - and only into a project. See :pr:`972`.
+
+
+.. _project_get_records:
+
+Getting records
+---------------
+
+:meth:`~qcportal.project_models.Project.get_record` fetches a record from the project, by
+project-local name or by ID.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> r = proj.get_record("hydrogen")
+      >>> print(r.id, r.status)
+      118326390 RecordStatusEnum.complete
+
+      >>> # By ID works too
+      >>> r = proj.get_record(118326390)
+
+      >>> # Fetch all of the record's data up front
+      >>> r = proj.get_record("hydrogen", include=['**'])
+
+The record that comes back is an ordinary record of the appropriate type - a
+:class:`~qcportal.singlepoint.record_models.SinglepointRecord` here - and behaves exactly as one
+retrieved through :meth:`~qcportal.client.PortalClient.get_records`. See :doc:`../records/index`.
+
+.. note::
+
+  Looking a record up by name requires the project's record metadata to have been fetched, which
+  happens automatically on first use. Records added during this session are also findable by name.
+
+
+.. _project_record_metadata:
+
+Listing records
+---------------
+
+The :attr:`~qcportal.project_models.Project.record_metadata` property lists what the project
+contains without fetching the records themselves. Each entry is a
+:class:`~qcportal.project_models.ProjectRecordMetadata` object holding the project-local name,
+description, and tags, plus the record's ID, type, and status.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for rm in proj.record_metadata:
+      ...     print(rm.record_id, rm.record_type, rm.status, rm.name, rm.tags)
+      118326390 singlepoint RecordStatusEnum.complete hydrogen []
+      118326412 singlepoint RecordStatusEnum.complete reference_hf ['reference']
+
+This is fetched from the server the first time it is accessed and then cached. The status values
+in particular go stale, since they are a snapshot from when the metadata was fetched. Call
+:meth:`~qcportal.project_models.Project.fetch_record_metadata` to refresh it.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.fetch_record_metadata()
+
+For an up-to-date count by status across the whole project, use
+:meth:`~qcportal.project_models.Project.status` instead - see :ref:`project_status`.
+
+
+.. _project_unlink_records:
+
+Removing records
+----------------
+
+:meth:`~qcportal.project_models.Project.unlink_records` removes records from the project. By
+default the records stay on the server and only the association with the project is dropped -
+this is the reverse of linking, and it applies equally to records that were added or imported.
+
+It accepts a single name or ID, or a list, and the two may be mixed.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.unlink_records("hydrogen")
+
+      >>> proj.unlink_records(["reference_hf", 118326390])
+
+Pass ``delete_records=True`` to delete the records themselves as well.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> proj.unlink_records("hydrogen_fresh", delete_records=True)
+
+.. note::
+
+  ``delete_records=True`` attempts to remove the record from the server, not just from the project,
+  and the deletion is permanent rather than the reversible soft delete.
+
+  It is best effort, though. A record that is also in another project or in a dataset is protected
+  by the database and will survive - unlinked from this project, but still on the server - and
+  nothing in the return value tells you so. See :ref:`project_deletion_shared`.
+
+
+Records QCPortal API
+--------------------
+
+* :class:`~qcportal.project_models.Project`
+
+  * :meth:`~qcportal.project_models.Project.add_record`
+  * :meth:`~qcportal.project_models.Project.import_record`
+  * :meth:`~qcportal.project_models.Project.link_record`
+  * :meth:`~qcportal.project_models.Project.get_record`
+  * :meth:`~qcportal.project_models.Project.unlink_records`
+  * :attr:`~qcportal.project_models.Project.record_metadata`
+  * :meth:`~qcportal.project_models.Project.fetch_record_metadata`
+
+* :class:`~qcportal.project_models.ProjectRecordMetadata`

--- a/docs/source/user_guide/qcportal_reference/index.rst
+++ b/docs/source/user_guide/qcportal_reference/index.rst
@@ -9,6 +9,7 @@ QCPortal API Reference
    auth
    base_models
    molecules
+   projects
    metadata_models
    tasks_services
    internal_jobs

--- a/docs/source/user_guide/qcportal_reference/projects.rst
+++ b/docs/source/user_guide/qcportal_reference/projects.rst
@@ -1,0 +1,4 @@
+Projects
+========
+
+.. automodule:: qcportal.project_models

--- a/docs/source/user_guide/qcportal_reference/tasks_services.rst
+++ b/docs/source/user_guide/qcportal_reference/tasks_services.rst
@@ -1,4 +1,14 @@
 Tasks and Services
 ==================
 
+The :class:`~qcportal.record_models.RecordTask` and :class:`~qcportal.record_models.RecordService`
+objects attached to a record are documented under :doc:`records/base_record_models`.
+
+The models below are the supporting types, most of which are used by compute managers
+rather than directly by users.
+
+.. automodule:: qcportal.tasks.models
+
+.. automodule:: qcportal.services.models
+
 .. automodule:: qcportal.generic_result

--- a/docs/source/user_guide/record_management.rst
+++ b/docs/source/user_guide/record_management.rst
@@ -156,7 +156,10 @@ If ``soft_delete=False`` ("hard delete"), then the record is deleted permanently
 
 .. important::
 
-  A record cannot be hard-deleted if it is being referenced somewhere (another record or a dataset).
+  A record cannot be hard-deleted if it is being referenced somewhere - another record, a dataset,
+  or a :doc:`project <projects/index>`. Such records are reported in the ``errors`` field of the
+  returned :class:`~qcportal.metadata_models.DeleteMetadata` rather than raising, so check it if it
+  matters.
 
 .. tab-set::
 

--- a/docs/source/user_guide/record_management.rst
+++ b/docs/source/user_guide/record_management.rst
@@ -222,9 +222,7 @@ Records that are ``waiting`` or ``running`` can be cancelled with
 be picked up by a compute manager.
 
 Cancelling can be undone with :meth:`~qcportal.client.PortalClient.uncancel_records`. If the record was ``running``
-before it was cancelled, with will go back to a ``waiting state``.
-
-Invalidation can be undone with :meth:`~qcportal.client.PortalClient.uncancel_records`.
+before it was cancelled, it will go back to a ``waiting`` state.
 
 .. tab-set::
 

--- a/docs/source/user_guide/record_retrieval.rst
+++ b/docs/source/user_guide/record_retrieval.rst
@@ -90,8 +90,7 @@ If a single ID is specified rather than a list, then just that record is returne
          "manager_name": null,
          "modified_on": "2019-03-07T19:45:27.745000",
          "molecule_id": 37,
-         "owner_group": null,
-         "owner_user": null,
+         "creator_user": null,
          ...
       }
 
@@ -134,8 +133,7 @@ case missing records are returned as ``None``
            "manager_name": null,
            "modified_on": "2019-03-07T19:45:27.745000",
            "molecule_id": 37,
-           "owner_group": null,
-           "owner_user": null,
+           "creator_user": null,
            ...
         },
         null,
@@ -147,8 +145,7 @@ case missing records are returned as ``None``
            "manager_name": null,
            "modified_on": "2019-03-07T19:45:42.748000",
            "molecule_id": 38,
-           "owner_group": null,
-           "owner_user": null,
+           "creator_user": null,
            ...
         }
       ]

--- a/docs/source/user_guide/records/base.rst
+++ b/docs/source/user_guide/records/base.rst
@@ -192,7 +192,7 @@ Calculations may also produce other outputs. All records support the following:
       >>> print(r.properties.keys())
       dict_keys(['pe energy', 'scf dipole', 'calcinfo_nmo',...
 
-      >>> print(r.properties["scf_dipole"])
+      >>> print(r.properties["scf dipole"])
       [0.5734967483313045, 0.5734967483328919, 0.0]
 
 

--- a/docs/source/user_guide/records/manybody.rst
+++ b/docs/source/user_guide/records/manybody.rst
@@ -311,9 +311,9 @@ as values in the ``levels`` dictionary.
         # NOTE - we are querying by the program actually used in the singlepoint calculations here
         #        not the overarching manybody program
 
-        r_iter = client.query_manybodys(program='psi4',
+        r_iter = client.query_manybodys(qc_program='psi4',
                                         created_after='2024-03-21 12:34:56',
-                                        include=['**'])
+                                        include=['**'],
                                         limit=50)
         for r in r_iter:
             print(r.id)

--- a/docs/source/user_guide/records/neb.rst
+++ b/docs/source/user_guide/records/neb.rst
@@ -1,26 +1,694 @@
 NEB calculations
 =====================================
 
-Stuff
+A nudged elastic band (NEB) calculation locates the minimum energy path between two endpoints -
+typically a reactant and a product - and from that path produces a guess at the transition state
+structure connecting them.
+
+The path is represented by a *chain*: an ordered list of molecular geometries (called *images*)
+running from one endpoint to the other. Each iteration computes the gradient at every image, and
+those gradients, together with spring forces that keep neighbouring images from sliding into each
+other, are used to move the whole chain downhill toward the minimum energy path. When the chain
+stops moving, the highest-energy image is a rough transition state.
+
+NEB records are :ref:`services <glossary_service>`. Every gradient evaluation is an ordinary
+:ref:`singlepoint record <singlepoint_record>`, and the optional endpoint and transition-state
+optimizations are ordinary :ref:`optimization records <optimization_record>`, all of which can be
+inspected individually. A single NEB record therefore accumulates a large number of child records:
+the number of images multiplied by the number of iterations.
+
+Optionally, the NEB service can also:
+
+- optimize the two endpoints of the chain before starting (``optimize_endpoints``), and
+- refine the guessed transition state into a true first-order saddle point, by computing its
+  Hessian and running a transition-state optimization (``optimize_ts``).
+
 
 .. _neb_record:
 
-NEB Record
--------------------
+NEB Records
+-----------
 
-Stuff
+NEB records contain all the fields of a :doc:`base record <base>`, and additionally include:
+
+- ``specification`` - The programs, level of theory, and NEB options (see below)
+- ``initial_chain`` - The chain of molecules the calculation started from, as it was submitted
+- ``singlepoints`` - The gradient calculations, as a dictionary keyed by chain iteration. Each value
+  is the list of :class:`~qcportal.singlepoint.record_models.SinglepointRecord` for that iteration,
+  ordered by position along the chain
+- ``final_chain`` - Shorthand for the singlepoints of the last iteration; that is, the converged path
+- ``result`` - The guessed transition state: the :doc:`molecule <../molecule>` of the
+  highest-energy image of the final chain
+- ``optimizations`` - Any endpoint or transition-state optimizations, as a dictionary (see below)
+- ``ts_optimization`` - Shorthand for the transition-state optimization, or ``None`` if there was not
+  one
+- ``ts_hessian`` - The Hessian :class:`~qcportal.singlepoint.record_models.SinglepointRecord`
+  computed on the guessed transition state before optimizing it, or ``None``
+
+The keys of the ``optimizations`` dictionary describe which optimization each one is:
+
+.. table::
+
+  ================  =========================================================================
+   Key               Optimization
+  ================  =========================================================================
+   ``initial``       The first image of the chain, optimized before the NEB started
+   ``final``         The last image of the chain, optimized before the NEB started
+   ``transition``    The guessed transition state, optimized to a first-order saddle point
+  ================  =========================================================================
+
+``initial`` and ``final`` are present only when ``optimize_endpoints`` was set, and ``transition``
+only when ``optimize_ts`` was set, so the dictionary is frequently empty.
+
+.. note::
+
+  ``result`` raises ``ValueError: NEB result is only available after the calculation is complete.``
+  unless the record's status is ``complete``. It is the *guessed* transition state taken straight
+  off the chain, not the result of the transition-state optimization; for that, use
+  ``ts_optimization.final_molecule``.
+
+.. note::
+
+  The record's underlying pydantic fields (``neb_result_``, ``singlepoints_``, ``optimizations_``,
+  and so on) are private storage for what has been fetched from the server. Use the properties listed
+  above - they fetch what they need on demand.
+
+
+.. _neb_specification:
+
+NEB Specification
+-----------------
+
+The :ref:`glossary_specification` for a NEB is a
+:class:`~qcportal.neb.record_models.NEBSpecification`. The fields are:
+
+- ``program`` - The program that drives the NEB (``"geometric"``)
+- ``singlepoint_specification`` - The level of theory for the gradient calculation at each image.
+  See :ref:`singlepoint_specification`
+- ``optimization_specification`` - Optional; how the transition state should be optimized when
+  ``optimize_ts`` is set. See :ref:`optimization_specification`
+- ``keywords`` - A :class:`~qcportal.neb.record_models.NEBKeywords` object holding the NEB options
+
+Unlike most other specifications, ``keywords`` is required and has no default - pass
+``NEBKeywords()`` to accept every default.
+
+.. _neb_keywords:
+
+NEB Keywords
+~~~~~~~~~~~~
+
+:class:`~qcportal.neb.record_models.NEBKeywords` has the following fields:
+
+.. table::
+
+  ==============================  ===========  =========================================================
+   Keyword                         Default      Description
+  ==============================  ===========  =========================================================
+   ``images``                      11           Number of images used to locate a rough transition
+                                                state structure. Must be greater than 5
+   ``spring_constant``             1.0          Spring constant, in kcal/mol/Ang^2
+   ``spring_type``                 0            How spring forces and gradients are combined; see below
+   ``maximum_force``               0.05         Convergence criterion: converge when the maximum
+                                                RMS-gradient of the chain (eV/Ang) falls below this
+   ``average_force``               0.025        Convergence criterion: converge when the average
+                                                RMS-gradient of the chain (eV/Ang) falls below this
+   ``maximum_cycle``               100          Maximum number of NEB iterations
+   ``optimize_endpoints``          ``False``    Optimize the two ends of the initial chain before
+                                                starting the NEB
+   ``optimize_ts``                 ``False``    After convergence, optimize the guessed transition
+                                                state to a first-order saddle point
+   ``align``                       ``True``     Align the images before starting
+   ``epsilon``                     1e-5         Small eigenvalue threshold for resetting the Hessian
+  ==============================  ===========  =========================================================
+
+``spring_type`` selects how the spring force and the gradient are projected:
+
+.. table::
+
+  =======  ==============================================================================
+   Value    Meaning
+  =======  ==============================================================================
+   0        Nudged elastic band - parallel spring force + perpendicular gradients
+   1        Hybrid elastic band - full spring force + perpendicular gradients
+   2        Plain elastic band - full spring force + full gradients
+  =======  ==============================================================================
+
+Both convergence criteria must be satisfied for the chain to be considered converged.
+
+.. important::
+
+  Before the first iteration the chain is respaced by geomeTRIC (and aligned, if ``align`` is set),
+  which may insert or remove images. The number of gradient calculations in an iteration therefore
+  need not equal the number of molecules you submitted.
+
+.. note::
+
+  The ``driver`` of ``singlepoint_specification`` is ignored. The service overrides it with
+  ``gradient`` for the chain calculations, and with ``hessian`` for the transition-state Hessian.
+  As with :ref:`optimizations <optimization_specification>`, the convention is to set
+  ``driver="deferred"``.
+
+What ``optimization_specification`` is (and is not) used for
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``optimization_specification`` applies **only to the transition-state optimization**, and even then
+the service adjusts it:
+
+- ``program`` is forced to ``geometric``
+- ``transition: True`` and the computed Hessian (``hess_data``) are added to its ``keywords``
+
+The endpoint optimizations requested by ``optimize_endpoints`` do **not** use it. They always run
+with ``geometric`` and ``coordsys: tric``, taking their level of theory from
+``singlepoint_specification``. Similarly, when ``optimization_specification`` is omitted and
+``optimize_ts`` is set, the transition-state optimization uses ``geometric`` with
+``coordsys: tric`` and ``transition: True``, again at the level of theory of
+``singlepoint_specification``.
+
+One consequence is worth noting: when ``optimization_specification`` *is* given, the
+transition-state Hessian is computed with that specification's ``qc_specification``, not with
+``singlepoint_specification``. Keep the two at the same level of theory unless you specifically want
+them to differ.
+
+.. dropdown:: Basic NEBSpecification
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBSpecification, NEBKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        neb_spec = NEBSpecification(
+            program="geometric",
+            singlepoint_specification=QCSpecification(
+                program="psi4",
+                driver="deferred",
+                method="b3lyp",
+                basis="def2-svp",
+            ),
+            keywords=NEBKeywords(),
+        )
+
+.. dropdown:: A coarser, cheaper chain
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBSpecification, NEBKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        neb_spec = NEBSpecification(
+            program="geometric",
+            singlepoint_specification=QCSpecification(
+                program="psi4", driver="deferred", method="hf", basis="sto-3g"
+            ),
+            keywords=NEBKeywords(
+                images=7,
+                maximum_cycle=50,
+                maximum_force=0.1,
+                average_force=0.05,
+            ),
+        )
+
+.. dropdown:: Optimize the endpoints before starting
+
+  Useful when the endpoints came from a scan, a docking program, or hand-built geometries, and are
+  not themselves minima.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBSpecification, NEBKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        neb_spec = NEBSpecification(
+            program="geometric",
+            singlepoint_specification=QCSpecification(
+                program="psi4", driver="deferred", method="b3lyp", basis="def2-svp"
+            ),
+            keywords=NEBKeywords(optimize_endpoints=True),
+        )
+
+.. dropdown:: Refine the guessed transition state
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBSpecification, NEBKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        neb_spec = NEBSpecification(
+            program="geometric",
+            singlepoint_specification=QCSpecification(
+                program="psi4", driver="deferred", method="b3lyp", basis="def2-svp"
+            ),
+            keywords=NEBKeywords(optimize_ts=True),
+        )
+
+.. dropdown:: Control the transition-state optimization explicitly
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBSpecification, NEBKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        qc_spec = QCSpecification(
+            program="psi4", driver="deferred", method="b3lyp", basis="def2-svp"
+        )
+
+        neb_spec = NEBSpecification(
+            program="geometric",
+            singlepoint_specification=qc_spec,
+            optimization_specification=OptimizationSpecification(
+                program="geometric",
+                qc_specification=qc_spec,
+                keywords={"maxiter": 300},
+            ),
+            keywords=NEBKeywords(optimize_ts=True),
+        )
+
+.. dropdown:: A plain elastic band with a stiffer spring
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBSpecification, NEBKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        neb_spec = NEBSpecification(
+            program="geometric",
+            singlepoint_specification=QCSpecification(
+                program="psi4", driver="deferred", method="b3lyp", basis="def2-svp"
+            ),
+            keywords=NEBKeywords(
+                spring_type=2,
+                spring_constant=5.0,
+            ),
+        )
+
+
+.. _neb_submission:
+
+Submitting Records
+------------------
+
+NEB records are submitted with :meth:`~qcportal.client.PortalClient.add_nebs`.
+This method takes the following information:
+
+- ``initial_chains`` - The chains to run. Each NEB starts from a single chain (a list of molecules),
+  so this is a **nested** list - one inner list per record
+- ``program`` - The NEB program (use ``"geometric"``)
+- ``singlepoint_specification`` - The level of theory for the gradient calculations
+- ``optimization_specification`` - The transition-state optimization details, or ``None``
+- ``keywords`` - A :class:`~qcportal.neb.record_models.NEBKeywords` object
+
+``optimization_specification`` and ``keywords`` have no defaults, so both must be given;
+pass ``None`` for the former if you do not need it.
+
+The molecules in a chain may be :doc:`Molecule <../molecule>` objects or molecule IDs,
+and the two may be mixed. The chain must be ordered from one endpoint to the other - the service
+treats the first and last elements as the endpoints.
+
+See :doc:`../record_submission` for more information about other arguments.
+
 
 .. _neb_dataset:
 
-NEB Dataset
---------------------
+NEB Datasets
+------------
 
-Stuff
+NEB :ref:`datasets <glossary_dataset>` are collections of NEB records.
+An :class:`entry <qcportal.neb.dataset_models.NEBDatasetEntry>` holds one chain:
+
+- ``name`` - The name of the entry
+- ``initial_chain`` - The ordered list of molecules making up this chain
+- ``additional_keywords`` - Per-entry NEB keywords, merged into the specification's
+  :class:`~qcportal.neb.record_models.NEBKeywords`
+- ``additional_singlepoint_keywords`` - Per-entry keywords, merged into the specification's
+  ``singlepoint_specification.keywords``
+- ``attributes`` - A user-defined dictionary of metadata for this entry
+- ``comment`` - A user-supplied comment
+
+The :class:`dataset specification <qcportal.neb.dataset_models.NEBDatasetSpecification>` holds the
+:class:`NEBSpecification <qcportal.neb.record_models.NEBSpecification>` that every entry is computed
+with.
+
+.. _neb_dataset_keywords:
+
+Per-entry keyword overrides
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a dataset is :ref:`submitted <dataset_submission>`, the server builds one NEB specification for
+each (entry, specification) pair by taking the dataset specification and updating it from the entry:
+
+.. table::
+
+  ===================================================  ==============================================
+   Specification field                                  Updated from the entry's
+  ===================================================  ==============================================
+   ``keywords``                                         ``additional_keywords``
+   ``singlepoint_specification.keywords``               ``additional_singlepoint_keywords``
+  ===================================================  ==============================================
+
+The merge is a plain dictionary update, one level deep: a key present in the entry replaces that key
+in the specification outright, and keys the entry does not mention are left alone. Nothing else in
+the specification is affected - the programs, method, basis, and ``optimization_specification`` come
+from the dataset specification alone and cannot be varied per entry.
+
+The normal arrangement is to put everything in the dataset specification and leave the entry
+keywords empty, reaching for ``additional_keywords`` only for the occasional chain that needs a
+looser convergence criterion or a different number of images.
+
+.. warning::
+
+  ``additional_keywords`` is stored as an unvalidated dictionary on the entry. It is only checked
+  against :class:`~qcportal.neb.record_models.NEBKeywords`, which forbids unknown fields, at the
+  point where the merged specification is built - that is, on :ref:`submission <dataset_submission>`,
+  not when the entry is added. A misspelled keyword is accepted without complaint and then fails the
+  submission, and because the failure happens inside the server it comes back as an internal server
+  error and an error ID rather than the name of the offending key. If a submission fails for no
+  apparent reason, check your entries' keys against the field names of
+  :class:`~qcportal.neb.record_models.NEBKeywords`.
+
+  ``additional_singlepoint_keywords`` is not checked this way, since ``QCSpecification.keywords``
+  is an open dictionary passed through to the QC program.
+
+See :doc:`../datasets/index` for general dataset operations and advanced usage.
+
+
+.. _neb_client_examples:
+
+Client Examples
+---------------
+
+.. dropdown:: Obtain a single NEB record by ID
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r = client.get_nebs(123)
+
+.. dropdown:: Obtain multiple NEB records by ID
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_lst = client.get_nebs([123, 456])
+
+.. dropdown:: Obtain multiple NEB records by ID, ignoring missing records
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_lst = client.get_nebs([123, 456, 789], missing_ok=True)
+
+.. dropdown:: Fetch the chain singlepoints and optimizations up front
+
+  A NEB record has a lot of children, so ``include=['**']`` can be very expensive. Ask only for
+  what you need.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r = client.get_nebs(123, include=['initial_chain', 'singlepoints'])
+
+.. dropdown:: Query NEB records by QC method and basis
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_iter = client.query_nebs(qc_method='b3lyp', qc_basis='def2-svp')
+        for r in r_iter:
+            print(r.id)
+
+.. dropdown:: Query NEB records containing a particular molecule in their initial chain
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_iter = client.query_nebs(molecule_id=8231)
+        for r in r_iter:
+            print(r.id)
+
+.. dropdown:: Add a NEB record
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        # chain is an ordered list of molecules from reactant to product
+        meta, ids = client.add_nebs(
+            [chain],
+            program='geometric',
+            singlepoint_specification=QCSpecification(
+                program='psi4', driver='deferred', method='b3lyp', basis='def2-svp'
+            ),
+            optimization_specification=None,
+            keywords=NEBKeywords(images=11),
+        )
+
+.. dropdown:: Add a NEB record that also locates the transition state
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        meta, ids = client.add_nebs(
+            [chain],
+            program='geometric',
+            singlepoint_specification=QCSpecification(
+                program='psi4', driver='deferred', method='b3lyp', basis='def2-svp'
+            ),
+            optimization_specification=None,
+            keywords=NEBKeywords(optimize_endpoints=True, optimize_ts=True),
+        )
+
+.. dropdown:: Follow the energy profile of the converged path
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> r = client.get_nebs(123)
+        >>> for sp in r.final_chain:
+        ...     print(sp.properties['return_energy'])
+        -78.5873142
+        -78.5841027
+        -78.5766319
+        ...
+
+.. dropdown:: Watch the chain converge over the iterations
+
+  ``singlepoints`` is keyed by iteration number, so the barrier height can be tracked as the
+  calculation proceeds.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> r = client.get_nebs(123)
+        >>> for iteration in sorted(r.singlepoints):
+        ...     energies = [sp.properties['return_energy'] for sp in r.singlepoints[iteration]]
+        ...     print(iteration, max(energies) - energies[0])
+        1 0.0421783
+        2 0.0398215
+        3 0.0391044
+
+.. dropdown:: Retrieve the guessed and optimized transition states
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> r = client.get_nebs(123)
+
+        >>> # The highest-energy image of the converged chain
+        >>> guess = r.result
+
+        >>> # The refined saddle point, if optimize_ts was set
+        >>> if r.ts_optimization is not None:
+        ...     ts = r.ts_optimization.final_molecule
+
+
+.. _neb_dataset_examples:
+
+Dataset Examples
+----------------
+
+See :doc:`../datasets/index` for more information and advanced usage.
+See the :ref:`specification <neb_specification>` section for all the options in creating
+specifications.
+
+.. dropdown:: Create a NEB dataset with default options
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        ds = client.add_dataset(
+                 "neb",
+                 "Dataset Name",
+                 "An example of a NEB dataset"
+        )
+
+.. dropdown:: Add a single entry to a NEB dataset
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        # hcn_chain is an ordered list of molecules
+        ds.add_entry("HCN isomerization", hcn_chain)
+
+.. dropdown:: Add many entries to a NEB dataset
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBDatasetNewEntry
+
+        # Chains built beforehand, for example by interpolating between endpoints
+        new_entries = [
+            NEBDatasetNewEntry(name=name, initial_chain=chain)
+            for name, chain in all_chains.items()
+        ]
+
+        # Efficiently add all entries in a single call
+        ds.add_entries(new_entries)
+
+.. dropdown:: Add a specification to a NEB dataset
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.neb import NEBSpecification, NEBKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        neb_spec = NEBSpecification(
+            program="geometric",
+            singlepoint_specification=QCSpecification(
+                program="psi4",
+                driver="deferred",
+                method="b3lyp",
+                basis="def2-svp",
+            ),
+            keywords=NEBKeywords(images=11, optimize_ts=True),
+        )
+
+        ds.add_specification("psi4/b3lyp/def2-svp", neb_spec)
+
+.. dropdown:: Loosen the convergence criteria for one difficult chain
+
+  Everything else about the entry is inherited from the dataset specification.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        # Uses the specification's keywords as-is
+        ds.add_entry("HCN isomerization", hcn_chain)
+
+        # Same level of theory, but fewer images and a looser force criterion
+        ds.add_entry(
+            "C4H3N2 isomerization",
+            c4h3n2_chain,
+            additional_keywords={"images": 7, "maximum_force": 0.1},
+        )
+
+.. dropdown:: Pass keywords through to the QC program for one entry
+
+  ``additional_singlepoint_keywords`` is merged into the specification's
+  ``singlepoint_specification.keywords`` the same way, which is useful when one chain has a molecule
+  that converges badly.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        ds.add_entry(
+            "stubborn chain",
+            stubborn_chain,
+            additional_singlepoint_keywords={"maxiter": 500, "guess": "sad"},
+        )
 
 
 .. _neb_qcportal_api:
 
 NEB QCPortal API
--------------------------
+----------------
 
-TODO
+* :mod:`Record models <qcportal.neb.record_models>`
+* :mod:`Dataset models <qcportal.neb.dataset_models>`
+
+* PortalClient methods
+
+  * :meth:`~qcportal.client.PortalClient.add_nebs`
+  * :meth:`~qcportal.client.PortalClient.get_nebs`
+  * :meth:`~qcportal.client.PortalClient.query_nebs`

--- a/docs/source/user_guide/records/reaction.rst
+++ b/docs/source/user_guide/records/reaction.rst
@@ -1,26 +1,526 @@
 Reaction calculations
 =====================================
 
-Stuff
+A reaction record computes a linear combination of energies - a reaction energy, a binding energy,
+an atomization energy, or anything else that can be written as a sum of coefficients times
+molecular energies.
+
+A reaction is defined by its *stoichiometry*: a list of (coefficient, molecule) pairs. Each molecule
+is computed once, and the total energy is the sum of each molecule's energy multiplied by its
+coefficient.
+
+Coefficients are given by the user and are usually negative for reactants and positive for products.
+For example, the dissociation energy of a water dimer is written as ``[(-1.0, dimer), (2.0, monomer)]``.
+
+Each component may be optimized before its energy is evaluated, evaluated at the geometry as given,
+or both. Reactions are :ref:`services <glossary_service>`, so the individual optimizations and
+singlepoints are ordinary records that can be inspected on their own.
+
 
 .. _reaction_record:
 
-Reaction Record
--------------------
+Reaction Records
+----------------
 
-Stuff
+Reaction records contain all the fields of a :doc:`base record <base>`, and additionally include:
+
+- ``specification`` - The programs, levels of theory, and other options (see below)
+- ``total_energy`` - The computed reaction energy, in hartrees. ``None`` until the record is complete
+- ``components`` - The individual pieces of the reaction; one per molecule
+
+Each element of ``components`` is a
+:class:`~qcportal.reaction.record_models.ReactionComponent` with the following fields:
+
+- ``molecule`` - The molecule as it was given in the stoichiometry. Note that this is the *input*
+  geometry; if the component was optimized, the optimized geometry is on the optimization record
+- ``molecule_id`` - The ID of that molecule
+- ``coefficient`` - The coefficient of this molecule in the reaction
+- ``singlepoint_id`` / ``singlepoint_record`` - The singlepoint computation for this component,
+  if the specification has a singlepoint specification
+- ``optimization_id`` / ``optimization_record`` - The optimization computation for this component,
+  if the specification has an optimization specification
+
+The energy that a component contributes to ``total_energy`` depends on which specifications
+were given:
+
+.. table::
+
+  ==========================================  =======================================================
+   Specification                               Energy used for each component
+  ==========================================  =======================================================
+   singlepoint only                            The energy of the singlepoint record
+   optimization only                           The final energy of the optimization record
+   both                                        The energy of the singlepoint record, which was run
+                                               on the optimized geometry
+  ==========================================  =======================================================
+
+
+.. _reaction_specification:
+
+Reaction Specification
+----------------------
+
+The :ref:`glossary_specification` for a reaction is a
+:class:`~qcportal.reaction.record_models.ReactionSpecification`. The fields are:
+
+- ``program`` - The program that drives the reaction service (``"reaction"``)
+- ``singlepoint_specification`` - How the energy of each component should be evaluated. See
+  :ref:`singlepoint_specification`. May be ``None``
+- ``optimization_specification`` - How each component should be optimized before its energy is
+  evaluated. See :ref:`optimization_specification`. May be ``None``
+- ``keywords`` - A :class:`~qcportal.reaction.record_models.ReactionKeywords` object
+
+At least one of ``singlepoint_specification`` and ``optimization_specification`` must be given.
+Which ones you give determines what the service does:
+
+- **Singlepoint only** - each molecule is computed at the geometry given in the stoichiometry.
+  This is the usual choice when the geometries are already optimized.
+- **Optimization only** - each molecule is optimized, and the final energy of the optimization is
+  used. The level of theory comes from the optimization's ``qc_specification``
+- **Both** - each molecule is optimized first, and then a separate singlepoint is run on the
+  optimized geometry. This is how you optimize at a cheap level of theory and evaluate energies at
+  a a more expensive one
+
+.. note::
+
+  :class:`~qcportal.reaction.record_models.ReactionKeywords` currently has no fields at all, so
+  ``ReactionKeywords()`` is the only meaningful value. It is still a required field of the
+  specification. It exists so that options can be added later without changing the shape of the
+  specification.
+
+.. dropdown:: Singlepoint energies at fixed geometries
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionSpecification, ReactionKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        rxn_spec = ReactionSpecification(
+            program="reaction",
+            singlepoint_specification=QCSpecification(
+                program="psi4",
+                driver="energy",
+                method="b3lyp",
+                basis="def2-svp",
+            ),
+            keywords=ReactionKeywords(),
+        )
+
+.. dropdown:: Optimize each component, use the optimized energy
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionSpecification, ReactionKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        rxn_spec = ReactionSpecification(
+            program="reaction",
+            optimization_specification=OptimizationSpecification(
+                program="geometric",
+                qc_specification=QCSpecification(
+                    program="psi4", method="b3lyp", basis="def2-svp", driver="deferred"
+                ),
+            ),
+            keywords=ReactionKeywords(),
+        )
+
+.. dropdown:: Optimize cheaply, then evaluate energies at a higher level of theory
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionSpecification, ReactionKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        rxn_spec = ReactionSpecification(
+            program="reaction",
+            # Optimize with b3lyp/def2-svp ...
+            optimization_specification=OptimizationSpecification(
+                program="geometric",
+                qc_specification=QCSpecification(
+                    program="psi4", method="b3lyp", basis="def2-svp", driver="deferred"
+                ),
+            ),
+            # ... but take the energies from ccsd(t)/def2-tzvp
+            singlepoint_specification=QCSpecification(
+                program="psi4",
+                driver="energy",
+                method="ccsd(t)",
+                basis="def2-tzvp",
+            ),
+            keywords=ReactionKeywords(),
+        )
+
+
+.. _reaction_submission:
+
+Submitting Records
+------------------
+
+Reaction records are submitted with :meth:`~qcportal.client.PortalClient.add_reactions`.
+This method takes the following information:
+
+- ``stoichiometries`` - The reactions to compute. Each reaction is a list of
+  ``(coefficient, molecule)`` pairs, so this is a **nested** list - one inner list per record
+- ``program`` - The reaction program (use ``"reaction"``)
+- ``singlepoint_specification`` - The singlepoint details, or ``None``
+- ``optimization_specification`` - The optimization details, or ``None``
+- ``keywords`` - A :class:`~qcportal.reaction.record_models.ReactionKeywords` object
+
+Note that ``singlepoint_specification``, ``optimization_specification``, and ``keywords`` have no
+defaults; the unused specification must be passed explicitly as ``None``.
+
+The molecules in a stoichiometry may be :doc:`Molecule <../molecule>` objects or molecule IDs, and
+the two may be mixed.
+
+See :doc:`../record_submission` for more information about other arguments.
+
 
 .. _reaction_dataset:
 
-Reaction Dataset
---------------------
+Reaction Datasets
+-----------------
 
-Stuff
+Reaction :ref:`datasets <glossary_dataset>` are collections of reaction records.
+An :class:`entry <qcportal.reaction.dataset_models.ReactionDatasetEntry>` holds one reaction:
+
+- ``name`` - The name of the entry
+- ``stoichiometries`` - The coefficients and molecules of this reaction
+- ``additional_keywords`` - Per-entry reaction keywords (see the note below)
+- ``attributes`` - A user-defined dictionary of metadata for this entry
+- ``comment`` - A user-supplied comment
+
+The stoichiometry is a property of the *entry*, not of the specification - a reaction dataset is a
+collection of different reactions, all computed the same way. The
+:class:`dataset specification <qcportal.reaction.dataset_models.ReactionDatasetSpecification>`
+holds the :class:`ReactionSpecification <qcportal.reaction.record_models.ReactionSpecification>`
+that every entry is computed with.
+
+When adding entries, each stoichiometry may be given either as a list of ``(coefficient, molecule)``
+tuples or as a list of
+:class:`~qcportal.reaction.dataset_models.ReactionDatasetEntryStoichiometry` objects.
+
+.. note::
+
+  Entries have an ``additional_keywords`` field, which mirrors the per-entry keyword overrides
+  available in :ref:`torsiondrive <torsiondrive_dataset_keywords>` and
+  :ref:`neb <neb_dataset_keywords>` datasets. Since :class:`~qcportal.reaction.record_models.ReactionKeywords` has no fields, and
+  ignores keys it does not recognize, **anything placed in a reaction entry's**
+  ``additional_keywords`` **is silently discarded** when the record is created. Leave it empty until
+  reaction keywords actually exist.
+
+See :doc:`../datasets/index` for general dataset operations and advanced usage.
+
+
+.. _reaction_client_examples:
+
+Client Examples
+---------------
+
+.. dropdown:: Obtain a single reaction record by ID
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r = client.get_reactions(123)
+
+.. dropdown:: Obtain multiple reaction records by ID
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_lst = client.get_reactions([123, 456])
+
+.. dropdown:: Obtain multiple reactions by ID, ignoring missing records
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_lst = client.get_reactions([123, 456, 789], missing_ok=True)
+
+.. dropdown:: Include the components and all their data during the initial fetch
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r = client.get_reactions(123, include=['**'])
+
+.. dropdown:: Query reactions by QC method and basis
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_iter = client.query_reactions(qc_method='b3lyp', qc_basis='def2-svp')
+        for r in r_iter:
+            print(r.id, r.total_energy)
+
+.. dropdown:: Query reactions that contain a particular molecule
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_iter = client.query_reactions(molecule_id=8231)
+        for r in r_iter:
+            print(r.id)
+
+.. dropdown:: Add a reaction record - singlepoint energies only
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        # Dissociation of a water dimer
+        meta, ids = client.add_reactions(
+            [[(-1.0, water_dimer), (2.0, water)]],
+            program='reaction',
+            singlepoint_specification=QCSpecification(
+                program='psi4', driver='energy', method='b3lyp', basis='def2-svp'
+            ),
+            optimization_specification=None,
+            keywords=ReactionKeywords(),
+        )
+
+.. dropdown:: Add a reaction record - optimize each component first
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        meta, ids = client.add_reactions(
+            [[(-1.0, water_dimer), (2.0, water)]],
+            program='reaction',
+            singlepoint_specification=QCSpecification(
+                program='psi4', driver='energy', method='ccsd(t)', basis='def2-tzvp'
+            ),
+            optimization_specification=OptimizationSpecification(
+                program='geometric',
+                qc_specification=QCSpecification(
+                    program='psi4', method='b3lyp', basis='def2-svp', driver='deferred'
+                ),
+            ),
+            keywords=ReactionKeywords(),
+        )
+
+.. dropdown:: Add several reactions at once
+
+  Each inner list is one reaction, and therefore one record.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        meta, ids = client.add_reactions(
+            [
+                [(-1.0, water_dimer), (2.0, water)],
+                [(-1.0, methanol_dimer), (2.0, methanol)],
+            ],
+            program='reaction',
+            singlepoint_specification=QCSpecification(
+                program='psi4', driver='energy', method='b3lyp', basis='def2-svp'
+            ),
+            optimization_specification=None,
+            keywords=ReactionKeywords(),
+        )
+
+.. dropdown:: Inspect the components of a completed reaction
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> r = client.get_reactions(123)
+        >>> print(r.total_energy)
+        -0.008132215079
+
+        >>> for c in r.components:
+        ...     print(c.coefficient, c.molecule.get_molecular_formula(), c.singlepoint_record.properties['return_energy'])
+        -1.0 H4O2 -152.1032871
+        2.0 H2O -76.0475774
+
+
+.. _reaction_dataset_examples:
+
+Dataset Examples
+----------------
+
+See :doc:`../datasets/index` for more information and advanced usage.
+See the :ref:`specification <reaction_specification>` section for all the options in creating
+specifications.
+
+.. dropdown:: Create a reaction dataset with default options
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        ds = client.add_dataset(
+                 "reaction",
+                 "Dataset Name",
+                 "An example of a reaction dataset"
+        )
+
+.. dropdown:: Add a single entry to a reaction dataset
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        ds.add_entry("water dimer dissociation", [(-1.0, water_dimer), (2.0, water)])
+
+.. dropdown:: Add many entries to a reaction dataset
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionDatasetNewEntry
+
+        # Dimer/monomer pairs worked out beforehand
+        dissociations = [
+            ("water", water_dimer, water),
+            ("methanol", methanol_dimer, methanol),
+            ("ammonia", ammonia_dimer, ammonia),
+        ]
+
+        new_entries = [
+            ReactionDatasetNewEntry(
+                name=f"{name} dimer dissociation",
+                stoichiometries=[(-1.0, dimer), (2.0, monomer)],
+            )
+            for name, dimer, monomer in dissociations
+        ]
+
+        # Efficiently add all entries in a single call
+        ds.add_entries(new_entries)
+
+.. dropdown:: Add entries using explicit stoichiometry objects
+
+  Equivalent to passing tuples, but easier to read when the reaction has several components.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionDatasetNewEntry
+        from qcportal.reaction.dataset_models import ReactionDatasetEntryStoichiometry
+
+        ent = ReactionDatasetNewEntry(
+            name="methane combustion",
+            stoichiometries=[
+                ReactionDatasetEntryStoichiometry(coefficient=-1.0, molecule=methane),
+                ReactionDatasetEntryStoichiometry(coefficient=-2.0, molecule=o2),
+                ReactionDatasetEntryStoichiometry(coefficient=1.0, molecule=co2),
+                ReactionDatasetEntryStoichiometry(coefficient=2.0, molecule=water),
+            ],
+        )
+
+        ds.add_entries(ent)
+
+.. dropdown:: Add a specification to a reaction dataset
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.reaction import ReactionSpecification, ReactionKeywords
+        from qcportal.singlepoint import QCSpecification
+
+        rxn_spec = ReactionSpecification(
+            program="reaction",
+            singlepoint_specification=QCSpecification(
+                program="psi4",
+                driver="energy",
+                method="b3lyp",
+                basis="def2-svp",
+            ),
+            keywords=ReactionKeywords(),
+        )
+
+        ds.add_specification("psi4/b3lyp/def2-svp", rxn_spec)
+
+.. dropdown:: Compare reaction energies across specifications
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> for e_name, s_name, record in ds.iterate_records(status='complete'):
+        ...     print(e_name, s_name, record.total_energy)
+        water dimer dissociation psi4/b3lyp/def2-svp -0.008132215079
+        water dimer dissociation psi4/mp2/def2-tzvp -0.007984120012
 
 
 .. _reaction_qcportal_api:
 
 Reaction QCPortal API
--------------------------
+---------------------
 
-TODO
+* :mod:`Record models <qcportal.reaction.record_models>`
+* :mod:`Dataset models <qcportal.reaction.dataset_models>`
+
+* PortalClient methods
+
+  * :meth:`~qcportal.client.PortalClient.add_reactions`
+  * :meth:`~qcportal.client.PortalClient.get_reactions`
+  * :meth:`~qcportal.client.PortalClient.query_reactions`

--- a/docs/source/user_guide/records/singlepoint.rst
+++ b/docs/source/user_guide/records/singlepoint.rst
@@ -226,6 +226,9 @@ If an entry with the same name already exists, it will be ignored.
 All arguments to this method are keyword-only. The source dataset is identified either by
 ``dataset_id``, or by both ``dataset_type`` and ``dataset_name`` together.
 
+Copying from another singlepoint dataset preserves the entries' ``additional_keywords``. Copying from
+an optimization dataset resets them to an empty dictionary, since an optimization entry has none.
+
 .. tab-set::
 
   .. tab-item:: PYTHON

--- a/docs/source/user_guide/records/singlepoint.rst
+++ b/docs/source/user_guide/records/singlepoint.rst
@@ -36,7 +36,7 @@ a :class:`~qcportal.singlepoint.record_models.QCSpecification`. The main fields 
 Protocols control additional flags for the computation. For singlepoint calculations, this includes whether
 to save the raw outputs, wavefunction, or native files.
 
-See the the :class:`~qcportal.singlepoint.SinglepointProtocols` API
+See the :class:`~qcportal.singlepoint.record_models.SinglepointProtocols` API
 documentation for more information.
 
 :class:`~qcportal.singlepoint.record_models.QCSpecification` objects can be created manually (for example,
@@ -223,6 +223,9 @@ the given entry will not be added.
 
 If an entry with the same name already exists, it will be ignored.
 
+All arguments to this method are keyword-only. The source dataset is identified either by
+``dataset_id``, or by both ``dataset_type`` and ``dataset_name`` together.
+
 .. tab-set::
 
   .. tab-item:: PYTHON
@@ -230,11 +233,18 @@ If an entry with the same name already exists, it will be ignored.
     .. code-block:: py3
 
       >>> ds = client.add_dataset("singlepoint", "Dataset from optimization")
-      >>> ds.add_entries_from(377, 'default') # from an optimization dataset
+
+      >>> # From an optimization dataset, identified by ID
+      >>> ds.add_entries_from(dataset_id=377, specification_name='default')
       InsertCountsMetadata(n_inserted=20, n_existing=0, error_description=None, errors=[])
 
       >>> print(ds.entry_names)
       ['000280960', '000524682', '010464300', ...
+
+      >>> # The source may also be given by type and name
+      >>> ds.add_entries_from(dataset_type='optimization',
+      ...                     dataset_name='Diatomic geometries',
+      ...                     specification_name='default')
 
 
 .. _singlepoint_client_examples:
@@ -304,7 +314,7 @@ Client Examples
 
         r_iter = client.query_singlepoints(program='psi4',
                                            created_after='2024-03-21 12:34:56',
-                                           include=['**'])
+                                           include=['**'],
                                            limit=50)
         for r in r_iter:
             print(r.id)
@@ -336,7 +346,7 @@ Client Examples
                                             driver='energy',
                                             method='b3lyp',
                                             basis='def2-svp',
-                                            keywords={'scf_type': 'df'}
+                                            keywords={'scf_type': 'df'})
 
 .. dropdown:: Add a singlepoint record, don't store raw output
 

--- a/docs/source/user_guide/records/torsiondrive.rst
+++ b/docs/source/user_guide/records/torsiondrive.rst
@@ -1,21 +1,543 @@
 Torsiondrive calculations
 =====================================
 
-Stuff
+Torsiondrives perform constrained scans over one or more dihedral angles.
+At each grid point (a specific set of dihedral values), a constrained geometry
+optimization is performed to minimize the energy while keeping the target
+dihedral(s) fixed. This produces a map of optimized structures and energies
+across the dihedral grid.
+
 
 .. _torsiondrive_record:
 
-Torsiondrive Record
--------------------
+Torsiondrive Records
+--------------------
 
-Stuff
+Torsiondrive records contain all the fields of a :doc:`base record <base>`, and additionally include:
+
+- ``initial_molecules`` - The starting molecules for the scan (one torsiondrive can start from multiple initial geometries)
+- ``optimizations`` - A mapping from grid keys to lists of constrained
+  :class:`~qcportal.optimization.record_models.OptimizationRecord` objects
+- ``minimum_optimizations`` - A mapping from grid keys to the selected lowest-energy
+  :class:`~qcportal.optimization.record_models.OptimizationRecord` for each grid point
+- ``specification`` - The scan/optimization setup (see below)
+
+Grid keys identify points in the dihedral scan. They are tuples whose length equals the
+number of scanned dihedrals.
+
+Convenience properties include:
+
+- :attr:`~qcportal.torsiondrive.record_models.TorsiondriveRecord.optimizations` -
+  Returns a dictionary mapping grid keys (tuples) to lists of optimization records run at that key.
+- :attr:`~qcportal.torsiondrive.record_models.TorsiondriveRecord.minimum_optimizations` -
+  Returns a dictionary mapping grid keys (tuples) to the lowest-energy optimization record at each key.
+- :attr:`~qcportal.torsiondrive.record_models.TorsiondriveRecord.final_energies` -
+  Returns a dictionary mapping grid keys (tuples) to the final energy (a.u.) from the minimum optimization at that key.
+
+
+.. _torsiondrive_specification:
+
+Torsiondrive Specification
+--------------------------
+
+The :ref:`glossary_specification` for a torsiondrive is a
+:class:`~qcportal.torsiondrive.record_models.TorsiondriveSpecification`. The key fields are:
+
+- ``program`` - The torsiondrive driver program (``"torsiondrive"``)
+- ``optimization_specification`` - How each constrained optimization should be run; see
+  :ref:`optimization_specification`
+- ``keywords`` - Torsiondrive scan definition and related options
+
+Keywords are provided via :class:`~qcportal.torsiondrive.record_models.TorsiondriveKeywords` and include:
+
+- ``dihedrals`` (list of 4-tuples of ints) - The dihedral indices to scan.
+- ``grid_spacing`` (list of ints, degrees) - The grid spacing for each dihedral. If multiple
+  values are given, they are paired element-wise with the dihedrals.
+- ``dihedral_ranges`` (optional list of (lower, upper) degree pairs) - Limits the scan range for each dihedral.
+- ``energy_decrease_thresh`` (float, optional) - Smallest energy decrease to trigger launching
+  new optimizations from a grid point.
+- ``energy_upper_limit`` (float, optional, a.u.) - Skip launching new optimizations whose starting energy is above
+  the current global minimum by more than this amount.
+
+Note: The constrained optimizations at each grid point use the details supplied by the
+:class:`~qcportal.optimization.record_models.OptimizationSpecification`, which in turn references the
+singlepoint QC settings inside its ``qc_specification``. See :ref:`singlepoint_specification` and
+:ref:`optimization_specification` for more.
+
+.. important::
+
+  Every field of :class:`~qcportal.torsiondrive.record_models.TorsiondriveKeywords` has a default,
+  so ``TorsiondriveKeywords()`` is valid and describes no scan at all. That is deliberate: in a
+  :ref:`torsiondrive dataset <torsiondrive_dataset>` the keywords are normally left empty in the
+  specification and supplied per entry instead, because ``dihedrals`` refers to atom indices that
+  differ from molecule to molecule. See :ref:`torsiondrive_dataset_keywords`.
+
+  When submitting a single record with :meth:`~qcportal.client.PortalClient.add_torsiondrives`
+  there are no entries, so the keywords must be given here.
+
+
+.. dropdown:: Basic TorsiondriveSpecification with a single dihedral
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.torsiondrive import TorsiondriveSpecification, TorsiondriveKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        td_spec = TorsiondriveSpecification(
+            program="torsiondrive",
+            optimization_specification=OptimizationSpecification(
+                program="geometric",
+                qc_specification=QCSpecification(program="psi4", method="b3lyp", basis="def2-svp", driver="deferred"),
+            ),
+            keywords=TorsiondriveKeywords(
+                dihedrals=[(0, 1, 2, 3)],
+                grid_spacing=[15],
+            ),
+        )
+
+
+.. dropdown:: Multiple dihedrals with different spacings and ranges
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.torsiondrive import TorsiondriveSpecification, TorsiondriveKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        td_spec = TorsiondriveSpecification(
+            program="torsiondrive",
+            optimization_specification=OptimizationSpecification(
+                program="geometric",
+                qc_specification=QCSpecification(program="psi4", method="wb97x-d", basis="def2-tzvp", driver="deferred"),
+            ),
+            keywords=TorsiondriveKeywords(
+                dihedrals=[(0, 1, 2, 3), (1, 2, 3, 4)],
+                grid_spacing=[15, 30],
+                dihedral_ranges=[(-180, 180), (-120, 120)],
+                energy_upper_limit=0.05,
+            ),
+        )
+
+
+.. _torsiondrive_submission:
+
+Submitting Records
+------------------
+
+Torsiondrive records can be submitted using a client via the :meth:`~qcportal.client.PortalClient.add_torsiondrives` method.
+This method takes the following key information:
+
+- ``initial_molecules`` - A list of lists of molecules. Each torsiondrive may start from multiple initial molecules,
+  so pass a nested list (one inner list per record).
+- ``program`` - The torsiondrive program (use ``"torsiondrive"``)
+- ``optimization_specification`` - The optimization setup for each grid point (see :ref:`torsiondrive_specification`)
+- ``keywords`` - The torsiondrive dihedral scan definition and options
+
+See :doc:`../record_submission` for more information about other common fields such as compute tag and priority.
+
+
+Client Examples
+---------------
+
+.. dropdown:: Obtain a single torsiondrive record by ID
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r = client.get_torsiondrives(123)
+
+.. dropdown:: Obtain multiple torsiondrive records by ID
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_lst = client.get_torsiondrives([123, 456])
+
+.. dropdown:: Include child optimizations and their data during fetch
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r = client.get_torsiondrives(123, include=["optimizations", "**"])  # include full child data
+        # Access optimizations via a mapping from grid keys (tuples) to lists of OptimizationRecord
+        for key, opt_list in r.optimizations.items():
+            print(key, [opt.id for opt in opt_list])
+
+.. dropdown:: Query torsiondrives by QC method/basis and include optimizations
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        r_iter = client.query_torsiondrives(qc_method='b3lyp', qc_basis='def2-svp', include=['optimizations'])
+        for r in r_iter:
+            print(r.id, len(r.optimizations))
+
+.. dropdown:: Submit torsiondrives with two different starting geometries
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.torsiondrive import TorsiondriveSpecification, TorsiondriveKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        td_spec = TorsiondriveSpecification(
+            program='torsiondrive',
+            optimization_specification=OptimizationSpecification(
+                program='geometric',
+                qc_specification=QCSpecification(program='psi4', method='b3lyp', basis='def2-svp', driver='deferred'),
+            ),
+            keywords=TorsiondriveKeywords(
+                dihedrals=[(0,1,2,3)],
+                grid_spacing=[15],
+            ),
+        )
+
+        # Two initial conformers for a single torsiondrive
+        meta, ids = client.add_torsiondrives(
+            initial_molecules=[[mol_conf1, mol_conf2]],
+            program='torsiondrive',
+            optimization_specification=td_spec.optimization_specification,
+            keywords=td_spec.keywords,
+        )
+
+
+Working with Results
+--------------------
+
+- Access the starting molecules via :attr:`~qcportal.torsiondrive.record_models.TorsiondriveRecord.initial_molecules`.
+- Access all optimizations per grid point via :attr:`~qcportal.torsiondrive.record_models.TorsiondriveRecord.optimizations`.
+- Access the lowest-energy optimization per grid point via
+  :attr:`~qcportal.torsiondrive.record_models.TorsiondriveRecord.minimum_optimizations`.
+- Get a simple map of final energies via :attr:`~qcportal.torsiondrive.record_models.TorsiondriveRecord.final_energies`.
+
+When writing/reading keys (for example, when working with serialized data), use
+:func:`~qcportal.torsiondrive.record_models.serialize_key` and
+:func:`~qcportal.torsiondrive.record_models.deserialize_key`.
+
 
 .. _torsiondrive_dataset:
 
-Torsiondrive Dataset
---------------------
+Torsiondrive Datasets
+---------------------
 
-Stuff
+Torsiondrive :ref:`datasets <glossary_dataset>` are collections of torsiondrive records.
+:class:`Entries <qcportal.torsiondrive.dataset_models.TorsiondriveDatasetEntry>` contain one or more
+initial molecules, and the
+:class:`dataset specifications <qcportal.torsiondrive.dataset_models.TorsiondriveDatasetSpecification>`
+wrap a :class:`TorsiondriveSpecification <qcportal.torsiondrive.record_models.TorsiondriveSpecification>`.
+
+Torsiondrive datasets differ from the other dataset types in one important way. For most dataset
+types the specification is self-contained and the entry supplies only the molecule. Here, the
+scan definition itself - which dihedral to drive - depends on the atom indices of the particular
+molecule, and those differ from entry to entry. So a torsiondrive entry carries keywords of its
+own, and the two are combined when records are created.
+
+An entry has two keyword fields in addition to its molecules:
+
+- ``additional_keywords`` - merged into the specification's torsiondrive
+  :class:`~qcportal.torsiondrive.record_models.TorsiondriveKeywords`. This is where ``dihedrals``
+  and ``grid_spacing`` normally live
+- ``additional_optimization_keywords`` - merged into the specification's
+  ``optimization_specification.keywords``
+
+See :doc:`../datasets/index` for general dataset operations and advanced usage.
+
+
+.. _torsiondrive_dataset_keywords:
+
+How entry and specification keywords are combined
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a dataset is :ref:`submitted <dataset_submission>`, the server builds one torsiondrive
+specification for each (entry, specification) pair by taking the dataset specification and
+updating it from the entry:
+
+.. table::
+
+  ===================================================  ==============================================================
+   Specification field                                  Updated from the entry's
+  ===================================================  ==============================================================
+   ``keywords``                                         ``additional_keywords``
+   ``optimization_specification.keywords``              ``additional_optimization_keywords``
+  ===================================================  ==============================================================
+
+The merge is a plain dictionary update, one level deep. A key present in the entry replaces that
+key in the specification outright; keys the entry does not mention are left as they were. Values
+are not combined element-wise - an entry that sets ``grid_spacing`` replaces the whole list, it
+does not append to it.
+
+Nothing else in the specification is affected. The ``optimization_specification``'s ``program``,
+``qc_specification``, and ``protocols`` come from the dataset specification alone and cannot be
+varied per entry.
+
+Because ``dihedrals`` is molecule-specific, the usual arrangement is:
+
+- **The dataset specification** holds the level of theory - the optimization program, the QC
+  program, method, and basis - and leaves ``keywords`` empty
+- **Each entry** holds that molecule's ``dihedrals`` and ``grid_spacing``
+
+Both halves are still ordinary keyword dictionaries, though, so anything that genuinely is common
+to the whole dataset can go in the specification instead and be inherited by every entry. Settings
+that are common to most entries but not all can be put in the specification and overridden by the
+handful of entries that differ. The examples below show each arrangement.
+
+.. warning::
+
+  ``additional_keywords`` is stored as an unvalidated dictionary on the entry. It is only checked
+  against :class:`~qcportal.torsiondrive.record_models.TorsiondriveKeywords`, which forbids unknown
+  fields, at the point where the merged specification is built - that is, on
+  :ref:`submission <dataset_submission>`, not when the entry is added.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        >>> # Note the typo - 'grid_spacings'. This is accepted without complaint
+        >>> ds.add_entry("butane", [butane_conf1], additional_keywords={"grid_spacings": [15]})
+
+  Because that validation failure happens inside the server, it does not come back as a friendly
+  message - on a server with the default ``hide_internal_errors`` setting you will get an internal
+  server error and an error ID rather than the name of the offending key. If a submission fails for
+  no apparent reason, check the spelling of the keys in your entries against the field names of
+  :class:`~qcportal.torsiondrive.record_models.TorsiondriveKeywords`.
+
+  ``additional_optimization_keywords`` is not checked this way, since
+  ``OptimizationSpecification.keywords`` is an open dictionary passed through to the optimization
+  program. A misspelled key there is silently ignored, or rejected later by the optimizer itself.
+
+Dataset Examples
+----------------
+
+.. dropdown:: Create a torsiondrive dataset
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        ds = client.add_dataset("torsiondrive", "Torsion Scan Dataset", "A demonstration torsiondrive dataset")
+
+.. dropdown:: Add a specification with empty keywords (the usual case)
+
+  The specification carries the level of theory only. ``keywords`` is left at its default, so
+  every field of the scan definition comes from the entries.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.torsiondrive import TorsiondriveSpecification, TorsiondriveKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        td_spec = TorsiondriveSpecification(
+            program="torsiondrive",
+            optimization_specification=OptimizationSpecification(
+                program="geometric",
+                qc_specification=QCSpecification(program="psi4", method="b3lyp", basis="def2-svp", driver="deferred"),
+            ),
+            keywords=TorsiondriveKeywords(),
+        )
+
+        ds.add_specification("td-geometric/psi4-b3lyp-def2-svp", td_spec)
+
+.. dropdown:: Add entries with per-entry dihedrals and grid spacing
+
+  Each entry drives a different dihedral, given as atom indices into that entry's own molecules.
+  This is the reason the scan definition lives on the entry rather than the specification.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        # The central C-C torsion of butane, and the C-C torsion of ethane -
+        # different atom indices in each molecule
+        ds.add_entry(
+            "butane",
+            [butane_conf1, butane_conf2],
+            additional_keywords={"dihedrals": [(0, 1, 2, 3)], "grid_spacing": [15]},
+        )
+
+        ds.add_entry(
+            "ethane",
+            [ethane_conf],
+            additional_keywords={"dihedrals": [(2, 0, 1, 5)], "grid_spacing": [15]},
+        )
+
+        ds.submit()
+
+.. dropdown:: Add many entries at once, building the entry objects directly
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.torsiondrive import TorsiondriveDatasetNewEntry
+
+        # Molecules and the dihedral to drive in each, worked out beforehand
+        to_scan = [
+            ("butane", [butane_conf1, butane_conf2], (0, 1, 2, 3)),
+            ("ethane", [ethane_conf], (2, 0, 1, 5)),
+            ("propane", [propane_conf], (0, 1, 2, 6)),
+        ]
+
+        entries = [
+            TorsiondriveDatasetNewEntry(
+                name=name,
+                initial_molecules=mols,
+                additional_keywords={"dihedrals": [dihedral], "grid_spacing": [15]},
+            )
+            for name, mols, dihedral in to_scan
+        ]
+
+        # Efficiently add all entries in a single call
+        ds.add_entries(entries)
+
+.. dropdown:: Put shared keywords in the specification instead
+
+  Options that are the same for every entry can go in the specification, where they only have to
+  be written once. Here the spacing and range are shared, and the entries supply only
+  ``dihedrals``.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        from qcportal.torsiondrive import TorsiondriveSpecification, TorsiondriveKeywords
+        from qcportal.optimization import OptimizationSpecification
+        from qcportal.singlepoint import QCSpecification
+
+        td_spec = TorsiondriveSpecification(
+            program="torsiondrive",
+            optimization_specification=OptimizationSpecification(
+                program="geometric",
+                qc_specification=QCSpecification(program="psi4", method="b3lyp", basis="def2-svp", driver="deferred"),
+            ),
+            keywords=TorsiondriveKeywords(
+                grid_spacing=[15],
+                dihedral_ranges=[(-165, 180)],
+                energy_upper_limit=0.05,
+            ),
+        )
+
+        ds.add_specification("coarse", td_spec)
+
+        # Entries only need to say which dihedral to drive
+        ds.add_entry("butane", [butane_conf1], additional_keywords={"dihedrals": [(0, 1, 2, 3)]})
+        ds.add_entry("ethane", [ethane_conf], additional_keywords={"dihedrals": [(2, 0, 1, 5)]})
+
+.. dropdown:: Override a specification keyword for one entry
+
+  An entry's ``additional_keywords`` replaces matching keys and leaves the rest alone, so a single
+  entry can deviate from the dataset-wide settings. With the ``"coarse"`` specification above:
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        # Uses the specification's grid_spacing of 15
+        ds.add_entry("butane", [butane_conf1], additional_keywords={"dihedrals": [(0, 1, 2, 3)]})
+
+        # Scanned more finely, but still inherits dihedral_ranges and energy_upper_limit
+        ds.add_entry(
+            "butane_fine",
+            [butane_conf1],
+            additional_keywords={"dihedrals": [(0, 1, 2, 3)], "grid_spacing": [5]},
+        )
+
+  The record created for ``butane_fine`` gets ``grid_spacing=[5]``,
+  ``dihedral_ranges=[(-165, 180)]``, and ``energy_upper_limit=0.05``.
+
+.. dropdown:: Pass keywords through to the optimizer per entry
+
+  ``additional_optimization_keywords`` is merged into ``optimization_specification.keywords`` the
+  same way, which is useful when one awkward molecule needs different optimizer settings.
+
+  .. tab-set::
+
+    .. tab-item:: PYTHON
+
+      .. code-block:: py3
+
+        td_spec = TorsiondriveSpecification(
+            program="torsiondrive",
+            optimization_specification=OptimizationSpecification(
+                program="geometric",
+                qc_specification=QCSpecification(program="psi4", method="b3lyp", basis="def2-svp", driver="deferred"),
+                keywords={"maxiter": 200},
+            ),
+            keywords=TorsiondriveKeywords(grid_spacing=[15]),
+        )
+
+        ds.add_specification("default", td_spec)
+
+        # Inherits maxiter=200
+        ds.add_entry("butane", [butane_conf1], additional_keywords={"dihedrals": [(0, 1, 2, 3)]})
+
+        # Overrides maxiter and adds another optimizer keyword
+        ds.add_entry(
+            "stubborn_molecule",
+            [stubborn_conf],
+            additional_keywords={"dihedrals": [(4, 5, 6, 7)]},
+            additional_optimization_keywords={"maxiter": 500, "coordsys": "dlc"},
+        )
+
+  The record for ``stubborn_molecule`` is optimized with
+  ``keywords={"maxiter": 500, "coordsys": "dlc"}`` - ``maxiter`` replaced, ``coordsys`` added.
+
+
+Notes and Tips
+--------------
+
+- Each grid point corresponds to a full :ref:`optimization record <optimization_record>`.
+  You can access trajectory information and final structures/energies via those records.
+- Torsiondrive keys represent dihedral angle positions; when serialized to strings (eg in JSON),
+  use helper functions to convert to/from tuples if needed.
+- See :ref:`singlepoint_specification` and :ref:`optimization_specification` for details on setting up the
+  underlying QC and optimization parameters used at each grid point.
+- In a dataset, ``dihedrals`` belongs on the entry, not the specification - see
+  :ref:`torsiondrive_dataset_keywords`. The finished record's ``specification`` shows the merged
+  result, so a record's keywords will not look identical to the dataset specification it came from.
+- ``driver="deferred"`` is the conventional setting for the ``qc_specification`` inside an
+  optimization specification, since the driver used at each step is decided by the optimizer.
 
 
 .. _torsiondrive_qcportal_api:
@@ -23,7 +545,11 @@ Stuff
 Torsiondrive QCPortal API
 -------------------------
 
-.. autoclass:: qcportal.torsiondrive.TorsiondriveRecord
-  :exclude-members: Config
+* :mod:`Record models <qcportal.torsiondrive.record_models>`
+* :mod:`Dataset models <qcportal.torsiondrive.dataset_models>`
 
-.. autoclass:: qcportal.torsiondrive.TorsiondriveSpecification
+* PortalClient methods
+
+  * :meth:`~qcportal.client.PortalClient.add_torsiondrives`
+  * :meth:`~qcportal.client.PortalClient.get_torsiondrives`
+  * :meth:`~qcportal.client.PortalClient.query_torsiondrives`

--- a/docs/source/user_guide/troubleshooting.rst
+++ b/docs/source/user_guide/troubleshooting.rst
@@ -282,7 +282,7 @@ status code and the server's message.
 Common cases:
 
 - **401 / 403** - not logged in, or the role does not permit the operation. Check the username and
-  password in use, and see :ref:`server_admin_roles` for what each role allows
+  password in use, and see :ref:`overview_roles` for what each role allows
 - **404** - the record, dataset, or project does not exist. Many client methods accept
   ``missing_ok=True`` to return ``None`` instead of raising
 - **400** - the server rejected the request. The message is usually specific

--- a/docs/source/user_guide/troubleshooting.rst
+++ b/docs/source/user_guide/troubleshooting.rst
@@ -1,2 +1,395 @@
 Troubleshooting
 ===============
+
+This page collects the questions that come up most often when computations do not behave as
+expected, and the client methods that answer them.
+
+Most problems fall into one of three categories: the computation is not being picked up, the
+computation ran and failed, or the client cannot talk to the server.
+
+
+.. _troubleshooting_waiting:
+
+A record is stuck in "waiting"
+------------------------------
+
+A record with a status of ``waiting`` has been created but it is not being claimed. See
+:ref:`record_status`. This is normal for a short while, but a record that stays ``waiting``
+indefinitely means no :ref:`compute manager <glossary_manager>` is able to take its
+:ref:`task <glossary_task>`.
+
+The server can answer this directly. :meth:`~qcportal.client.PortalClient.get_waiting_reason`
+takes a record ID and reports why the record has not been claimed, checking each active manager in
+turn. :meth:`~qcportal.record_models.BaseRecord.get_waiting_reason` does the same from a record
+object.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> client.get_waiting_reason(118326390)
+      {'reason': 'No manager matches programs & tags',
+       'details': {'test_cluster-a_host1-1234-5678': "Manager missing programs: {'psi4'}",
+                   'test_cluster-a_host2-8765-4321': 'Manager does not handle tag "big_mem"'}}
+
+      >>> # Or from the record
+      >>> r = client.get_records(118326390)
+      >>> r.get_waiting_reason()
+      {'reason': 'Waiting for a free manager',
+       'details': {'test_cluster-a_host1-1234-5678': 'Manager is busy'}}
+
+The ``reason`` key is always present and holds the overall answer. When the record really is
+waiting and there is at least one active manager, a ``details`` key is also present, mapping each
+active manager's name to why that particular manager cannot take the task.
+
+The possible values of ``reason`` are:
+
+.. table::
+
+  ==========================================  =================================================================
+   Reason                                      What it means
+  ==========================================  =================================================================
+   ``Record does not exist``                   No record with that ID on the server
+   ``Record is not waiting``                   The record's status is something other than ``waiting``
+   ``Record is a service``                     Services are iterated by the server, not claimed by a
+                                               manager. See :ref:`troubleshooting_service`
+   ``No active managers``                      No manager is currently connected to the server
+   ``No manager matches programs & tags``      Managers are active, but none has both the required programs
+                                               and a matching compute tag. Check ``details``
+   ``Waiting for a free manager``              A manager could take this task but is at capacity. This is
+                                               normal - the task should run once the manager has room
+  ==========================================  =================================================================
+
+The two entries to act on are the ``details`` messages:
+
+**Manager missing programs** - the task requires a program the manager does not have installed.
+The required program comes from the record's specification, so a singlepoint with
+``program="psi4"`` needs a manager with psi4 available. Managers report what they have, which you
+can check with :meth:`~qcportal.client.PortalClient.query_managers`.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for m in client.query_managers(status='active'):
+      ...     print(m.name, m.compute_tags, sorted(m.programs.keys()))
+      test_cluster-a_host1-1234-5678 ['big_mem'] ['geometric', 'qcengine']
+      test_cluster-a_host2-8765-4321 ['*'] ['psi4', 'qcengine', 'rdkit']
+
+**Manager does not handle tag** - the record's :ref:`compute tag <glossary_tag>` is not one the
+manager is configured to claim. Note that a task tagged ``*`` is claimed *only* by a manager that
+also has ``*``; the wildcard is not a "match anything" on the task side. See :ref:`compute_tags`.
+
+A record's tag can be changed after the fact with
+:meth:`~qcportal.client.PortalClient.modify_records`.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> r = client.get_records(118326390)
+      >>> print(r.task.compute_tag, r.task.required_programs)
+      big_mem ['psi4', 'qcengine']
+
+      >>> client.modify_records(118326390, new_compute_tag='*')
+
+:meth:`~qcportal.client.PortalClient.query_active_managers` answers the same question ahead of
+time - given a tag and a set of programs, which managers could take such a task.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> client.query_active_managers(compute_tag=['big_mem'], programs={'psi4': []})
+      []
+
+      >>> client.query_active_managers(compute_tag=['*'], programs={'psi4': []})
+      ['test_cluster-a_host2-8765-4321']
+
+.. note::
+
+  ``get_waiting_reason`` only considers managers the server currently regards as *active*. A
+  manager that has stopped reporting in is eventually marked inactive, and any tasks it had
+  claimed are returned to ``waiting`` to be claimed by someone else.
+
+
+.. _troubleshooting_errors:
+
+A record has an error
+---------------------
+
+A record with a status of ``error`` ran and failed. The details are on the record itself.
+
+- :attr:`~qcportal.record_models.BaseRecord.error` - a dictionary with ``error_type`` and
+  ``error_message``. Usually the most useful thing to read
+- :attr:`~qcportal.record_models.BaseRecord.stdout` - the program's output, if it was stored
+- :attr:`~qcportal.record_models.BaseRecord.stderr` - anything written to stderr
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> r = client.get_records(118326390)
+      >>> print(r.status)
+      RecordStatusEnum.error
+
+      >>> print(r.error["error_type"])
+      unknown_error
+
+      >>> print(r.error["error_message"])
+      QCEngine Unknown Error:
+      ...
+      psi4.driver.p4util.exceptions.SCFConvergenceError: Could not converge SCF iterations in 200 iterations.
+
+A record may have been attempted more than once. Each attempt is an entry in
+:attr:`~qcportal.record_models.BaseRecord.compute_history`, and the top-level ``error``,
+``stdout``, and ``stderr`` reflect the most recent one. Earlier entries are useful when a record has
+been reset and failed differently each time, and the ``manager_name`` on each entry tells you
+*where* it failed - a program failing on one cluster but not another is a strong signal.
+See :doc:`records/base`.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for h in r.compute_history:
+      ...     print(h.modified_on, h.status, h.manager_name)
+      2026-04-19 15:14:31.128937+00:00 RecordStatusEnum.error test_cluster-a_host1-1234-5678
+      2026-04-21 09:02:11.551204+00:00 RecordStatusEnum.error test_cluster-a_host2-8765-4321
+
+To find the errored records among many, query by status, or use a dataset's status methods.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for r in client.query_records(status='error', limit=10):
+      ...     print(r.id, r.record_type, r.error["error_type"])
+      118326390 singlepoint unknown_error
+      118326404 optimization compute_error
+
+      >>> # Within a dataset
+      >>> ds = client.get_dataset_by_id(377)
+      >>> ds.print_status()
+        specification    complete    error
+      ---------------  ----------  -------
+       b3lyp/def2-svp          18        2
+
+If an error looks transient - a node failure, a network problem, a queue timeout - reset the record
+to run it again with :meth:`~qcportal.client.PortalClient.reset_records`. A server may also be
+configured to reset errored records automatically; see
+:ref:`server_configuration_autoreset_error`.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> client.reset_records(118326390)
+      UpdateMetadata(error_description=None, errors=[], updated_idx=[0], n_children_updated=0)
+
+.. hint::
+
+  If an error is *not* transient - an unknown method, a basis set the program does not have, a
+  molecule that will never converge - resetting will just fail again. Fix the specification and
+  submit a new record instead.
+
+.. note::
+
+  A compute manager disappearing does not normally produce an ``error``. Those records go back to
+  ``waiting`` instead, and there is nothing to reset.
+
+
+.. _troubleshooting_service:
+
+A service is not progressing
+----------------------------
+
+A :ref:`service <glossary_service>` - a torsiondrive, gridoptimization, NEB, manybody, or reaction
+record - is iterated by the server rather than claimed by a manager, so
+:meth:`~qcportal.client.PortalClient.get_waiting_reason` will only tell you
+``Record is a service``. See :doc:`../overview/tasks_services`.
+
+A service alternates between waiting on the records it created and iterating. The usual reason it
+appears stalled is that one of those dependencies is itself stuck or errored.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> r = client.get_records(118326390)
+      >>> print(r.is_service)
+      True
+
+      >>> # What is it waiting on?
+      >>> dep_ids = [d.record_id for d in r.service.dependencies]
+      >>> for dep in client.get_records(dep_ids):
+      ...     print(dep.id, dep.status)
+      118326391 RecordStatusEnum.complete
+      118326392 RecordStatusEnum.error
+
+Once a stuck dependency is dealt with, the service will pick up again on its next iteration.
+Services also write progress to :attr:`~qcportal.record_models.BaseRecord.stdout` as they run,
+which is worth reading - unlike task-based records, this is updated while the record is still
+running.
+
+Two server settings limit how quickly services iterate: ``max_active_services`` caps how many run
+at once, and ``service_frequency`` sets how often the server looks for services to iterate. On a
+busy server a service may simply be queued behind others. See :ref:`server_configuration`.
+
+
+.. _troubleshooting_connection:
+
+The client cannot reach the server
+----------------------------------
+
+Failed requests raise :class:`~qcportal.client_base.PortalRequestError`, which carries the HTTP
+status code and the server's message.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> from qcportal import PortalRequestError
+
+      >>> try:
+      ...     r = client.get_records(1)
+      ... except PortalRequestError as e:
+      ...     print(e.status_code)
+      ...     print(e.msg)
+      404
+      Request failed: Could not find record with id 1
+
+Common cases:
+
+- **401 / 403** - not logged in, or the role does not permit the operation. Check the username and
+  password in use, and see :ref:`server_admin_roles` for what each role allows
+- **404** - the record, dataset, or project does not exist. Many client methods accept
+  ``missing_ok=True`` to return ``None`` instead of raising
+- **400** - the server rejected the request. The message is usually specific
+- **500** - an internal server error. See :ref:`troubleshooting_server_errors`
+
+If the connection fails outright rather than returning a status code, the address or the
+credentials are the place to start. :meth:`~qcportal.client.PortalClient.get_server_information`
+is a cheap way to confirm you are talking to the server you think you are.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> print(client.address)
+      https://ml.qcarchive.molssi.org/
+
+      >>> info = client.get_server_information()
+      >>> print(info["version"])
+      0.65
+
+See :doc:`client_setup` and :doc:`connecting_qcportal` for how the address and credentials are
+resolved, including from configuration files and environment variables.
+
+
+.. _troubleshooting_slow:
+
+Retrieval is slow
+-----------------
+
+Repeatedly fetching the same records is the most common cause of a slow script.
+
+- Enable an on-disk cache by passing ``cache_dir`` to the
+  :class:`~qcportal.client.PortalClient` constructor. Records and datasets are then reused
+  across runs instead of being downloaded again. See :doc:`datasets/caching`
+- Fetch in bulk. :meth:`~qcportal.client.PortalClient.get_records` takes a list of IDs and
+  retrieves them in one request; a loop of single-ID calls does one request each
+- Use ``include=['**']`` when you know you will need all of a record's data, so it arrives in the
+  initial fetch rather than as a separate request per field later
+- For a finished dataset, a :ref:`view <dataset_views>` is a single local file with no server
+  round-trips at all
+
+.. hint::
+
+  Queries return an :doc:`iterator <query_iterators>`, not a list, and fetch in batches as you
+  iterate. Calling ``list()`` on a query with no ``limit`` will try to pull everything.
+
+
+.. _troubleshooting_server_errors:
+
+Internal server errors
+----------------------
+
+Errors inside the server itself are recorded in a separate log from record errors. By default the
+server does not show the details to users - the ``hide_internal_errors`` setting - and instead
+returns an error ID to quote to an administrator. See :ref:`server_configuration`.
+
+Users with sufficient permissions can read that log with
+:meth:`~qcportal.client.PortalClient.query_error_log`.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> for e in client.query_error_log(limit=5):
+      ...     print(e.id, e.error_date, e.user, e.request_path)
+      12 2026-08-01 14:22:03.118293+00:00 ben /api/v1/records/bulkGet?
+
+      >>> # Or look up the ID a user was given
+      >>> entry = next(iter(client.query_error_log(error_id=12)))
+      >>> print(entry.error_text)
+      Traceback (most recent call last):
+      ...
+
+Entries are :class:`~qcportal.serverinfo.models.ErrorLogEntry` objects, and the query can be
+filtered by ``error_id``, ``user``, ``before``, and ``after``. Old entries are removed with
+:meth:`~qcportal.client.PortalClient.delete_error_log`, which takes a cutoff date and returns the
+number deleted.
+
+.. tab-set::
+
+  .. tab-item:: PYTHON
+
+    .. code-block:: py3
+
+      >>> from datetime import datetime
+      >>> client.delete_error_log(datetime(2026, 1, 1))
+      41
+
+
+Troubleshooting API
+-------------------
+
+* PortalClient methods
+
+  * :meth:`~qcportal.client.PortalClient.get_waiting_reason`
+  * :meth:`~qcportal.client.PortalClient.query_managers`
+  * :meth:`~qcportal.client.PortalClient.query_active_managers`
+  * :meth:`~qcportal.client.PortalClient.reset_records`
+  * :meth:`~qcportal.client.PortalClient.modify_records`
+  * :meth:`~qcportal.client.PortalClient.get_server_information`
+  * :meth:`~qcportal.client.PortalClient.query_error_log`
+  * :meth:`~qcportal.client.PortalClient.delete_error_log`
+
+* :meth:`~qcportal.record_models.BaseRecord.get_waiting_reason`
+* :class:`~qcportal.client_base.PortalRequestError`
+* :class:`~qcportal.serverinfo.models.ErrorLogEntry`

--- a/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
@@ -48,6 +48,7 @@ dependencies:
   # Worker codes below
   - qcengine>=0.50,<0.70a0
   - psi4>=1.10.1
+  - libxc-c=7.0.0 # pinned due to errors. Remove eventually
   - rdkit
 
   # Testing packages

--- a/qcarchivetesting/conda-envs/fulltest_worker.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_worker.yaml
@@ -31,5 +31,6 @@ dependencies:
   # Worker codes below
   - qcengine>=0.50,<0.70a0
   - psi4>=1.10.1
+  - libxc-c=7.0.0 # pinned due to errors. Remove eventually
   - rdkit
   - geometric>=1.1.1

--- a/qcfractal/qcfractal/components/gridoptimization/dataset_socket.py
+++ b/qcfractal/qcfractal/components/gridoptimization/dataset_socket.py
@@ -71,7 +71,7 @@ class GridoptimizationDatasetSocket(BaseDatasetSocket):
         session: Session,
         dataset_id: int,
         entry_orm: Iterable[GridoptimizationDatasetEntryORM],
-        spec_orm: Iterable[GridoptimizationDatasetSpecificationORM],
+        specification_orm: Iterable[GridoptimizationDatasetSpecificationORM],
         existing_records: Iterable[Tuple[str, str]],
         compute_tag: str,
         compute_priority: PriorityEnum,
@@ -82,7 +82,7 @@ class GridoptimizationDatasetSocket(BaseDatasetSocket):
         n_inserted = 0
         n_existing = 0
 
-        for spec in spec_orm:
+        for spec in specification_orm:
             goopt_spec_obj = spec.specification.to_model(GridoptimizationSpecification)
             goopt_spec_input_dict = goopt_spec_obj.model_dump()
 

--- a/qcfractal/qcfractal/components/manybody/dataset_socket.py
+++ b/qcfractal/qcfractal/components/manybody/dataset_socket.py
@@ -69,7 +69,7 @@ class ManybodyDatasetSocket(BaseDatasetSocket):
         session: Session,
         dataset_id: int,
         entry_orm: Iterable[ManybodyDatasetEntryORM],
-        spec_orm: Iterable[ManybodyDatasetSpecificationORM],
+        specification_orm: Iterable[ManybodyDatasetSpecificationORM],
         existing_records: Iterable[Tuple[str, str]],
         compute_tag: str,
         compute_priority: PriorityEnum,
@@ -85,7 +85,7 @@ class ManybodyDatasetSocket(BaseDatasetSocket):
         normal_entries = [x for x in entry_orm if not x.additional_singlepoint_keywords]
 
         # Normal entries - just let it rip
-        for spec in spec_orm:
+        for spec in specification_orm:
             new_normal_entries = [x for x in normal_entries if (x.name, spec.name) not in existing_records]
             molecule_ids = [x.initial_molecule_id for x in new_normal_entries]
 
@@ -109,7 +109,7 @@ class ManybodyDatasetSocket(BaseDatasetSocket):
             n_existing += meta.n_existing
 
         # Now the ones with additional keywords
-        for spec in spec_orm:
+        for spec in specification_orm:
             spec_obj = spec.specification.to_model(ManybodySpecification)
             spec_input_dict = spec_obj.model_dump()
 

--- a/qcfractal/qcfractal/components/neb/dataset_socket.py
+++ b/qcfractal/qcfractal/components/neb/dataset_socket.py
@@ -73,7 +73,7 @@ class NEBDatasetSocket(BaseDatasetSocket):
         session: Session,
         dataset_id: int,
         entry_orm: Iterable[NEBDatasetEntryORM],
-        spec_orm: Iterable[NEBDatasetSpecificationORM],
+        specification_orm: Iterable[NEBDatasetSpecificationORM],
         existing_records: Iterable[Tuple[str, str]],
         compute_tag: str,
         compute_priority: PriorityEnum,
@@ -84,7 +84,7 @@ class NEBDatasetSocket(BaseDatasetSocket):
         n_inserted = 0
         n_existing = 0
 
-        for spec in spec_orm:
+        for spec in specification_orm:
             neb_spec_obj = spec.specification.to_model(NEBSpecification)
             neb_spec_input_dict = neb_spec_obj.model_dump()
 

--- a/qcfractal/qcfractal/components/optimization/dataset_socket.py
+++ b/qcfractal/qcfractal/components/optimization/dataset_socket.py
@@ -69,7 +69,7 @@ class OptimizationDatasetSocket(BaseDatasetSocket):
         session: Session,
         dataset_id: int,
         entry_orm: Iterable[OptimizationDatasetEntryORM],
-        spec_orm: Iterable[OptimizationDatasetSpecificationORM],
+        specification_orm: Iterable[OptimizationDatasetSpecificationORM],
         existing_records: Iterable[Tuple[str, str]],
         compute_tag: str,
         compute_priority: PriorityEnum,
@@ -85,7 +85,7 @@ class OptimizationDatasetSocket(BaseDatasetSocket):
         normal_entries = [x for x in entry_orm if not x.additional_keywords]
 
         # Normal entries - just let it rip
-        for spec in spec_orm:
+        for spec in specification_orm:
             new_normal_entries = [x for x in normal_entries if (x.name, spec.name) not in existing_records]
             molecule_ids = [x.initial_molecule_id for x in new_normal_entries]
 
@@ -109,7 +109,7 @@ class OptimizationDatasetSocket(BaseDatasetSocket):
             n_existing += meta.n_existing
 
         # Now the ones with additional keywords
-        for spec in spec_orm:
+        for spec in specification_orm:
             spec_obj = spec.specification.to_model(OptimizationSpecification)
             spec_input_dict = spec_obj.model_dump()
 

--- a/qcfractal/qcfractal/components/reaction/dataset_socket.py
+++ b/qcfractal/qcfractal/components/reaction/dataset_socket.py
@@ -82,7 +82,7 @@ class ReactionDatasetSocket(BaseDatasetSocket):
         session: Session,
         dataset_id: int,
         entry_orm: Iterable[ReactionDatasetEntryORM],
-        spec_orm: Iterable[ReactionDatasetSpecificationORM],
+        specification_orm: Iterable[ReactionDatasetSpecificationORM],
         existing_records: Iterable[Tuple[str, str]],
         compute_tag: str,
         compute_priority: PriorityEnum,
@@ -98,7 +98,7 @@ class ReactionDatasetSocket(BaseDatasetSocket):
         normal_entries = [x for x in entry_orm if not x.additional_keywords]
 
         # Normal entries - just let it rip
-        for spec in spec_orm:
+        for spec in specification_orm:
             new_normal_entries = [x for x in normal_entries if (x.name, spec.name) not in existing_records]
             stoichiometries = [[(x.coefficient, x.molecule_id) for x in y.stoichiometries] for y in new_normal_entries]
 
@@ -122,7 +122,7 @@ class ReactionDatasetSocket(BaseDatasetSocket):
             n_existing += meta.n_existing
 
         # Now the ones with additional keywords
-        for spec in spec_orm:
+        for spec in specification_orm:
             spec_obj = spec.specification.to_model(ReactionSpecification)
             spec_input_dict = spec_obj.model_dump()
 

--- a/qcfractal/qcfractal/components/singlepoint/dataset_socket.py
+++ b/qcfractal/qcfractal/components/singlepoint/dataset_socket.py
@@ -71,7 +71,7 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
         session: Session,
         dataset_id: int,
         entry_orm: Iterable[SinglepointDatasetEntryORM],
-        spec_orm: Iterable[SinglepointDatasetSpecificationORM],
+        specification_orm: Iterable[SinglepointDatasetSpecificationORM],
         existing_records: Iterable[Tuple[str, str]],
         compute_tag: str,
         compute_priority: PriorityEnum,
@@ -87,7 +87,7 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
         normal_entries = [x for x in entry_orm if not x.additional_keywords]
 
         # Normal entries - just let it rip
-        for spec in spec_orm:
+        for spec in specification_orm:
             new_normal_entries = [x for x in normal_entries if (x.name, spec.name) not in existing_records]
             molecule_ids = [x.molecule_id for x in new_normal_entries]
 
@@ -111,7 +111,7 @@ class SinglepointDatasetSocket(BaseDatasetSocket):
             n_existing += meta.n_existing
 
         # Now the ones with additional keywords
-        for spec in spec_orm:
+        for spec in specification_orm:
             spec_obj = spec.specification.to_model(QCSpecification)
             spec_input_dict = spec_obj.model_dump()
 

--- a/qcfractal/qcfractal/components/test_dataset_client.py
+++ b/qcfractal/qcfractal/components/test_dataset_client.py
@@ -50,6 +50,31 @@ def test_dataset_client_add_get(submitter_client: PortalClient, dataset_type: st
     assert ds2.id == ds.id
 
 
+def test_dataset_client_add_default_compute_tag_priority(submitter_client: PortalClient):
+    ds = submitter_client.add_dataset(
+        "singlepoint",
+        "Test dataset",
+        default_compute_tag="new_tag",
+        default_compute_priority=PriorityEnum.high,
+    )
+
+    assert ds.default_compute_tag == "new_tag"
+    assert ds.default_compute_priority == PriorityEnum.high
+
+
+def test_dataset_client_add_default_tag_priority_deprecated(submitter_client: PortalClient):
+    # 'default_tag'/'default_priority' are deprecated, but should still work
+    ds = submitter_client.add_dataset(
+        "singlepoint",
+        "Test dataset",
+        default_tag="old_tag",
+        default_priority=PriorityEnum.low,
+    )
+
+    assert ds.default_compute_tag == "old_tag"
+    assert ds.default_compute_priority == PriorityEnum.low
+
+
 def test_dataset_client_status(snowflake: QCATestingSnowflake):
     snowflake_client = snowflake.client()
     storage_socket = snowflake.get_storage_socket()

--- a/qcfractal/qcfractal/components/torsiondrive/dataset_socket.py
+++ b/qcfractal/qcfractal/components/torsiondrive/dataset_socket.py
@@ -73,7 +73,7 @@ class TorsiondriveDatasetSocket(BaseDatasetSocket):
         session: Session,
         dataset_id: int,
         entry_orm: Iterable[TorsiondriveDatasetEntryORM],
-        spec_orm: Iterable[TorsiondriveDatasetSpecificationORM],
+        specification_orm: Iterable[TorsiondriveDatasetSpecificationORM],
         existing_records: Iterable[Tuple[str, str]],
         compute_tag: str,
         compute_priority: PriorityEnum,
@@ -84,7 +84,7 @@ class TorsiondriveDatasetSocket(BaseDatasetSocket):
         n_inserted = 0
         n_existing = 0
 
-        for spec in spec_orm:
+        for spec in specification_orm:
             td_spec_obj = spec.specification.to_model(TorsiondriveSpecification)
             td_spec_input_dict = td_spec_obj.model_dump()
 

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -83,7 +83,7 @@ class DatabaseConfig(QCFConfigBase):
     """The port the database is running on. If own = True, a database will be started, binding to this port"""
 
     database_name: str = "qcfractal_default"
-    """The database name to connect to."""
+    """The database name to connect to"""
 
     username: str
     """The database username to connect with"""
@@ -201,7 +201,7 @@ class AutoResetConfig(QCFConfigBase):
     """
 
     unknown_error: int = 2
-    """Maximum automatic restarts for errors that could not be classified."""
+    """Maximum automatic restarts for errors that could not be classified"""
 
     compute_lost: int = 5
     """Maximum automatic restarts for computations whose compute resource disappeared.
@@ -213,7 +213,7 @@ class AutoResetConfig(QCFConfigBase):
     """
 
     random_error: int = 5
-    """Maximum automatic restarts for errors the server recognises as intermittent."""
+    """Maximum automatic restarts for errors the server recognises as intermittent"""
 
 
 class APILimitConfig(QCFConfigBase):
@@ -272,7 +272,7 @@ class WebAPIConfig(QCFConfigBase):
     """The IP address or hostname to bind to"""
 
     port: int = 7777
-    """The port on which to run the REST interface."""
+    """The port on which to run the REST interface"""
 
     secret_key: str
     """Secret key for flask api. See documentation"""
@@ -348,7 +348,7 @@ class S3Config(QCFConfigBase):
     """
 
     verify: bool = True
-    """Verify TLS certificates when connecting to S3."""
+    """Verify TLS certificates when connecting to S3"""
 
     passthrough: bool = False
     """Whether clients may download directly from the S3 endpoint.
@@ -367,7 +367,7 @@ class S3Config(QCFConfigBase):
     """AWS/S3 secret key"""
 
     auto_create_buckets: bool = False
-    """Create the buckets named in ``bucket_map`` at startup if they do not already exist."""
+    """Create the buckets named in ``bucket_map`` at startup if they do not already exist"""
 
     bucket_map: S3BucketMap = Field(default_factory=S3BucketMap)
     """Configuration for where to store various files"""
@@ -389,16 +389,16 @@ class CORSconfig(QCFConfigBase):
     enabled: bool = False
     """Whether to send CORS headers at all. With this off the other options here do nothing."""
 
-    origins: list[str] = Field([])
+    origins: list[str] = []
     """Origins permitted to make cross-origin requests. Use ``["*"]`` to allow any origin."""
 
     supports_credentials: bool = False
-    """Whether cross-origin requests may carry credentials (cookies, authorization headers)."""
+    """Whether cross-origin requests may carry credentials (cookies, authorization headers)"""
 
-    headers: list[str] = Field([])
-    """Request headers a cross-origin request is allowed to set, such as ``Authorization``."""
+    headers: list[str] = []
+    """Request headers a cross-origin request is allowed to set, such as ``Authorization``"""
 
-    methods: list[str] = Field([])
+    methods: list[str] = []
     """HTTP methods permitted for cross-origin requests. Empty means the CORS default."""
 
 
@@ -473,7 +473,6 @@ class FractalConfig(BaseSettings):
     access_log_keep: int = 0
     """How far back to keep access logs (in days or as a duration string). 0 means keep all"""
 
-    # maxmind_account_id: int | None = Field(None, description="Account ID for MaxMind GeoIP2 service")
     maxmind_license_key: str | None = None
     """License key for MaxMind GeoIP2 service. If provided, the GeoIP2 database will be downloaded and updated
     automatically

--- a/qcfractal/qcfractal/config.py
+++ b/qcfractal/qcfractal/config.py
@@ -4,7 +4,6 @@ The global qcfractal config file specification.
 
 import logging
 import os
-import re
 import secrets
 import tempfile
 from typing import Any, Annotated
@@ -59,7 +58,7 @@ def make_uri_string(
 
 
 class QCFConfigBase(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
 
 class DatabaseConfig(QCFConfigBase):
@@ -67,59 +66,61 @@ class DatabaseConfig(QCFConfigBase):
     Settings for the database used by QCFractal
     """
 
-    base_folder: str = Field(
-        ...,
-        description="The base folder to use as the default for some options (logs, etc). Default is the location of the config file.",
-    )
+    base_folder: str
+    """The base folder to use as the default for some options (logs, etc). Default is the location of the config
+    file.
+    """
 
-    full_uri: str | None = Field(
-        None, description="Full connection URI. This overrides host,username,password,port, etc"
-    )
+    full_uri: str | None = None
+    """Full connection URI. This overrides host,username,password,port, etc"""
 
-    host: str = Field(
-        "localhost",
-        description="The hostname or ip address the database is running on. If own = True, this must be localhost. May also be a path to a directory containing the database socket file",
-    )
-    port: int = Field(
-        5432,
-        description="The port the database is running on. If own = True, a database will be started, binding to this port",
-    )
-    database_name: str = Field("qcfractal_default", description="The database name to connect to.")
-    username: str = Field(..., description="The database username to connect with")
-    password: str = Field(..., description="The database password to connect with")
-    query: dict[str, str | int] = Field(
-        {}, description="Extra connection query parameters at the end of the URL string"
-    )
+    host: str = "localhost"
+    """The hostname or ip address the database is running on. If own = True, this must be localhost. May also be a
+    path to a directory containing the database socket file
+    """
 
-    own: bool = Field(
-        True,
-        description="If True, QCFractal will control the database instance. If False, you must start and manage the database yourself",
-    )
+    port: int = 5432
+    """The port the database is running on. If own = True, a database will be started, binding to this port"""
 
-    data_directory: str | None = Field(
-        None,
-        description="Location to place the database if own == True. Default is [base_folder]/database if we own the database",
-    )
-    logfile: str | None = Field(
-        None,
-        description="Path to a file to use as the database logfile (if own == True). Default is [base_folder]/qcfractal_database.log",
-    )
+    database_name: str = "qcfractal_default"
+    """The database name to connect to."""
 
-    echo_sql: bool = Field(False, description="[ADVANCED] output raw SQL queries being run")
-    pg_tool_dir: str | None = Field(
-        None,
-        description="Directory containing Postgres tools such as psql and pg_ctl (ie, /usr/bin, or /usr/lib/postgresql/13/bin). If not specified, an attempt to find them will be made. This field is only required if autodetection fails and own == True",
-    )
+    username: str
+    """The database username to connect with"""
 
-    pool_size: int = Field(
-        5,
-        description="[ADVANCED] set the size of the connection pool to use in SQLAlchemy. Set to zero to disable pooling",
-    )
+    password: str
+    """The database password to connect with"""
 
-    maintenance_db: str = Field(
-        "postgres",
-        description="[ADVANCED] An existing database (not the one you want to use/create). This is used for database management",
-    )
+    query: dict[str, str | int] = {}
+    """Extra connection query parameters at the end of the URL string"""
+
+    own: bool = True
+    """If True, QCFractal will control the database instance. If False, you must start and manage the database
+    yourself
+    """
+
+    data_directory: str | None = None
+    """Location to place the database if own == True. Default is [base_folder]/database if we own the database"""
+
+    logfile: str | None = None
+    """Path to a file to use as the database logfile (if own == True). Default is
+    [base_folder]/qcfractal_database.log
+    """
+
+    echo_sql: bool = False
+    """[ADVANCED] output raw SQL queries being run"""
+
+    pg_tool_dir: str | None = None
+    """Directory containing Postgres tools such as psql and pg_ctl (ie, /usr/bin, or /usr/lib/postgresql/13/bin). If
+    not specified, an attempt to find them will be made. This field is only required if autodetection fails and
+    own == True
+    """
+
+    pool_size: int = 5
+    """[ADVANCED] set the size of the connection pool to use in SQLAlchemy. Set to zero to disable pooling"""
+
+    maintenance_db: str = "postgres"
+    """[ADVANCED] An existing database (not the one you want to use/create). This is used for database management"""
 
     @model_validator(mode="after")
     def _check_paths(self):
@@ -190,13 +191,29 @@ class DatabaseConfig(QCFConfigBase):
 
 class AutoResetConfig(QCFConfigBase):
     """
-    Limits on the number of records returned per query. This can be specified per object (molecule, etc)
+    How many times the server will automatically retry a failed computation
     """
 
-    enabled: bool = Field(False, description="Enable/disable automatic restart. True = enabled")
-    unknown_error: int = Field(2, description="Max restarts for unknown errors")
-    compute_lost: int = Field(5, description="Max restarts for computations where the compute resource disappeared")
-    random_error: int = Field(5, description="Max restarts for random errors")
+    enabled: bool = False
+    """Whether to automatically reset errored records at all.
+
+    With this disabled, every errored record waits for someone to reset it by hand.
+    """
+
+    unknown_error: int = 2
+    """Maximum automatic restarts for errors that could not be classified."""
+
+    compute_lost: int = 5
+    """Maximum automatic restarts for computations whose compute resource disappeared.
+
+    This covers the ordinary ways a batch job ends without reporting back - a walltime kill,
+    a preempted node, a manager killed mid-task. These failures say nothing about whether the computation
+    itself is sound, which is why the default is more generous than for
+    ``unknown_error``.
+    """
+
+    random_error: int = 5
+    """Maximum automatic restarts for errors the server recognises as intermittent."""
 
 
 class APILimitConfig(QCFConfigBase):
@@ -204,22 +221,38 @@ class APILimitConfig(QCFConfigBase):
     Limits on the number of records returned per query. This can be specified per object (molecule, etc)
     """
 
-    get_records: int = Field(1000, description="Number of calculation records that can be retrieved")
-    add_records: int = Field(500, description="Number of calculation records that can be added")
+    get_records: int = 1000
+    """Number of calculation records that can be retrieve in a single request"""
 
-    get_dataset_entries: int = Field(2000, description="Number of dataset entries that can be retrieved")
+    add_records: int = 500
+    """Number of calculation records that can be added in a single request"""
 
-    get_molecules: int = Field(1000, description="Number of molecules that can be retrieved")
-    add_molecules: int = Field(1000, description="Number of molecules that can be added")
+    get_dataset_entries: int = 2000
+    """Number of dataset entries that can be retrieved in a single request"""
 
-    get_managers: int = Field(1000, description="Number of manager records to return")
+    get_molecules: int = 1000
+    """Number of molecules that can be retrieved in a single request"""
 
-    manager_tasks_claim: int = Field(200, description="Number of tasks a single manager can pull down")
-    manager_tasks_return: int = Field(10, description="Number of tasks a single manager can return at once")
+    add_molecules: int = 1000
+    """Number of molecules that can be added in a single request"""
 
-    get_access_logs: int = Field(1000, description="Number of access log records to return")
-    get_error_logs: int = Field(100, description="Number of error log records to return")
-    get_internal_jobs: int = Field(1000, description="Number of internal jobs to return")
+    get_managers: int = 1000
+    """Number of manager records to return"""
+
+    manager_tasks_claim: int = 200
+    """Number of tasks a single manager can pull down"""
+
+    manager_tasks_return: int = 10
+    """Number of tasks a single manager can return at once"""
+
+    get_access_logs: int = 1000
+    """Number of access log records to return"""
+
+    get_error_logs: int = 100
+    """Number of error log records to return"""
+
+    get_internal_jobs: int = 1000
+    """Number of internal jobs to return"""
 
 
 class WebAPIConfig(QCFConfigBase):
@@ -227,51 +260,58 @@ class WebAPIConfig(QCFConfigBase):
     Settings for the Web API (api) interface
     """
 
-    num_threads_per_worker: int = Field(4, description="Number of threads per worker")
-    worker_timeout: int = Field(
-        120,
-        description="If the master process does not hear from a worker for the given amount of time (in seconds),"
-        "kill it. This effectively limits the time a worker has to respond to a request",
-    )
-    host: str = Field("localhost", description="The IP address or hostname to bind to")
-    port: int = Field(7777, description="The port on which to run the REST interface.")
+    num_threads_per_worker: int = 4
+    """Number of threads per worker"""
 
-    secret_key: str = Field(..., description="Secret key for flask api. See documentation")
-    jwt_secret_key: str = Field(..., description="Secret key for web tokens. See documentation")
-    jwt_access_token_expires: int = Field(
-        60 * 60, description="The time (in seconds) an access token is valid for. Default is 1 hour"
-    )
-    jwt_refresh_token_expires: int = Field(
-        60 * 60 * 24, description="The time (in seconds) a refresh token is valid for. Default is 1 day"
-    )
-    user_session_max_age: int = Field(
-        60 * 60 * 24, description="The time (in seconds) that a user session can be idle (for browser-based sessions)"
-    )
-    user_session_cookie_name: str = Field(
-        "qcf_session", description="Name to use for a session cookie (for browser-based sessions)"
-    )
-    user_session_cookie_domain: str | None = Field(
-        None, description="Domain to use for the user-session cookie (for browser-based sessions)"
-    )
-    user_session_cookie_samesite: str | None = Field(
-        None, description="Set the SameSite flag for the user-session cookie (for browser-based sessions)"
-    )
-    user_session_cookie_partitioned: bool = Field(
-        False, description="Use the Partitioned flag for the user-session cookie (for browser-based sessions)"
-    )
-    user_session_cookie_secure: bool = Field(
-        False, description="Use Secure flag for the user-session cookie (for browser-based sessions)"
-    )
-    user_session_cookie_httponly: bool = Field(
-        False, description="Use Secure flag for the user-session cookie (for browser-based sessions)"
-    )
+    worker_timeout: int = 120
+    """If the master process does not hear from a worker for the given amount of time (in seconds),kill it. This
+    effectively limits the time a worker has to respond to a request
+    """
 
-    extra_flask_options: dict[str, Any] | None = Field(
-        None, description="Any additional options to pass directly to flask"
-    )
-    extra_waitress_options: dict[str, Any] | None = Field(
-        None, description="Any additional options to pass directly to the waitress serve function"
-    )
+    host: str = "localhost"
+    """The IP address or hostname to bind to"""
+
+    port: int = 7777
+    """The port on which to run the REST interface."""
+
+    secret_key: str
+    """Secret key for flask api. See documentation"""
+
+    jwt_secret_key: str
+    """Secret key for web tokens. See documentation"""
+
+    jwt_access_token_expires: int = 60 * 60
+    """The time (in seconds) an access token is valid for. Default is 1 hour"""
+
+    jwt_refresh_token_expires: int = 60 * 60 * 24
+    """The time (in seconds) a refresh token is valid for. Default is 1 day"""
+
+    user_session_max_age: int = 60 * 60 * 24
+    """The time (in seconds) that a user session can be idle (for browser-based sessions)"""
+
+    user_session_cookie_name: str = "qcf_session"
+    """Name to use for a session cookie (for browser-based sessions)"""
+
+    user_session_cookie_domain: str | None = None
+    """Domain to use for the user-session cookie (for browser-based sessions)"""
+
+    user_session_cookie_samesite: str | None = None
+    """Set the SameSite flag for the user-session cookie (for browser-based sessions)"""
+
+    user_session_cookie_partitioned: bool = False
+    """Use the Partitioned flag for the user-session cookie (for browser-based sessions)"""
+
+    user_session_cookie_secure: bool = False
+    """Use Secure flag for the user-session cookie (for browser-based sessions)"""
+
+    user_session_cookie_httponly: bool = False
+    """Use Secure flag for the user-session cookie (for browser-based sessions)"""
+
+    extra_flask_options: dict[str, Any] | None = None
+    """Any additional options to pass directly to flask"""
+
+    extra_waitress_options: dict[str, Any] | None = None
+    """Any additional options to pass directly to the waitress serve function"""
 
     @field_validator(
         "jwt_access_token_expires",
@@ -288,8 +328,11 @@ class WebAPIConfig(QCFConfigBase):
 S3BucketName = Annotated[str, StringConstraints(min_length=3, max_length=63, pattern=r"^[a-z0-9\-]+[a-z0-9]$")]
 
 class S3BucketMap(QCFConfigBase):
-    dataset_attachment: S3BucketName = Field("dataset-attachments", description="Bucket to hold dataset views")
-    project_attachment: S3BucketName = Field("project-attachments", description="Bucket to hold project attachments")
+    dataset_attachment: S3BucketName = "dataset-attachments"
+    """Bucket to hold dataset views"""
+
+    project_attachment: S3BucketName = "project-attachments"
+    """Bucket to hold project attachments"""
 
 
 class S3Config(QCFConfigBase):
@@ -298,16 +341,36 @@ class S3Config(QCFConfigBase):
     """
 
     enabled: bool = False
-    verify: bool = True
-    passthrough: bool = False
-    endpoint_url: str | None = Field(None, description="S3 endpoint URL")
-    access_key_id: str | None = Field(None, description="AWS/S3 access key")
-    secret_access_key: str | None = Field(None, description="AWS/S3 secret key")
-    auto_create_buckets: bool = False
+    """Whether to store large external files (dataset views, attachments) in S3.
 
-    bucket_map: S3BucketMap = Field(
-        default_factory=S3BucketMap, description="Configuration for where to store various files"
-    )
+    When enabled, ``endpoint_url``, ``access_key_id`` and ``secret_access_key`` are all
+    required; the server refuses to start otherwise.
+    """
+
+    verify: bool = True
+    """Verify TLS certificates when connecting to S3."""
+
+    passthrough: bool = False
+    """Whether clients may download directly from the S3 endpoint.
+
+    With this off, file contents are proxied through the server, so clients never need
+    to reach S3 themselves.
+    """
+
+    endpoint_url: str | None = None
+    """S3 endpoint URL"""
+
+    access_key_id: str | None = None
+    """AWS/S3 access key"""
+
+    secret_access_key: str | None = None
+    """AWS/S3 secret key"""
+
+    auto_create_buckets: bool = False
+    """Create the buckets named in ``bucket_map`` at startup if they do not already exist."""
+
+    bucket_map: S3BucketMap = Field(default_factory=S3BucketMap)
+    """Configuration for where to store various files"""
 
     @model_validator(mode="after")
     def _check_enabled(self):
@@ -324,10 +387,19 @@ class CORSconfig(QCFConfigBase):
     """
 
     enabled: bool = False
+    """Whether to send CORS headers at all. With this off the other options here do nothing."""
+
     origins: list[str] = Field([])
+    """Origins permitted to make cross-origin requests. Use ``["*"]`` to allow any origin."""
+
     supports_credentials: bool = False
+    """Whether cross-origin requests may carry credentials (cookies, authorization headers)."""
+
     headers: list[str] = Field([])
+    """Request headers a cross-origin request is allowed to set, such as ``Authorization``."""
+
     methods: list[str] = Field([])
+    """HTTP methods permitted for cross-origin requests. Empty means the CORS default."""
 
 
 class FractalConfig(BaseSettings):
@@ -335,114 +407,122 @@ class FractalConfig(BaseSettings):
     Fractal Server settings
     """
 
-    base_folder: str = Field(
-        ...,
-        description="The base directory to use as the default for some options (logs, etc). Default is the location of the config file.",
-    )
+    base_folder: str
+    """The base directory to use as the default for some options (logs, etc). Default is the location of the config
+    file.
+    """
 
-    temporary_dir: str | None = Field(
-        None,
-        description="Temporary directory to use for things such as view creation. If None, uses system default. This may require a lot of space!",
-    )
+    temporary_dir: str | None = None
+    """Temporary directory to use for things such as view creation. If None, uses system default. This may require a
+    lot of space!
+    """
 
     # Info for the REST interface
-    name: str = Field("QCFractal Server", description="The QCFractal server name")
+    name: str = "QCFractal Server"
+    """The QCFractal server name"""
 
-    enable_security: bool = Field(True, description="Enable user authentication and authorization")
-    allow_unauthenticated_read: bool = Field(
-        True,
-        description="Allows unauthenticated read access to this instance. This does not extend to sensitive tables (such as user information)",
-    )
-    strict_compute_tags: bool = Field(
-        False,
-        description="If True, disables wildcard behavior for compute tags. This disables managers from claiming all "
-        "tags if they specify a wildcard ('*') tag. Managers will still be able to claim tasks with an "
-        "explicit '*' tag if they specify the '*' queue tag in their config",
-    )
+    enable_security: bool = True
+    """Enable user authentication and authorization"""
+
+    allow_unauthenticated_read: bool = True
+    """Allows unauthenticated read access to this instance. This does not extend to sensitive tables (such as user
+    information)
+    """
+
+    strict_compute_tags: bool = False
+    """If True, disables wildcard behavior for compute tags. This disables managers from claiming all tags if they
+    specify a wildcard ('*') tag. Managers will still be able to claim tasks with an explicit '*' tag if they
+    specify the '*' queue tag in their config
+    """
 
     # Logging and profiling
-    logfile: str | None = Field(
-        None,
-        description="Path to a file to use for server logging. If not specified, logs will be printed to standard output",
-    )
-    loglevel: str = Field(
-        "INFO", description="Level of logging to enable (debug, info, warning, error, critical). Case insensitive"
-    )
+    logfile: str | None = None
+    """Path to a file to use for server logging. If not specified, logs will be printed to standard output"""
 
-    hide_internal_errors: bool = Field(
-        True,
-        description="If True, internal errors will only be reported as an error "
-        "number to the user. If False, the entire error/backtrace "
-        "will be sent (which could rarely contain sensitive info). "
-        "In either case, errors will be stored in the database",
-    )
+    loglevel: str = "INFO"
+    """Level of logging to enable (debug, info, warning, error, critical). Case insensitive"""
+
+    hide_internal_errors: bool = True
+    """If True, internal errors will only be reported as an error number to the user. If False, the entire
+    error/backtrace will be sent (which could rarely contain sensitive info). In either case, errors will be
+    stored in the database
+    """
 
     # Periodics
-    service_frequency: int = Field(60, description="The frequency at which to update services (in seconds)")
-    max_active_services: int = Field(20, description="The maximum number of concurrent active services")
-    heartbeat_frequency: int = Field(
-        1800,
-        description="The frequency (in seconds) to check the heartbeat of compute managers",
-        gt=0,
-    )
-    heartbeat_frequency_jitter: float = Field(
-        0.1, description="Jitter fraction to be applied to the heartbeat frequency", ge=0
-    )
-    heartbeat_max_missed: int = Field(
-        5,
-        description="The maximum number of heartbeats that a compute manager can miss. If more are missed, the worker is considered dead",
-        ge=0,
-    )
+    service_frequency: int = 60
+    """The frequency at which to update services (in seconds)"""
+
+    max_active_services: int = 20
+    """The maximum number of concurrent active services"""
+
+    heartbeat_frequency: int = Field(1800, gt=0)
+    """The frequency (in seconds) to check the heartbeat of compute managers"""
+
+    heartbeat_frequency_jitter: float = Field(0.1, ge=0)
+    """Jitter fraction to be applied to the heartbeat frequency"""
+
+    heartbeat_max_missed: int = Field(5, ge=0)
+    """The maximum number of heartbeats that a compute manager can miss. If more are missed, the worker is considered
+    dead
+    """
 
     # Access logging
-    log_access: bool = Field(False, description="Store API access in the database")
-    access_log_keep: int = Field(
-        0, description="How far back to keep access logs (in days or as a duration string). 0 means keep all"
-    )
+    log_access: bool = False
+    """Store API access in the database"""
+
+    access_log_keep: int = 0
+    """How far back to keep access logs (in days or as a duration string). 0 means keep all"""
 
     # maxmind_account_id: int | None = Field(None, description="Account ID for MaxMind GeoIP2 service")
-    maxmind_license_key: str | None = Field(
-        None,
-        description="License key for MaxMind GeoIP2 service. If provided, the GeoIP2 database will be downloaded and updated automatically",
-    )
+    maxmind_license_key: str | None = None
+    """License key for MaxMind GeoIP2 service. If provided, the GeoIP2 database will be downloaded and updated
+    automatically
+    """
 
-    geoip2_dir: str | None = Field(
-        None,
-        description="Directory containing the Maxmind GeoIP2 Cities file (GeoLite2-City.mmdb) Defaults to [base_folder]/geoip2. This directory will be created if needed.",
-    )
+    geoip2_dir: str | None = None
+    """Directory containing the Maxmind GeoIP2 Cities file (GeoLite2-City.mmdb) Defaults to [base_folder]/geoip2.
+    This directory will be created if needed.
+    """
 
-    geoip2_filename: str = Field(
-        "GeoLite2-City.mmdb", description="Filename of the Maxmind GeoIP2 Cities file (GeoLite2-City.mmdb)"
-    )
+    geoip2_filename: str = "GeoLite2-City.mmdb"
+    """Filename of the Maxmind GeoIP2 Cities file (GeoLite2-City.mmdb)"""
 
     # Internal jobs
-    internal_job_processes: int = Field(
-        1, description="Number of processes for processing internal jobs and async requests"
-    )
-    internal_job_keep: int = Field(
-        0, description="How far back to keep finished internal jobs (in days or as a duration string). 0 means keep all"
-    )
+    internal_job_processes: int = 1
+    """Number of processes for processing internal jobs and async requests"""
+
+    internal_job_keep: int = 0
+    """How far back to keep finished internal jobs (in days or as a duration string). 0 means keep all"""
 
     # Homepage settings
-    homepage_redirect_url: str | None = Field(None, description="Redirect to this URL when going to the root path")
-    homepage_directory: str | None = Field(None, description="Use this directory to serve the homepage")
+    homepage_redirect_url: str | None = None
+    """Redirect to this URL when going to the root path"""
+
+    homepage_directory: str | None = None
+    """Use this directory to serve the homepage"""
 
     # File uploads
-    upload_directory: str | None = Field(None, description="Directory to store user-uploaded files for processing")
+    upload_directory: str | None = None
+    """Directory to store user-uploaded files for processing"""
 
     # Other settings blocks
-    database: DatabaseConfig = Field(..., description="Configuration of the settings for the database")
-    api: WebAPIConfig = Field(..., description="Configuration of the REST interface")
-    s3: S3Config = Field(default_factory=S3Config, description="Configuration of the S3 file storage (optional)")
-    api_limits: APILimitConfig = Field(
-        default_factory=APILimitConfig, description="Configuration of the limits to the api"
-    )
-    cors: CORSconfig = Field(
-        default_factory=CORSconfig, description="Configuration Cross Origin Resource sharing (advanced)"
-    )
-    auto_reset: AutoResetConfig = Field(
-        default_factory=AutoResetConfig, description="Configuration for automatic resetting of tasks"
-    )
+    database: DatabaseConfig
+    """Configuration of the settings for the database"""
+
+    api: WebAPIConfig
+    """Configuration of the REST interface"""
+
+    s3: S3Config = Field(default_factory=S3Config)
+    """Configuration of the S3 file storage (optional)"""
+
+    api_limits: APILimitConfig = Field(default_factory=APILimitConfig)
+    """Configuration of the limits to the api"""
+
+    cors: CORSconfig = Field(default_factory=CORSconfig)
+    """Configuration Cross Origin Resource sharing (advanced)"""
+
+    auto_reset: AutoResetConfig = Field(default_factory=AutoResetConfig)
+    """Configuration for automatic resetting of tasks"""
 
     @field_validator("loglevel", mode="after")
     @classmethod
@@ -497,7 +577,11 @@ class FractalConfig(BaseSettings):
         return self
 
     model_config = SettingsConfigDict(
-        extra="forbid", case_sensitive=False, env_prefix="QCF_", env_nested_delimiter="__"
+        extra="forbid",
+        case_sensitive=False,
+        env_prefix="QCF_",
+        env_nested_delimiter="__",
+        use_attribute_docstrings=True,
     )
 
     # Since we manually read the yaml files, the values passed into the init
@@ -512,6 +596,58 @@ class FractalConfig(BaseSettings):
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
         return env_settings, dotenv_settings, init_settings, file_secret_settings
+
+
+# Environment variable prefixes that were removed when the configuration moved from one
+# BaseSettings per section (each with its own flat prefix) to a single BaseSettings at
+# the top level with env_nested_delimiter="__". Maps the old prefix to its replacement.
+_DEPRECATED_ENV_PREFIXES: list[tuple[str, str]] = [
+    ("QCF_DB_", "QCF_DATABASE__"),
+    ("QCF_APILIMIT_", "QCF_API_LIMITS__"),
+    ("QCF_AUTORESET_", "QCF_AUTO_RESET__"),
+    ("QCF_S3_", "QCF_S3__"),
+    ("QCF_API_", "QCF_API__"),
+]
+
+
+def check_deprecated_env_vars() -> None:
+    """
+    Raise if the environment contains one of the removed per-section variable prefixes
+
+    These no longer have any effect, so without this check a stale ``QCF_DB_HOST`` would
+    leave the setting at its default with no indication that anything was wrong.
+
+    Raises
+    ------
+    RuntimeError
+        If a deprecated environment variable is set. The message names the replacement.
+    """
+
+    # Checked first: a valid variable can begin with a deprecated prefix. QCF_API_LIMITS__
+    # starts with QCF_API_, and used to be rejected as if it were the old QCF_API_ prefix,
+    # which made api_limits impossible to set from the environment at all.
+    current_prefixes = tuple(
+        f"QCF_{name.upper()}__"
+        for name, field in FractalConfig.model_fields.items()
+        if isinstance(field.annotation, type) and issubclass(field.annotation, BaseModel)
+    )
+
+    for key in os.environ:
+        upper_key = key.upper()
+
+        if upper_key.startswith(current_prefixes):
+            continue
+
+        for old_prefix, new_prefix in _DEPRECATED_ENV_PREFIXES:
+            if not upper_key.startswith(old_prefix):
+                continue
+            # A further underscore means a nested-style name that simply does not exist
+            # (eg QCF_DB__HOST); leave it to pydantic rather than suggesting a mangled
+            # replacement.
+            if upper_key.startswith(old_prefix + "_"):
+                continue
+            new_key = new_prefix + upper_key[len(old_prefix) :]
+            raise RuntimeError(f"Environment variable {key} is deprecated. Use {new_key} instead.")
 
 
 def read_configuration(file_paths: list[str], extra_config: dict[str, Any] | None = None) -> FractalConfig:
@@ -547,20 +683,7 @@ def read_configuration(file_paths: list[str], extra_config: dict[str, Any] | Non
 
     config_data["base_folder"] = os.path.abspath(base_dir)
 
-    # Test environment values for old names
-    for key in os.environ.keys():
-        if re.match(r"QCF_DB_[^_]", key):
-            new_key = key.replace("QCF_DB_", "QCF_DATABASE__")
-            raise RuntimeError(f"Environment variable {key} is deprecated. Use {new_key} instead.")
-        if re.match(r"QCF_API_[^_]", key):
-            new_key = key.replace("QCF_API_", "QCF_API__")
-            raise RuntimeError(f"Environment variable {key} is deprecated. Use {new_key} instead.")
-        if re.match("QCF_AUTORESET_[^_]", key):
-            new_key = key.replace("QCF_AUTORESET_", "QCF_AUTO_RESET__")
-            raise RuntimeError(f"Environment variable {key} is deprecated. Use {new_key} instead.")
-        if re.match("QCF_S3_[^_]", key):
-            new_key = key.replace("QCF_S3_", "QCF_S3__")
-            raise RuntimeError(f"Environment variable {key} is deprecated. Use {new_key} instead.")
+    check_deprecated_env_vars()
 
     # Pydantic will handle reading from environment variables
     # See if it can assemble a config. If there was a problem, and no

--- a/qcfractal/qcfractal/test_config.py
+++ b/qcfractal/qcfractal/test_config.py
@@ -1,7 +1,10 @@
 import copy
 import os
 
-from qcfractal.config import FractalConfig
+import pytest
+import yaml
+
+from qcfractal.config import FractalConfig, check_deprecated_env_vars, read_configuration
 
 _base_config = {
     "api": {
@@ -80,3 +83,64 @@ def test_config_tmpdir_create(tmp_path):
 
     assert cfg.temporary_dir == str(tmp_path / "qcatmpdir")
     assert os.path.exists(cfg.temporary_dir)
+
+
+@pytest.fixture
+def clean_qcf_env(monkeypatch):
+    """Removes any QCF_* variables inherited from the caller's environment"""
+    for key in list(os.environ):
+        if key.upper().startswith("QCF_"):
+            monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+@pytest.mark.parametrize(
+    "old_var,expected_new",
+    [
+        ("QCF_DB_HOST", "QCF_DATABASE__HOST"),
+        ("QCF_API_PORT", "QCF_API__PORT"),
+        ("QCF_APILIMIT_GET_RECORDS", "QCF_API_LIMITS__GET_RECORDS"),
+        ("QCF_AUTORESET_ENABLED", "QCF_AUTO_RESET__ENABLED"),
+        ("QCF_S3_ENABLED", "QCF_S3__ENABLED"),
+        # Matching is case insensitive, since pydantic-settings reads env vars that way
+        ("qcf_db_host", "QCF_DATABASE__HOST"),
+    ],
+)
+def test_config_deprecated_env_vars(clean_qcf_env, old_var, expected_new):
+    clean_qcf_env.setenv(old_var, "some_value")
+
+    with pytest.raises(RuntimeError, match=f"Use {expected_new} instead"):
+        check_deprecated_env_vars()
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    [
+        "QCF_LOGLEVEL",
+        "QCF_DATABASE__HOST",
+        "QCF_API__PORT",
+        # Begins with the deprecated QCF_API_ prefix, and used to be rejected because of
+        # it, which made api_limits impossible to set from the environment
+        "QCF_API_LIMITS__GET_RECORDS",
+        "QCF_AUTO_RESET__ENABLED",
+        "QCF_CORS__ENABLED",
+        "QCF_S3__ENABLED",
+    ],
+)
+def test_config_current_env_vars_not_deprecated(clean_qcf_env, env_var):
+    clean_qcf_env.setenv(env_var, "1")
+
+    check_deprecated_env_vars()  # must not raise
+
+
+def test_config_env_var_api_limits(clean_qcf_env, tmp_path):
+    """api_limits must be settable from the environment"""
+
+    config_path = tmp_path / "qcfractal_config.yaml"
+    with open(config_path, "w") as f:
+        yaml.safe_dump(_base_config, f)
+
+    clean_qcf_env.setenv("QCF_API_LIMITS__GET_RECORDS", "4321")
+    cfg = read_configuration([str(config_path)])
+
+    assert cfg.api_limits.get_records == 4321

--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -166,7 +166,7 @@ class FractalServerSettings(QCFComputeConfigBase):
     """Password to authenticate to the Fractal Server with (alongside the `username`)"""
 
     verify: bool | None = None
-    """Use Server-side generated SSL certification or not."""
+    """Use Server-side generated SSL certification or not"""
 
 
 class FractalComputeConfig(BaseSettings):
@@ -216,9 +216,9 @@ class FractalComputeConfig(BaseSettings):
     See https://parsl.readthedocs.io/en/stable/userguide/advanced/usage_tracking.html
     """
 
-    server: FractalServerSettings = Field(...)
+    server: FractalServerSettings
     environments: PackageEnvironmentSettings = Field(default_factory=PackageEnvironmentSettings)
-    executors: dict[str, AllExecutorTypes] = Field(...)
+    executors: dict[str, AllExecutorTypes]
 
     model_config = SettingsConfigDict(
         extra="forbid",

--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -47,7 +47,7 @@ def _walltime_must_be_str(w) -> str:
 
 
 class QCFComputeConfigBase(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
 
 class PackageEnvironmentSettings(QCFComputeConfigBase):
@@ -58,14 +58,14 @@ class PackageEnvironmentSettings(QCFComputeConfigBase):
     direct appropriate calculations to them.
     """
 
-    use_manager_environment: bool = Field(
-        True,
-        description="Use the environment that the manager is running in for computation. May be in addition to other environments",
-    )
-    conda: list[str] = Field([], description="List of conda environments to query for installed packages")
-    apptainer: list[str] = Field(
-        [], description="List of paths to apptainer/singularity files to query for installed packages"
-    )
+    use_manager_environment: bool = True
+    """Use the environment that the manager is running in for computation. May be in addition to other environments"""
+
+    conda: list[str] = []
+    """List of conda environments to query for installed packages"""
+
+    apptainer: list[str] = []
+    """List of paths to apptainer/singularity files to query for installed packages"""
 
 
 class ExecutorConfig(QCFComputeConfigBase):
@@ -154,67 +154,78 @@ class FractalServerSettings(QCFComputeConfigBase):
     to ensure its security.
     """
 
-    fractal_uri: str = Field(..., description="Full URI to the Fractal Server you want to connect to")
-    username: str | None = Field(
-        None,
-        description="Username to connect to the Fractal Server with. When not provided, a connection is attempted "
-        "as a guest user, which in most default Servers will be unable to return results.",
-    )
-    password: str | None = Field(
-        None, description="Password to authenticate to the Fractal Server with (alongside the `username`)"
-    )
-    verify: bool | None = Field(None, description="Use Server-side generated SSL certification or not.")
+    fractal_uri: str
+    """Full URI to the Fractal Server you want to connect to"""
+
+    username: str | None = None
+    """Username to connect to the Fractal Server with. When not provided, a connection is attempted as a guest user,
+    which in most default Servers will be unable to return results.
+    """
+
+    password: str | None = None
+    """Password to authenticate to the Fractal Server with (alongside the `username`)"""
+
+    verify: bool | None = None
+    """Use Server-side generated SSL certification or not."""
 
 
 class FractalComputeConfig(BaseSettings):
-    base_folder: str = Field(
-        ...,
-        description="The base folder to use as the default for some options (logs, etc). Default is the location of the config file.",
-    )
+    base_folder: str
+    """The base folder to use as the default for some options (logs, etc). Default is the location of the config
+    file.
+    """
 
-    cluster: str = Field(
-        ...,
-        description="Name of this scheduler to present to the Fractal Server. Descriptive names help the server "
-        "identify the manager resource and assists with debugging.",
-    )
+    cluster: str
+    """Name of this scheduler to present to the Fractal Server. Descriptive names help the server identify the
+    manager resource and assists with debugging.
+    """
+
     loglevel: str = "INFO"
-    logfile: str | None = Field(
-        None,
-        description="Full path to save a log file to, including the filename. If not provided, information will still "
-        "be reported to terminal, but not saved. When set, logger information is sent to this file.",
-    )
-    update_frequency: float = Field(
-        30,
-        description="Time between heartbeats/update checks between this Manager and the Fractal Server. The lower this "
-        "value, the shorter the intervals. If you have an unreliable network connection, consider "
-        "increasing this time as repeated, consecutive network failures will cause the Manager to shut "
-        "itself down to maintain integrity between it and the Fractal Server. Units of seconds",
-        gt=0,
-    )
-    update_frequency_jitter: float = Field(
-        0.1,
-        description="The update frequency will be modified by up to a certain amount for each request. The "
-        "update_frequency_jitter represents a fraction of the update_frequency to allow as a max. "
-        "Ie, update_frequency=60, and jitter=0.1, updates will happen between 54 and 66 seconds. "
-        "This helps with spreading out server load.",
-        ge=0,
-    )
+    logfile: str | None = None
+    """Full path to save a log file to, including the filename. If not provided, information will still be reported
+    to terminal, but not saved. When set, logger information is sent to this file.
+    """
 
-    max_idle_time: int | None = Field(
-        None,
-        description="Maximum consecutive time in seconds that the manager "
-        "should be allowed to run. If this is reached, the manager will shutdown.",
-    )
+    update_frequency: float = Field(30, gt=0)
+    """Time between heartbeats/update checks between this Manager and the Fractal Server. The lower this value, the
+    shorter the intervals. If you have an unreliable network connection, consider increasing this time as
+    repeated, consecutive network failures will cause the Manager to shut itself down to maintain integrity
+    between it and the Fractal Server. Units of seconds
+    """
+
+    update_frequency_jitter: float = Field(0.1, ge=0)
+    """The update frequency will be modified by up to a certain amount for each request. The update_frequency_jitter
+    represents a fraction of the update_frequency to allow as a max. Ie, update_frequency=60, and jitter=0.1,
+    updates will happen between 54 and 66 seconds. This helps with spreading out server load.
+    """
+
+    max_idle_time: int | None = None
+    """Maximum consecutive time in seconds that the manager should be allowed to run. If this is reached, the manager
+    will shutdown.
+    """
 
     parsl_run_dir: str = "parsl_run_dir"
+    """Directory for parsl to use for temporary files, submission scripts, etc
+    """
+
     parsl_usage_tracking: int = 0
+    """Set to 1-3 to send usage information to Parsl developers. This helps Parsl to collect
+    aggregate statistics on usage to better report to funding agencies. Recommended to help enable them
+    to keep working, but disabled by default for privacy reasons.
+    
+    See https://parsl.readthedocs.io/en/stable/userguide/advanced/usage_tracking.html
+    """
 
     server: FractalServerSettings = Field(...)
     environments: PackageEnvironmentSettings = Field(default_factory=PackageEnvironmentSettings)
     executors: dict[str, AllExecutorTypes] = Field(...)
 
     model_config = SettingsConfigDict(
-        extra="forbid", case_sensitive=False, env_prefix="QCF_COMPUTE_", env_nested_delimiter="__"
+        extra="forbid",
+        case_sensitive=False,
+        env_prefix="QCF_COMPUTE_",
+        env_nested_delimiter="__",
+        use_attribute_docstrings=True,
     )
 
     # Since we manually read the yaml files, the values passed into the init

--- a/qcportal/qcportal/auth/models.py
+++ b/qcportal/qcportal/auth/models.py
@@ -62,11 +62,16 @@ class GroupInfo(BaseModel):
     Information about a group
     """
 
-    id: int | None = Field(None, description="ID of the group")
-    groupname: str = Field(..., description="The name of the group")
-    description: str = Field("", description="Text description of the group")
+    id: int | None = None
+    """ID of the group"""
 
-    model_config = ConfigDict(extra="forbid")
+    groupname: str
+    """The name of the group"""
+
+    description: str = ""
+    """Text description of the group"""
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
     @field_validator("groupname", mode="before")
     @classmethod
@@ -86,19 +91,34 @@ class UserInfo(BaseModel):
     """
 
     # id may be None when used for initial creation
-    id: int | None = Field(None, frozen=True, description="The id of the user")
-    auth_type: AuthTypeEnum = Field(
-        AuthTypeEnum.password, frozen=True, description="Type of authentication the user uses"
-    )
-    username: str = Field(..., frozen=True, description="The username of this user")
-    role: str = Field(..., description="The role this user belongs to")
-    groups: list[str] = Field([], description="Groups this user belongs to")
-    enabled: bool = Field(..., description="Whether this user is enabled or not")
-    fullname: Max128Str = Field("", description="The full name or description of the user")
-    organization: Max128Str = Field("", description="The organization the user belongs to")
-    email: Max128Str = Field("", description="The email address for the user")
+    id: int | None = Field(None, frozen=True)
+    """The id of the user"""
 
-    model_config = ConfigDict(extra="forbid")
+    auth_type: AuthTypeEnum = Field(AuthTypeEnum.password, frozen=True)
+    """Type of authentication the user uses"""
+
+    username: str = Field(..., frozen=True)
+    """The username of this user"""
+
+    role: str
+    """The role this user belongs to"""
+
+    groups: list[str] = []
+    """Groups this user belongs to"""
+
+    enabled: bool
+    """Whether this user is enabled or not"""
+
+    fullname: Max128Str = ""
+    """The full name or description of the user"""
+
+    organization: Max128Str = ""
+    """The organization the user belongs to"""
+
+    email: Max128Str = ""
+    """The email address for the user"""
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
     @field_validator("username", mode="before")
     @classmethod

--- a/qcportal/qcportal/base_models.py
+++ b/qcportal/qcportal/base_models.py
@@ -22,7 +22,7 @@ def validate_list_to_single(v):
 
 
 class RestModelBase(BaseModel):
-    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+    model_config = ConfigDict(extra="forbid", validate_assignment=True, use_attribute_docstrings=True)
 
 
 class CommonBulkGetBody(RestModelBase):

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -2209,7 +2209,7 @@ class PortalClient(PortalClientBase):
         This checks if the calculations already exist in the database. If so, it returns
         the existing id, otherwise it will insert it and return the new id.
 
-        This will add one record per set of molecules
+        This will add one record per reaction
 
         Parameters
         ----------
@@ -2235,7 +2235,7 @@ class PortalClient(PortalClientBase):
         -------
         :
             Metadata about the insertion, and a list of record ids. The ids will be in the
-            order of the input molecules
+            order of the input stoichiometries
         """
 
         if "tag" in kwargs:
@@ -2351,7 +2351,7 @@ class PortalClient(PortalClientBase):
         parent_id
             Query records that have a parent is in the given list
         child_id
-            Query records that have a child (optimization calculation) is in the given list
+            Query records that have a child (singlepoint or optimization calculation) is in the given list
         created_before
             Query records that were created before the given date/time
         created_after
@@ -2572,7 +2572,7 @@ class PortalClient(PortalClientBase):
         parent_id
             Query records that have a parent is in the given list
         child_id
-            Query records that have a child (optimization calculation) is in the given list
+            Query records that have a child (singlepoint calculation) is in the given list
         created_before
             Query records that were created before the given date/time
         created_after
@@ -2582,7 +2582,7 @@ class PortalClient(PortalClientBase):
         modified_after
             Query records that were modified after the given date/time
         program
-            Query records whose reaction program is in the given list
+            Query records whose manybody program is in the given list
         qc_program
             Query records whose qc program is in the given list
         qc_method
@@ -2651,21 +2651,24 @@ class PortalClient(PortalClientBase):
         This checks if the calculations already exist in the database. If so, it returns
         the existing id, otherwise it will insert it and return the new id.
 
-        This will add one record per set of molecules
+        This will add one record per initial chain
 
         Parameters
         ----------
         initial_chains
-            The initial chains to run the NEB calculations on . Each NEB calculation starts with a single
+            The initial chains to run the NEB calculations on. Each NEB calculation starts with a single
             chain (list of molecules), so this is a nested list
         program
             The program to run the neb computation with ("geometric")
         singlepoint_specification
             Specification of how each singlepoint (gradient/hessian) should be run
         optimization_specification
-            Specification of how any optimizations of the torsiondrive should be run
+            Specification of how the transition state optimization should be run, if one was requested
+            with the optimize_ts keyword. May be None. Note that this does not apply to the endpoint
+            optimizations requested with the optimize_endpoints keyword, which always use geometric
+            with the level of theory given in the singlepoint specification
         keywords
-            The torsiondrive keywords for the computation
+            The NEB keywords for the computation
         compute_tag
             The tag for the task. This will assist in routing to appropriate compute managers.
         compute_priority
@@ -2677,7 +2680,7 @@ class PortalClient(PortalClientBase):
         -------
         :
             Metadata about the insertion, and a list of record ids. The ids will be in the
-            order of the input molecules
+            order of the input chains
         """
 
         if "tag" in kwargs:
@@ -2795,7 +2798,7 @@ class PortalClient(PortalClientBase):
         parent_id
             Query records that have a parent is in the given list
         child_id
-            Query records that have a child (optimization calculation) is in the given list
+            Query records that have a child (singlepoint or optimization calculation) is in the given list
         created_before
             Query records that were created before the given date/time
         created_after
@@ -2805,7 +2808,7 @@ class PortalClient(PortalClientBase):
         modified_after
             Query records that were modified after the given date/time
         program
-            Query records whose torsiondrive program is in the given list
+            Query records whose neb program is in the given list
         qc_program
             Query records whose qc program is in the given list
         qc_method

--- a/qcportal/qcportal/client.py
+++ b/qcportal/qcportal/client.py
@@ -271,6 +271,38 @@ class PortalClient(PortalClientBase):
         extras: Optional[Dict[str, Any]] = None,
         existing_ok: bool = False,
     ) -> Project:
+        """
+        Creates a new project on the server
+
+        Project names are unique across the server, and are compared case-insensitively.
+
+        Parameters
+        ----------
+        name
+            Name of the new project
+        description
+            Optional longer description of the project
+        tagline
+            Optional short description of the project
+        tags
+            Optional list of tags to attach to the project
+        default_compute_tag
+            The default :ref:`compute tag <glossary_tag>` for computations created within this
+            project. Records and datasets added to the project inherit this unless they override it
+        default_compute_priority
+            The default priority for computations created within this project
+        extras
+            Optional dictionary of arbitrary additional information
+        existing_ok
+            If True, return the existing project if one already exists with this name, rather
+            than raising an exception
+
+        Returns
+        -------
+        :
+            The new project (or existing project if `existing_ok=True` and a project with the given
+            name already exists)
+        """
         if description is None:
             description = ""
         if tagline is None:
@@ -294,12 +326,20 @@ class PortalClient(PortalClientBase):
         proj_id = self.make_request("post", f"api/v1/projects", int, body=body)
         return self.get_project_by_id(proj_id)
 
-    def get_project(self, project_name: str):
+    def get_project(self, project_name: str) -> Project:
+        """
+        Obtain a project by name
+
+        The name is matched case-insensitively.
+        """
         body = ProjectQueryModel(project_name=project_name)
         proj_dict = self.make_request("post", f"api/v1/projects/query", Dict[str, Any], body=body)
         return Project(**proj_dict, client=self)
 
     def get_project_by_id(self, project_id: int) -> Project:
+        """
+        Obtain a project by ID
+        """
         project_dict = self.make_request("get", f"api/v1/projects/{project_id}", Dict[str, Any])
         return Project(**project_dict, client=self)
 
@@ -310,6 +350,23 @@ class PortalClient(PortalClientBase):
         delete_datasets: bool = False,
         delete_dataset_records: bool = False,
     ):
+        """
+        Deletes a project from the server
+
+        By default, only the project itself is deleted. The records and datasets it contained
+        remain on the server.
+
+        Parameters
+        ----------
+        project_id
+            ID of the project to delete
+        delete_records
+            If True, also delete the records that were added directly to the project
+        delete_datasets
+            If True, also delete the datasets that were in the project
+        delete_dataset_records
+            If True, also delete the records contained in those datasets
+        """
 
         params = ProjectDeleteParams(
             delete_records=delete_records,
@@ -318,14 +375,57 @@ class PortalClient(PortalClientBase):
         )
         return self.make_request("delete", f"api/v1/projects/{project_id}", None, url_params=params)
 
-    def list_projects(self):
+    def list_projects(self) -> List[Dict[str, Any]]:
+        """
+        Obtain a summary of all projects on the server
+
+        Each entry is a dictionary with the keys ``id``, ``project_name``, ``tagline``, ``tags``,
+        ``description``, ``record_count``, ``dataset_count``, ``owner_user``, and ``creator_user``.
+
+        The full project is not returned - use :meth:`get_project` or :meth:`get_project_by_id`
+        for that.
+
+        Returns
+        -------
+        :
+            A list of dictionaries, one per project, ordered by project ID
+        """
         return self.make_request("get", f"api/v1/projects", List[Dict[str, Any]])
 
-    def query_project_records(self, record_id: Union[int, Iterable[int]]):
+    def query_project_records(self, record_id: Union[int, Iterable[int]]) -> List[Dict]:
+        """
+        Determine which projects the given records belong to
+
+        Records that are not in any project simply do not appear in the result, so the returned
+        list may be shorter than the list of IDs given.
+
+        Returns
+        -------
+        :
+            A list of dictionaries, each with the keys ``record_id``, ``project_id``,
+            ``project_name``, and ``record_name``
+        """
         body = ProjectQueryRecords(record_id=make_list(record_id))
         return self.make_request("post", f"api/v1/projects/queryrecords", List[Dict], body=body)
 
-    def query_project_datasets(self, dataset_id: Union[int, Iterable[int]]):
+    def query_project_datasets(self, dataset_id: Union[int, Iterable[int]]) -> List[Dict]:
+        """
+        Determine which projects the given datasets belong to
+
+        Datasets that are not in any project simply do not appear in the result, so the returned
+        list may be shorter than the list of IDs given.
+
+        Parameters
+        ----------
+        dataset_id
+            A dataset ID or list of dataset IDs to look up
+
+        Returns
+        -------
+        :
+            A list of dictionaries, each with the keys ``record_id`` (which holds the *dataset*
+            ID), ``project_id``, ``project_name``, and ``dataset_name``
+        """
         body = ProjectQueryDatasets(dataset_id=make_list(dataset_id))
         return self.make_request("post", f"api/v1/projects/querydatasets", List[Dict], body=body)
 
@@ -408,8 +508,8 @@ class PortalClient(PortalClientBase):
         group: Optional[str] = None,
         provenance: Optional[Dict[str, Any]] = None,
         visibility: bool = None,
-        default_tag: str = "*",
-        default_priority: PriorityEnum = PriorityEnum.normal,
+        default_compute_tag: str = "*",
+        default_compute_priority: PriorityEnum = PriorityEnum.normal,
         extras: Optional[Dict[str, Any]] = None,
         owner_group: Optional[str] = None,
         existing_ok: bool = False,
@@ -417,6 +517,12 @@ class PortalClient(PortalClientBase):
     ) -> BaseDataset:
 
         # TODO - DEPRECATED - Remove eventually
+        if "default_tag" in kwargs:
+            self._logger.warning("'default_tag' is deprecated; use 'default_compute_tag' instead")
+            default_compute_tag = kwargs["default_tag"]
+        if "default_priority" in kwargs:
+            self._logger.warning("'default_priority' is deprecated; use 'default_compute_priority' instead")
+            default_compute_priority = kwargs["default_priority"]
         if group is not None:
             self._logger.warning(f"'group' parameter has been deprecated and will be removed in a future version")
         if visibility is not None:
@@ -447,8 +553,8 @@ class PortalClient(PortalClientBase):
             tagline=tagline,
             tags=tags,
             provenance=provenance,
-            default_tag=default_tag,
-            default_priority=default_priority,
+            default_compute_tag=default_compute_tag,
+            default_compute_priority=default_compute_priority,
             extras=extras,
             existing_ok=existing_ok,
         )

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -722,6 +722,19 @@ class BaseDataset(BaseModel):
         return self._cache_data is not None and self._cache_data.read_only
 
     def status(self) -> dict[str, Any]:
+        """
+        Returns the status of the dataset's computations, broken down by specification
+
+        The status is computed on the server, and does not require downloading any records.
+
+        Returns
+        -------
+        :
+            A dictionary with specification names as keys. Each value is itself a dictionary
+            mapping record status to the number of records of the dataset with that status.
+            Statuses with no records are not present.
+        """
+
         self.assert_online()
 
         return self._client.make_request("get", f"{self._base_url}/status", dict[str, dict[RecordStatusEnum, int]])
@@ -748,6 +761,18 @@ class BaseDataset(BaseModel):
         print(self.status_table())
 
     def detailed_status(self) -> list[tuple[str, str, RecordStatusEnum]]:
+        """
+        Returns the status of every record of the dataset individually
+
+        Unlike :meth:`status`, nothing is grouped or counted - there is one entry per record.
+        This is what to use when you need to know *which* entries are in a particular state.
+
+        Returns
+        -------
+        :
+            A list of tuples (entry name, specification name, status), in no particular order
+        """
+
         self.assert_online()
 
         return self._client.make_request(
@@ -757,6 +782,21 @@ class BaseDataset(BaseModel):
         )
 
     def status_by_compute_tag(self) -> list[tuple[str, RecordStatusEnum, int]]:
+        """
+        Returns the status of the dataset's computations, broken down by compute tag
+
+        Only records that still have an entry in the task or service queue are counted. A record's
+        task is removed from the queue when it completes, so completed records do not appear here,
+        and these counts will not sum to the counts returned by :meth:`status`. In practice, this
+        function reports the waiting, running, and errored records of the dataset - that is, the
+        work that is still outstanding, and which compute tag it is queued under.
+
+        Returns
+        -------
+        :
+            A list of tuples (compute tag, status, number of records), in no particular order
+        """
+
         self.assert_online()
 
         return self._client.make_request(

--- a/qcportal/qcportal/dataset_models.py
+++ b/qcportal/qcportal/dataset_models.py
@@ -671,11 +671,11 @@ class BaseDataset(BaseModel):
         """
         Creates a view of this dataset on the server
 
-        This function will return an :class:`~qcportal.internal_jobs.InternalJob` which can be used to watch
+        This function will return an :class:`~qcportal.internal_jobs.models.InternalJob` which can be used to watch
         for completion if desired. The job will run server side without user interaction.
 
         Note the ID field of the object if you with to retrieve this internal job later
-        (via :meth:`get_internal_jobs` or
+        (via :meth:`~qcportal.dataset_models.BaseDataset.list_internal_jobs` or
         :meth:`PortalClient.get_internal_job <qcportal.client.PortalClient.get_internal_job>`)
 
         Parameters
@@ -698,7 +698,7 @@ class BaseDataset(BaseModel):
         Returns
         -------
         :
-            An :class:`~qcportal.internal_job.InternalJob` object which can be used to watch for completion.
+            An :class:`~qcportal.internal_jobs.models.InternalJob` object which can be used to watch for completion.
         """
 
         body = DatasetCreateViewBody(
@@ -1229,7 +1229,7 @@ class BaseDataset(BaseModel):
 
         Raises
         ------
-        AssertionError:
+        AssertionError
             If the dataset is a view or is not online.
         """
 
@@ -1270,7 +1270,7 @@ class BaseDataset(BaseModel):
 
         Raises
         ------
-        AssertionError:
+        AssertionError
             If the dataset is a view or if the client is offline.
         """
 
@@ -1310,7 +1310,7 @@ class BaseDataset(BaseModel):
 
         Raises
         ------
-        AssertionError:
+        AssertionError
             If the dataset is a view or not online.
         """
 

--- a/qcportal/qcportal/gridoptimization/record_models.py
+++ b/qcportal/qcportal/gridoptimization/record_models.py
@@ -86,21 +86,21 @@ class ScanDimension(BaseModel):
     A full description of a dimension to scan over.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
-    type: ScanTypeEnum = Field(..., description=str(ScanTypeEnum.__doc__))
-    indices: list[int] = Field(
-        ...,
-        description="The indices of atoms to select for the scan. The size of this is a function of the type. e.g., "
-        "distances, angles and dihedrals require 2, 3, and 4 atoms, respectively.",
-    )
-    steps: list[float] = Field(
-        ...,
-        description="Step sizes to scan in relative to your current location in the scan. This must be a strictly "
-        "monotonic series.",
-        json_schema_extra={"units": ["Bohr", "degrees"]},
-    )
-    step_type: StepTypeEnum = Field(..., description=str(StepTypeEnum.__doc__))
+    type: ScanTypeEnum
+    """The type of scan to perform"""
+
+    indices: list[int]
+    """The indices of atoms to select for the scan. The size of this is a function of the type. e.g., distances,
+    angles and dihedrals require 2, 3, and 4 atoms, respectively.
+    """
+
+    steps: list[float] = Field(..., json_schema_extra={"units": ["Bohr", "degrees"]})
+    """Step sizes to scan in relative to your current location in the scan. This must be a strictly monotonic series."""
+
+    step_type: StepTypeEnum
+    """Whether the step values are absolute, or relative to the starting value"""
 
     @field_validator("type", "step_type", mode="before")
     @classmethod
@@ -133,16 +133,15 @@ class GridoptimizationKeywords(BaseModel):
     Keywords for grid optimizations
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
-    scans: list[ScanDimension] = Field(
-        [], description="The dimensions to scan along (along with their options) for the Gridoptimization."
-    )
-    preoptimization: bool = Field(
-        True,
-        description="If ``True``, first runs an unrestricted optimization before starting the grid computations. "
-        "This is especially useful when combined with ``relative`` ``step_types``.",
-    )
+    scans: list[ScanDimension] = []
+    """The dimensions to scan along (along with their options) for the Gridoptimization"""
+
+    preoptimization: bool = True
+    """If ``True``, first runs an unrestricted optimization before starting the grid computations. This is especially
+    useful when combined with ``relative`` ``step_types``.
+    """
 
 
 class GridoptimizationSpecification(BaseModel):

--- a/qcportal/qcportal/managers/models.py
+++ b/qcportal/qcportal/managers/models.py
@@ -103,11 +103,20 @@ class ComputeManager(BaseModel):
 
 
 class ManagerActivationBody(RestModelBase):
-    name_data: ManagerName = Field(..., description="Name information about this manager")
-    manager_version: str = Field(..., description="Version of the manager itself")
-    username: str | None = Field(..., description="Username this manager is connected with")
-    programs: dict[LowerStr, list[str]] = Field(..., description="Programs available on this manager")
-    compute_tags: list[LowerStr] = Field(..., description="Tags this manager will compute for")
+    name_data: ManagerName
+    """Name information about this manager"""
+
+    manager_version: str
+    """Version of the manager itself"""
+
+    username: str | None
+    """Username this manager is connected with"""
+
+    programs: dict[LowerStr, list[str]]
+    """Programs available on this manager"""
+
+    compute_tags: list[LowerStr]
+    """Tags this manager will compute for"""
 
     @field_validator("compute_tags", mode="after")
     @classmethod

--- a/qcportal/qcportal/manybody/record_models.py
+++ b/qcportal/qcportal/manybody/record_models.py
@@ -36,7 +36,7 @@ class ManybodySpecification(BaseModel):
     program: LowerStr = "qcmanybody"
     levels: dict[int | Literal["supersystem"], QCSpecification]
     bsse_correction: list[BSSECorrectionEnum]
-    keywords: ManybodyKeywords = Field(ManybodyKeywords())
+    keywords: ManybodyKeywords = ManybodyKeywords()
     protocols: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/qcportal/qcportal/neb/record_models.py
+++ b/qcportal/qcportal/neb/record_models.py
@@ -26,51 +26,44 @@ class NEBKeywords(BaseModel):
     NEBRecord options
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
-    images: int = Field(
-        11,
-        description="Number of images that will be used to locate a rough transition state structure.",
-        gt=5,
-    )
+    images: int = Field(11, gt=5)
+    """Number of images that will be used to locate a rough transition state structure"""
 
-    spring_constant: float = Field(
-        1.0,
-        description="Spring constant in kcal/mol/Ang^2.",
-    )
+    spring_constant: float = 1.0
+    """Spring constant in kcal/mol/Ang^2"""
 
-    spring_type: int = Field(
-        0,
-        description="0: Nudged Elastic Band (parallel spring force + perpendicular gradients)\n"
-        "1: Hybrid Elastic Band (full spring force + perpendicular gradients)\n"
-        "2: Plain Elastic Band (full spring force + full gradients)\n",
-    )
+    spring_type: int = 0
+    """Which spring and gradient terms to use.
 
-    maximum_force: float = Field(
-        0.05,
-        description="Convergence criteria. Converge when maximum RMS-gradient (ev/Ang) of the chain fall below maximum_force.",
-    )
+    * ``0`` - Nudged Elastic Band (parallel spring force + perpendicular gradients)
+    * ``1`` - Hybrid Elastic Band (full spring force + perpendicular gradients)
+    * ``2`` - Plain Elastic Band (full spring force + full gradients)
+    """
 
-    average_force: float = Field(
-        0.025,
-        description="Convergence criteria. Converge when average RMS-gradient (ev/Ang) of the chain fall below average_force.",
-    )
+    maximum_force: float = 0.05
+    """Convergence criteria. Converge when maximum RMS-gradient (ev/Ang) of the chain fall below maximum_force."""
 
-    maximum_cycle: int = Field(100, description="Maximum iteration number for NEB calculation.")
+    average_force: float = 0.025
+    """Convergence criteria. Converge when average RMS-gradient (ev/Ang) of the chain fall below average_force."""
 
-    optimize_ts: bool = Field(
-        False,
-        description="Setting it equal to true will perform a transition sate optimization starting with the guessed transition state structure from the NEB calculation result.",
-    )
+    maximum_cycle: int = 100
+    """Maximum iteration number for NEB calculation"""
 
-    optimize_endpoints: bool = Field(
-        False,
-        description="Setting it equal to True will optimize two end points of the initial chain before starting NEB.",
-    )
+    optimize_ts: bool = False
+    """Perform a transition state optimization, starting from the transition state structure guessed by the
+    NEB calculation
+    """
 
-    align: bool = Field(True, description="Align the images before starting the NEB calculation.")
+    optimize_endpoints: bool = False
+    """Optimize the two end points of the initial chain before starting NEB"""
 
-    epsilon: float = Field(1e-5, description="Small eigenvalue threshold for resetting Hessian.")
+    align: bool = True
+    """Align the images before starting the NEB calculation"""
+
+    epsilon: float = 1e-5
+    """Small eigenvalue threshold for resetting Hessian"""
 
     @model_validator(mode="before")
     @classmethod

--- a/qcportal/qcportal/optimization/record_models.py
+++ b/qcportal/qcportal/optimization/record_models.py
@@ -46,9 +46,10 @@ class OptimizationProtocols(BaseModel):
     Protocols regarding the manipulation of a Optimization output data.
     """
 
-    trajectory: TrajectoryProtocolEnum = Field(
-        TrajectoryProtocolEnum.all, description=str(TrajectoryProtocolEnum.__doc__)
-    )
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    trajectory: TrajectoryProtocolEnum = TrajectoryProtocolEnum.all
+    """Which gradient evaluations to keep in the trajectory"""
 
 
 class OptimizationSpecification(BaseModel):
@@ -58,12 +59,19 @@ class OptimizationSpecification(BaseModel):
     This is the same as the input specification, with a few ids added
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
-    program: LowerStr = Field(..., description="The program to use for an optimization")
+    program: LowerStr
+    """The program to use for an optimization"""
+
     qc_specification: QCSpecification
-    keywords: dict[str, Any] = Field({})
+    """The specification used for the gradient evaluations at each step of the optimization"""
+
+    keywords: dict[str, Any] = {}
+    """Program-specific keywords to use for the optimization"""
+
     protocols: OptimizationProtocols = Field(default_factory=OptimizationProtocols)
+    """Which parts of the optimization output to keep"""
 
     @field_validator("qc_specification", mode="before")
     @classmethod

--- a/qcportal/qcportal/project_models.py
+++ b/qcportal/qcportal/project_models.py
@@ -23,13 +23,17 @@ if TYPE_CHECKING:
 
 class ProjectAttachmentType(str, Enum):
     """
-    The type of attachment a file is for a dataset
+    The type of attachment a file is for a project
     """
 
     other = "other"
 
 
 class ProjectAttachment(ExternalFile):
+    """
+    A file that has been uploaded to a project
+    """
+
     attachment_type: ProjectAttachmentType
     tags: list[str]
 
@@ -124,6 +128,13 @@ class ProjectAttachmentUploadBody(ExternalFileUploadBase):
 
 
 class ProjectRecordMetadata(BaseModel):
+    """
+    Information about a record contained in a project
+
+    This is the lightweight information about a record that a project stores, and does
+    not include the record itself. Use :meth:`Project.get_record` to obtain the full record.
+    """
+
     record_id: int
     name: str
     description: str
@@ -134,6 +145,13 @@ class ProjectRecordMetadata(BaseModel):
 
 
 class ProjectDatasetMetadata(BaseModel):
+    """
+    Information about a dataset contained in a project
+
+    This is the lightweight information about a dataset that a project stores, and does
+    not include the dataset itself. Use :meth:`Project.get_dataset` to obtain the full dataset.
+    """
+
     dataset_id: int
     dataset_type: str
     name: str
@@ -149,6 +167,13 @@ class ProjectQueryDatasets(RestModelBase):
     dataset_id: list[int]
 
 class Project(BaseModel):
+    """
+    A named collection of records, datasets, and files
+
+    A project groups together the records and datasets belonging to a single piece of work.
+    Within a project, records and datasets are given names, and most methods here accept
+    either that name or the underlying ID.
+    """
 
     model_config = ConfigDict(extra="forbid", validate_assignment=True, frozen=False)
 
@@ -183,9 +208,15 @@ class Project(BaseModel):
 
     @property
     def offline(self) -> bool:
+        """
+        True if this project is not connected to a server
+        """
         return self._client is None
 
     def assert_online(self):
+        """
+        Raises a RuntimeError if this project is not connected to a server
+        """
         if self.offline:
             raise RuntimeError("Project is not connected to a QCFractal server")
 
@@ -209,6 +240,12 @@ class Project(BaseModel):
     #############################
     @property
     def dataset_metadata(self) -> list[ProjectDatasetMetadata]:
+        """
+        Information about the datasets in this project
+
+        This is fetched from the server the first time it is accessed, and then cached. Use
+        :meth:`fetch_dataset_metadata` to fetch it again.
+        """
         self.assert_online()
         if len(self._dataset_metadata) == 0:
             self.fetch_dataset_metadata()
@@ -216,12 +253,31 @@ class Project(BaseModel):
 
     @property
     def record_metadata(self) -> list[ProjectRecordMetadata]:
+        """
+        Information about the records in this project
+
+        This is fetched from the server the first time it is accessed, and then cached. Use
+        :meth:`fetch_record_metadata` to fetch it again.
+        """
         self.assert_online()
         if len(self._record_metadata) == 0:
             self.fetch_record_metadata()
         return self._record_metadata
 
     def status(self) -> dict[str, dict[RecordStatusEnum, int]]:
+        """
+        Obtain a summary of the status of everything in this project
+
+        The returned dictionary has two keys - ``records`` and ``datasets``. Each maps to a
+        dictionary of record status to the number of records with that status. The ``records``
+        entry counts only the records added directly to the project; the ``datasets`` entry
+        counts the records of all the datasets in the project, summed together.
+
+        Returns
+        -------
+        :
+            Counts of record statuses, split into records and datasets
+        """
         self.assert_online()
 
         return self._client.make_request(
@@ -239,6 +295,12 @@ class Project(BaseModel):
         raise KeyError(f"Record '{name}' not found")
 
     def fetch_record_metadata(self):
+        """
+        Fetches information about the records in this project from the server
+
+        This overwrites what is stored locally, and is available through the
+        :attr:`record_metadata` property.
+        """
         self.assert_online()
 
         self._record_metadata = self._client.make_request(
@@ -256,6 +318,38 @@ class Project(BaseModel):
         compute_priority: PriorityEnum | None = None,
         find_existing: bool = True,
     ) -> BaseRecord:
+        """
+        Creates a new record in this project and submits it for computation
+
+        Unlike the ``add_*`` methods of the client, this takes a single record input object
+        (for example, a :class:`~qcportal.singlepoint.record_models.SinglepointInput`) and
+        creates a single record.
+
+        Parameters
+        ----------
+        name
+            Name to give this record within the project. Must be unique within the project
+        record_input
+            The specification and input molecule(s), as a record input object
+        description
+            Optional longer description of this record
+        tags
+            Optional list of tags to attach to this record within the project
+        compute_tag
+            The :ref:`compute tag <glossary_tag>` to use. Defaults to the project's
+            ``default_compute_tag``
+        compute_priority
+            The priority to run this computation at. Defaults to the project's
+            ``default_compute_priority``
+        find_existing
+            If True, and a matching record already exists on the server, use that record rather
+            than creating a new one. See :ref:`record_submit_dedup`
+
+        Returns
+        -------
+        :
+            The new record, attached to the project and server
+        """
 
         self.assert_online()
 
@@ -309,15 +403,21 @@ class Project(BaseModel):
         tags: list[str] = None,
     ) -> BaseRecord:
         """
-        Imports a computation record into this project
+        Imports an already-computed record into this project
 
+        The record is not run on this server - the existing results are stored as-is. This is
+        used for ingesting records computed elsewhere (on another server, or by hand).
 
         Parameters
         ----------
         name
+            Name to give this record within the project. Must be unique within the project
         record
+            The completed record or result to import
         description
+            Optional longer description of this record
         tags
+            Optional list of tags to attach to this record within the project
 
         Returns
         -------
@@ -326,6 +426,11 @@ class Project(BaseModel):
         """
 
         self.assert_online()
+
+        if tags is None:
+            tags = []
+        if description is None:
+            description = ""
 
         body_data = ProjectRecordImportBody(
             name=name,
@@ -358,6 +463,28 @@ class Project(BaseModel):
         description: str,
         tags: list[str],
     ) -> BaseRecord:
+        """
+        Adds an existing record on the server to this project
+
+        The record itself is not copied or modified - the project gains a reference to it,
+        along with a project-local name, description, and tags.
+
+        Parameters
+        ----------
+        record_id
+            ID of an existing record on the server
+        name
+            Name to give this record within the project. Must be unique within the project
+        description
+            Longer description of this record
+        tags
+            List of tags to attach to this record within the project
+
+        Returns
+        -------
+        :
+            The linked record
+        """
 
         body = ProjectLinkRecordBody(record_id=record_id, name=name, description=description, tags=tags)
         self._client.make_request("post", f"api/v1/projects/{self.id}/records/link", None, body=body)
@@ -378,6 +505,19 @@ class Project(BaseModel):
         return rec
 
     def unlink_records(self, record_ids: int | str | list[int | str], delete_records: bool = False):
+        """
+        Removes records from this project
+
+        By default the records remain on the server and only the association with this project
+        is removed.
+
+        Parameters
+        ----------
+        record_ids
+            Record IDs or project-local record names to remove from the project
+        delete_records
+            If True, also delete the records themselves from the server
+        """
         record_ids = make_list(record_ids)
         record_ids = [self._lookup_record_id(rid) if isinstance(rid, str) else rid for rid in record_ids]
         body = ProjectUnlinkRecordsBody(record_ids=record_ids, delete_records=delete_records)
@@ -390,6 +530,21 @@ class Project(BaseModel):
         record_id: int | str,
         include: Sequence[str] | None = None,
     ) -> BaseRecord:
+        """
+        Obtain a record contained in this project
+
+        Parameters
+        ----------
+        record_id
+            The record ID, or the name the record was given within this project
+        include
+            Additional fields to include in the returned record
+
+        Returns
+        -------
+        :
+            The record, of the appropriate type for the computation
+        """
 
         if isinstance(record_id, str):
             record_id = self._lookup_record_id(record_id)
@@ -415,6 +570,12 @@ class Project(BaseModel):
         raise KeyError(f"Dataset '{name}' not found")
 
     def fetch_dataset_metadata(self):
+        """
+        Fetches information about the datasets in this project from the server
+
+        This overwrites what is stored locally, and is available through the
+        :attr:`dataset_metadata` property.
+        """
         self.assert_online()
 
         self._dataset_metadata = self._client.make_request(
@@ -436,6 +597,40 @@ class Project(BaseModel):
         extras: dict[str, Any] | None = None,
         existing_ok: bool = False,
     ) -> BaseDataset:
+        """
+        Creates a new dataset within this project
+
+        Parameters
+        ----------
+        dataset_type
+            The type of dataset to create (``singlepoint``, ``optimization``, and so on)
+        name
+            Name to give this dataset. Must be unique within the project
+        description
+            Optional longer description of this dataset
+        tagline
+            Optional short description of this dataset
+        tags
+            Optional list of tags to attach to this dataset
+        provenance
+            Optional dictionary describing the source of this dataset
+        default_compute_tag
+            The default :ref:`compute tag <glossary_tag>` for computations submitted from this
+            dataset. Defaults to the project's ``default_compute_tag``
+        default_compute_priority
+            The default priority for computations submitted from this dataset. Defaults to the
+            project's ``default_compute_priority``
+        extras
+            Optional dictionary of arbitrary additional information
+        existing_ok
+            If True, return the existing dataset if one with this name is already in the project,
+            rather than raising an exception
+
+        Returns
+        -------
+        :
+            The new dataset, of the appropriate type for ``dataset_type``
+        """
 
         self.assert_online()
 
@@ -492,6 +687,31 @@ class Project(BaseModel):
         tagline: str | None = None,
         tags: list[str] | None = None,
     ) -> BaseDataset:
+        """
+        Adds an existing dataset on the server to this project
+
+        The dataset itself is not copied. The project gains a reference to it, optionally
+        under a different name and description.
+
+        Parameters
+        ----------
+        dataset_id
+            ID of an existing dataset on the server
+        name
+            Name to give this dataset within the project. If None, the dataset's existing
+            name is kept
+        description
+            Longer description of this dataset. If None, the existing description is kept
+        tagline
+            Short description of this dataset. If None, the existing tagline is kept
+        tags
+            List of tags for this dataset. If None, the existing tags are kept
+
+        Returns
+        -------
+        :
+            The linked dataset
+        """
 
         body = ProjectLinkDatasetBody(
             dataset_id=dataset_id, name=name, description=description, tagline=tagline, tags=tags
@@ -518,6 +738,21 @@ class Project(BaseModel):
         delete_datasets: bool = False,
         delete_dataset_records: bool = False,
     ):
+        """
+        Removes datasets from this project
+
+        By default the datasets remain on the server and only the association with this project
+        is removed.
+
+        Parameters
+        ----------
+        dataset_ids
+            Dataset IDs or project-local dataset names to remove from the project
+        delete_datasets
+            If True, also delete the datasets themselves from the server
+        delete_dataset_records
+            If True, also delete the records contained in those datasets
+        """
         dataset_ids = make_list(dataset_ids)
         dataset_ids = [self._lookup_dataset_id(ds_id) if isinstance(ds_id, str) else ds_id for ds_id in dataset_ids]
         body = ProjectUnlinkDatasetsBody(
@@ -528,6 +763,19 @@ class Project(BaseModel):
         self._dataset_metadata = [d for d in self._dataset_metadata if d.dataset_id not in dataset_ids]
 
     def get_dataset(self, dataset_id: int | str) -> BaseDataset:
+        """
+        Obtain a dataset contained in this project
+
+        Parameters
+        ----------
+        dataset_id
+            The dataset ID, or the name the dataset was given within this project
+
+        Returns
+        -------
+        :
+            The dataset, of the appropriate type for the dataset
+        """
         if isinstance(dataset_id, str):
             dataset_id = self._lookup_dataset_id(dataset_id)
 
@@ -541,6 +789,12 @@ class Project(BaseModel):
     # Attachments
     #############################
     def fetch_attachments(self):
+        """
+        Fetches the metadata for this project's attachments from the server
+
+        This overwrites what is stored locally, and is available through the
+        :attr:`attachments` property.
+        """
         self.assert_online()
 
         self.attachments_ = self._client.make_request(
@@ -552,6 +806,13 @@ class Project(BaseModel):
 
     @property
     def attachments(self) -> list[ProjectAttachment]:
+        """
+        The files that have been uploaded to this project
+
+        This is fetched from the server the first time it is accessed, and then cached.
+        The returned objects contain only the file metadata - use
+        :meth:`~qcportal.external_files.models.ExternalFile.download` to obtain the contents.
+        """
         self.assert_online()
         if self.attachments_ is None:
             self.fetch_attachments()
@@ -566,6 +827,29 @@ class Project(BaseModel):
         provenance: dict[str, Any] | None = None,
         new_file_name: str | None = None,
     ) -> int:
+        """
+        Uploads a file to this project
+
+        Parameters
+        ----------
+        file_path
+            Path to the local file to upload
+        attachment_type
+            The kind of attachment this is. Currently only ``other`` is available
+        tags
+            List of tags to attach to this file
+        description
+            Optional longer description of this file
+        provenance
+            Optional dictionary describing the source of this file
+        new_file_name
+            Store the file under this name instead of the base name of ``file_path``
+
+        Returns
+        -------
+        :
+            ID of the newly-created attachment
+        """
         self.assert_online()
 
         if provenance is None:
@@ -593,6 +877,14 @@ class Project(BaseModel):
         return file_id
 
     def delete_attachment(self, file_id: int):
+        """
+        Deletes an attachment from this project
+
+        Parameters
+        ----------
+        file_id
+            ID of the attachment to delete
+        """
         self.assert_online()
         self._client.make_request("delete", f"api/v1/projects/{self.id}/attachments/{file_id}", None)
 

--- a/qcportal/qcportal/record_models.py
+++ b/qcportal/qcportal/record_models.py
@@ -26,11 +26,16 @@ _T = TypeVar("_T")
 class Provenance(BaseModel):
     """Provenance information."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", use_attribute_docstrings=True)
 
-    creator: str = Field(..., description="The name of the program, library, or person who created the object.")
-    version: str = Field("", description="The version of the creator, blank otherwise")
-    routine: str = Field("", description="The name of the routine or function within the creator, blank otherwise.")
+    creator: str
+    """The name of the program, library, or person who created the object"""
+
+    version: str = ""
+    """The version of the creator, blank otherwise"""
+
+    routine: str = ""
+    """The name of the routine or function within the creator, blank otherwise"""
 
 
 class PriorityEnum(int, Enum):
@@ -115,10 +120,14 @@ class OutputStore(BaseModel):
     Storage of outputs and error messages, with optional compression
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
-    output_type: OutputTypeEnum = Field(..., description="The type of output this is (stdout, error, etc)")
-    compression_type: CompressionEnum = Field(CompressionEnum.none, description="Compression method (such as lzma)")
+    output_type: OutputTypeEnum
+    """The type of output this is (stdout, error, etc)"""
+
+    compression_type: CompressionEnum = CompressionEnum.none
+    """Compression method (such as lzma)"""
+
     data_: QCPortalBytes | None = Field(None, alias="data")
 
     _data_url: str | None = PrivateAttr(None)
@@ -224,10 +233,14 @@ class NativeFile(BaseModel):
     Storage of native files, with compression
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
-    name: str = Field(..., description="Name of the file")
-    compression_type: CompressionEnum = Field(..., description="Compression method (such as lzma)")
+    name: str
+    """Name of the file"""
+
+    compression_type: CompressionEnum
+    """Compression method (such as lzma)"""
+
     data_: QCPortalBytes | None = Field(None, alias="data")
 
     _data_url: str | None = PrivateAttr(None)
@@ -406,7 +419,7 @@ class BaseRecord(BaseModel):
     tags: list[str] | None = None
 
     properties: dict[str, Any] | None
-    extras: dict[str, Any] = Field({})
+    extras: dict[str, Any] = {}
 
     status: RecordStatusEnum
     manager_name: str | None

--- a/qcportal/qcportal/singlepoint/dataset_models.py
+++ b/qcportal/qcportal/singlepoint/dataset_models.py
@@ -122,6 +122,34 @@ class SinglepointDataset(BaseDataset):
         dataset_id: int | None = None,
         specification_name: str | None = None,
     ) -> InsertCountsMetadata:
+        """
+        Adds entries to this dataset by copying them from another dataset
+
+        The source dataset may be another singlepoint dataset, or an optimization dataset.
+        When copying from an optimization dataset, ``specification_name`` is required, and the
+        molecule of each new entry is the optimized (final) molecule of the corresponding record.
+        Entries whose record is not complete are skipped.
+
+        Entries whose name already exists in this dataset are ignored.
+
+        Parameters
+        ----------
+        dataset_type
+            Type of the dataset to copy entries from. Must be given together with ``dataset_name``
+        dataset_name
+            Name of the dataset to copy entries from. Must be given together with ``dataset_type``
+        dataset_id
+            ID of the dataset to copy entries from. May be given instead of the type and name
+        specification_name
+            Specification of the source dataset to take molecules from. Required when copying
+            from an optimization dataset, and unused otherwise
+
+        Returns
+        -------
+        :
+            Metadata about how many entries were added
+        """
+
         body = SinglepointDatasetEntriesFrom(
             dataset_type=dataset_type,
             dataset_name=dataset_name,

--- a/qcportal/qcportal/singlepoint/record_models.py
+++ b/qcportal/qcportal/singlepoint/record_models.py
@@ -24,18 +24,15 @@ from qcportal.record_models import (
 class Model(BaseModel):
     """The computational molecular sciences model to run."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", use_attribute_docstrings=True)
 
-    method: str = Field(  # type: ignore
-        ...,
-        description="The quantum chemistry method to evaluate (e.g., B3LYP, PBE, ...). "
-        "For MM, name of the force field.",
-    )
-    basis: str | None = Field(  # type: ignore
-        None,
-        description="The quantum chemistry basis set to evaluate (e.g., 6-31g, cc-pVDZ, ...). Can be ``None`` for "
-        "methods without basis sets. For molecular mechanics, name of the atom-typer.",
-    )
+    method: str
+    """The quantum chemistry method to evaluate (e.g., B3LYP, PBE, ...). For MM, name of the force field."""
+
+    basis: str | None = None
+    """The quantum chemistry basis set to evaluate (e.g., 6-31g, cc-pVDZ, ...). Can be ``None`` for methods without
+    basis sets. For molecular mechanics, name of the atom-typer.
+    """
 
 class SinglepointDriver(str, Enum):
     # Copied from qcelemental to add "deferred"
@@ -59,14 +56,15 @@ class WavefunctionProtocolEnum(str, Enum):
 class ErrorCorrectionProtocol(BaseModel):
     r"""Configuration for how computational chemistry programs handle error correction"""
 
-    default_policy: bool = Field(
-        True, description="Whether to allow error corrections to be used " "if not directly specified in `policies`"
-    )
-    policies: dict[str, bool] | None = Field(
-        None,
-        description="Settings that define whether specific error corrections are allowed. "
-        "Keys are the name of a known error and values are whether it is allowed to be used.",
-    )
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    default_policy: bool = True
+    """Whether to allow error corrections to be used if not directly specified in `policies`"""
+
+    policies: dict[str, bool] | None = None
+    """Settings that define whether specific error corrections are allowed. Keys are the name of a known error and
+    values are whether it is allowed to be used.
+    """
 
     def allows(self, policy: str):
         if self.policies is None:
@@ -85,36 +83,45 @@ class NativeFilesProtocolEnum(str, Enum):
 class SinglepointProtocols(BaseModel):
     r"""Protocols regarding the manipulation of computational result data."""
 
-    wavefunction: WavefunctionProtocolEnum = Field(
-        WavefunctionProtocolEnum.none, description=str(WavefunctionProtocolEnum.__doc__)
-    )
-    stdout: bool = Field(True, description="Primary output file to keep from the computation")
-    error_correction: ErrorCorrectionProtocol = Field(
-        default_factory=ErrorCorrectionProtocol, description="Policies for error correction"
-    )
-    native_files: NativeFilesProtocolEnum = Field(
-        NativeFilesProtocolEnum.none,
-        description="Policies for keeping processed files from the computation",
-    )
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    wavefunction: WavefunctionProtocolEnum = WavefunctionProtocolEnum.none
+    """Which parts of the wavefunction to keep"""
+
+    stdout: bool = True
+    """Primary output file to keep from the computation"""
+
+    error_correction: ErrorCorrectionProtocol = Field(default_factory=ErrorCorrectionProtocol)
+    """Policies for error correction"""
+
+    native_files: NativeFilesProtocolEnum = NativeFilesProtocolEnum.none
+    """Policies for keeping processed files from the computation"""
 
 
 class QCSpecification(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
-    program: LowerStr = Field(
-        ...,
-        description="The quantum chemistry program to evaluate the computation with. Not all quantum chemistry programs"
-        " support all combinations of driver/method/basis.",
-    )
-    driver: SinglepointDriver = Field(...)
-    method: LowerStr = Field(..., description="The quantum chemistry method to evaluate (e.g., B3LYP, PBE, ...).")
-    basis: LowerStr | None = Field(
-        ...,
-        description="The quantum chemistry basis set to evaluate (e.g., 6-31g, cc-pVDZ, ...). Can be ``None`` for "
-        "methods without basis sets.",
-    )
-    keywords: dict[str, Any] = Field({}, description="Program-specific keywords to use for the computation")
+    program: LowerStr
+    """The quantum chemistry program to evaluate the computation with. Not all quantum chemistry programs support all
+    combinations of driver/method/basis.
+    """
+
+    driver: SinglepointDriver
+    """What the computation should return - energy, gradient, hessian, or properties"""
+
+    method: LowerStr
+    """The quantum chemistry method to evaluate (e.g., B3LYP, PBE, ...)"""
+
+    basis: LowerStr | None
+    """The quantum chemistry basis set to evaluate (e.g., 6-31g, cc-pVDZ, ...). Can be ``None`` for methods without
+    basis sets.
+    """
+
+    keywords: dict[str, Any] = {}
+    """Program-specific keywords to use for the computation"""
+
     protocols: SinglepointProtocols = Field(default_factory=SinglepointProtocols)
+    """Which parts of the computation output to keep"""
 
     @field_validator("basis", mode="before")
     @classmethod

--- a/qcportal/qcportal/tasks/models.py
+++ b/qcportal/qcportal/tasks/models.py
@@ -6,10 +6,17 @@ from qcportal.managers import ManagerName
 
 
 class TaskClaimBody(RestModelBase):
-    name_data: ManagerName = Field(..., description="Name information about this manager")
-    programs: dict[LowerStr, list[str]] = Field(..., description="Subset of programs to claim tasks for")
-    compute_tags: list[str] = Field(..., description="Subset of tags to claim tasks from")
-    limit: int = Field(..., description="Limit on the number of tasks to claim")
+    name_data: ManagerName
+    """Name information about this manager"""
+
+    programs: dict[LowerStr, list[str]]
+    """Subset of programs to claim tasks for"""
+
+    compute_tags: list[str]
+    """Subset of tags to claim tasks from"""
+
+    limit: int
+    """Limit on the number of tasks to claim"""
 
     @field_validator("compute_tags", mode="after")
     @classmethod
@@ -40,5 +47,8 @@ class TaskClaimBody(RestModelBase):
 
 
 class TaskReturnBody(RestModelBase):
-    name_data: ManagerName = Field(..., description="Name information about this manager")
+    name_data: ManagerName
+    """Name information about this manager"""
+
     results_compressed: dict[int, QCPortalBytes]
+    """Compressed results of the completed computations, keyed by task id"""

--- a/qcportal/qcportal/torsiondrive/dataset_models.py
+++ b/qcportal/qcportal/torsiondrive/dataset_models.py
@@ -126,6 +126,42 @@ class TorsiondriveDataset(BaseDataset):
         dataset_id: int | None = None,
         specification_name: str | None = None,
     ) -> InsertCountsMetadata:
+        """
+        Adds entries to this dataset by copying them from another dataset
+
+        The source dataset may be another torsiondrive dataset, or an optimization dataset.
+
+        When copying from another torsiondrive dataset, entries are copied whole - including their
+        ``additional_keywords`` and ``additional_optimization_keywords``, and therefore their scan
+        definitions.
+
+        When copying from an optimization dataset, ``specification_name`` is required, and the single
+        initial molecule of each new entry is the optimized molecule of the corresponding record.
+        Entries whose record is not complete are skipped. Note that an optimization entry has no
+        scan definition to copy, so ``additional_keywords`` and ``additional_optimization_keywords``
+        of the new entries are empty - the dihedrals to scan must come from the dataset
+        specification, or the entries must be added manually instead.
+
+        Entries whose name already exists in this dataset are ignored.
+
+        Parameters
+        ----------
+        dataset_type
+            Type of the dataset to copy entries from. Must be given together with ``dataset_name``
+        dataset_name
+            Name of the dataset to copy entries from. Must be given together with ``dataset_type``
+        dataset_id
+            ID of the dataset to copy entries from. May be given instead of the type and name
+        specification_name
+            Specification of the source dataset to take molecules from. Required when copying
+            from an optimization dataset, and unused otherwise
+
+        Returns
+        -------
+        :
+            Metadata about how many entries were added
+        """
+
         body = TorsiondriveDatasetEntriesFrom(
             dataset_type=dataset_type,
             dataset_name=dataset_name,

--- a/qcportal/qcportal/torsiondrive/record_models.py
+++ b/qcportal/qcportal/torsiondrive/record_models.py
@@ -49,34 +49,27 @@ class TorsiondriveKeywords(BaseModel):
     Options for torsiondrive calculations
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
-    dihedrals: list[tuple[int, int, int, int]] = Field(
-        [],
-        description="The list of dihedrals to select for the TorsionDrive operation. Each entry is a tuple of integers "
-        "of for particle indices.",
-    )
-    grid_spacing: list[int] = Field(
-        [],
-        description="List of grid spacing for dihedral scan in degrees. Multiple values will be mapped to each "
-        "dihedral angle.",
-    )
-    dihedral_ranges: list[tuple[int, int]] | None = Field(
-        None,
-        description="A list of dihedral range limits as a pair (lower, upper). "
-        "Each range corresponds to the dihedrals in input.",
-    )
-    energy_decrease_thresh: float | None = Field(
-        None,
-        description="The threshold of the smallest energy decrease amount to trigger activating optimizations from "
-        "grid point.",
-    )
-    energy_upper_limit: float | None = Field(
-        None,
-        description="The threshold if the energy of a grid point that is higher than the current global minimum, to "
-        "start new optimizations, in unit of a.u. I.e. if energy_upper_limit = 0.05, current global "
-        "minimum energy is -9.9 , then a new task starting with energy -9.8 will be skipped.",
-    )
+    dihedrals: list[tuple[int, int, int, int]] = []
+    """The list of dihedrals to select for the TorsionDrive operation. Each entry is a tuple of integers of for
+    particle indices.
+    """
+
+    grid_spacing: list[int] = []
+    """List of grid spacing for dihedral scan in degrees. Multiple values will be mapped to each dihedral angle."""
+
+    dihedral_ranges: list[tuple[int, int]] | None = None
+    """A list of dihedral range limits as a pair (lower, upper). Each range corresponds to the dihedrals in input."""
+
+    energy_decrease_thresh: float | None = None
+    """The threshold of the smallest energy decrease amount to trigger activating optimizations from grid point"""
+
+    energy_upper_limit: float | None = None
+    """The threshold if the energy of a grid point that is higher than the current global minimum, to start new
+    optimizations, in unit of a.u. I.e. if energy_upper_limit = 0.05, current global minimum energy is -9.9 , then
+    a new task starting with energy -9.8 will be skipped.
+    """
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

This PR adds lots of missing docs and does some minor re-organization. It also replaces autodoc-pydantic with [sphinxcontrib-pydantic](https://github.com/mscheltienne/sphinxcontrib-pydantic) as autodoc-pydantic seems to be unmaintained and not compatible with sphinx 9.0+.

This also includes some small code improvements (mostly some type hints, but also a few small bugs) and docstrings, but nothing consequential.

This also adds an extension to sphinx that makes nice summary tables for things like the server and worker configuration.

A chunk of the docs were generated with Claude, but reviewed by me for sanity. Claude also fixed quite a few inconsistencies in the docs and docstrings.

## Status
- [X] Code base linted
- [X] Ready to go
