### PR TITLE
Better handling of testing command line options & remove unneeded dependencies

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,13 +10,13 @@ def pytest_addoption(parser):
     Additional PyTest CLI flags to add
 
     See `pytest_collection_modifyitems` for handling and `pytest_configure` for adding known in-line marks.
+
+    Note that --client-encoding and --fractal-uri are added by the qcarchivetesting pytest plugin,
+    since they are used by fixtures distributed in that package (this file is not distributed
+    anywhere, so options defined here are not available to other projects).
     """
 
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
-    parser.addoption("--client-encoding", type=str, default="application/json", help="set client encoding to test")
-    parser.addoption(
-        "--fractal-uri", type=str, default="snowflake", help="URI of the fractal instance to run full tests against"
-    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/qcarchivetesting/conda-envs/fulltest_server.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_server.yaml
@@ -24,7 +24,6 @@ dependencies:
   - pyjwt>=2.10.0
   - packaging
   - python-dateutil
-  - pytz
 
   # QCFractal dependencies
   - flask

--- a/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_snowflake.yaml
@@ -24,7 +24,6 @@ dependencies:
   - pyjwt>=2.10.0
   - packaging
   - python-dateutil
-  - pytz
 
   # QCFractalCompute dependencies
   - parsl

--- a/qcarchivetesting/conda-envs/fulltest_testing.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_testing.yaml
@@ -24,7 +24,6 @@ dependencies:
   - pyjwt>=2.10.0
   - packaging
   - python-dateutil
-  - pytz
 
   # QCFractalCompute dependencies
   - parsl

--- a/qcarchivetesting/conda-envs/fulltest_worker.yaml
+++ b/qcarchivetesting/conda-envs/fulltest_worker.yaml
@@ -23,7 +23,6 @@ dependencies:
   - pyjwt>=2.10.0
   - packaging
   - python-dateutil
-  - pytz
 
   # QCFractalCompute dependencies
   - parsl

--- a/qcarchivetesting/pyproject.toml
+++ b/qcarchivetesting/pyproject.toml
@@ -39,7 +39,7 @@ qcarchive_fixtures = "qcarchivetesting.testing_fixtures"
 
 
 [tool.setuptools.package-data]
-qcarchivetesting = ["*_data/**", "config_files/**"]
+qcarchivetesting = ["*_data/**", "config_files/**", "data_generator/*.json.xz"]
 
 
 [tool.versioningit]

--- a/qcarchivetesting/qcarchivetesting/testing_fixtures.py
+++ b/qcarchivetesting/qcarchivetesting/testing_fixtures.py
@@ -18,6 +18,53 @@ from qcportal.utils import update_nested_dict
 from .helpers import geoip_path, geoip_filename, ip_tests_enabled, s3_tests_enabled
 from .testing_classes import QCATestingPostgresServer, QCATestingSnowflake, _activated_manager_programs
 
+_default_client_encoding = "application/json"
+_default_fractal_uri = "snowflake"
+
+
+def pytest_addoption(parser):
+    """
+    Additional PyTest CLI flags used by the fixtures in this module
+
+    These are added here, rather than in a conftest.py, since this module is registered as a
+    pytest plugin (see the pytest11 entry point). That way, the options are available to any
+    project that installs qcarchivetesting and uses these fixtures.
+    """
+
+    parser.addoption(
+        "--client-encoding", type=str, default=_default_client_encoding, help="set client encoding to test"
+    )
+    parser.addoption(
+        "--fractal-uri",
+        type=str,
+        default=_default_fractal_uri,
+        help="URI of the fractal instance to run full tests against",
+    )
+
+
+@pytest.fixture(scope="session")
+def client_encoding(pytestconfig) -> str:
+    """
+    The encoding used by clients created by these fixtures
+
+    This defaults to the value of the --client-encoding CLI flag, but may be overridden by
+    a project that uses these fixtures (for example, to parametrize over encodings).
+    """
+
+    return pytestconfig.getoption("--client-encoding", default=_default_client_encoding)
+
+
+@pytest.fixture(scope="session")
+def fractal_uri(pytestconfig) -> str:
+    """
+    The URI of the fractal instance to run full tests against
+
+    This defaults to the value of the --fractal-uri CLI flag, but may be overridden by
+    a project that uses these fixtures.
+    """
+
+    return pytestconfig.getoption("--fractal-uri", default=_default_fractal_uri)
+
 
 def _generate_default_config(pg_harness, extra_config=None) -> FractalConfig:
     # Create a configuration. Since this is mostly just for a storage socket,
@@ -110,14 +157,13 @@ def session(storage_socket):
 
 
 @pytest.fixture(scope="session")
-def session_snowflake(postgres_server, pytestconfig):
+def session_snowflake(postgres_server, client_encoding):
     """
     A QCFractal testing snowflake, existing for the entire session
     """
 
     pg_harness = postgres_server.get_new_harness("session_snowflake")
-    encoding = pytestconfig.getoption("--client-encoding")
-    with QCATestingSnowflake(pg_harness, encoding) as snowflake:
+    with QCATestingSnowflake(pg_harness, client_encoding) as snowflake:
         pg_harness.create_template()
         yield snowflake
 
@@ -135,15 +181,14 @@ def snowflake(session_snowflake):
 
 
 @pytest.fixture(scope="session")
-def session_secure_snowflake(postgres_server, pytestconfig):
+def session_secure_snowflake(postgres_server, client_encoding):
     """
     A QCFractal snowflake with authorization/authentication enabled
     """
 
     pg_harness = postgres_server.get_new_harness("session_secure_snowflake")
-    encoding = pytestconfig.getoption("--client-encoding")
     with QCATestingSnowflake(
-        pg_harness, encoding, create_users=True, enable_security=True, allow_unauthenticated_read=False
+        pg_harness, client_encoding, create_users=True, enable_security=True, allow_unauthenticated_read=False
     ) as snowflake:
         pg_harness.create_template()
         yield snowflake
@@ -160,15 +205,14 @@ def secure_snowflake(session_secure_snowflake):
 
 
 @pytest.fixture(scope="session")
-def session_secure_snowflake_allow_read(postgres_server, pytestconfig):
+def session_secure_snowflake_allow_read(postgres_server, client_encoding):
     """
     A QCFractal snowflake with authorization/authentication enabled, but allowing unauthenticated read
     """
 
     pg_harness = postgres_server.get_new_harness("session_secure_snowflake_allow_read")
-    encoding = pytestconfig.getoption("--client-encoding")
     with QCATestingSnowflake(
-        pg_harness, encoding, create_users=True, enable_security=True, allow_unauthenticated_read=True
+        pg_harness, client_encoding, create_users=True, enable_security=True, allow_unauthenticated_read=True
     ) as snowflake:
         pg_harness.create_template()
         yield snowflake
@@ -241,18 +285,16 @@ def activated_manager_programs(activated_manager) -> ManagerName:
 
 
 @pytest.fixture(scope="function")
-def fulltest_client(pytestconfig):
+def fulltest_client(fractal_uri):
     """
     A portal client used for full end-to-end tests
     """
 
-    uri = pytestconfig.getoption("--fractal-uri")
-
-    if uri == "snowflake":
+    if fractal_uri == "snowflake":
         from qcfractal.snowflake import FractalSnowflake
 
         s = FractalSnowflake()
         yield s.client()
 
     else:
-        yield PortalClient(address=uri)
+        yield PortalClient(address=fractal_uri)

--- a/qcfractal/pyproject.toml
+++ b/qcfractal/pyproject.toml
@@ -61,7 +61,7 @@ qcfractal-server = "qcfractal.qcfractal_server_cli:main"
 
 
 [tool.setuptools.package-data]
-qcfractal = ["alembic.ini", "alembic/script.py.mako"]
+qcfractal = ["alembic.ini", "alembic/script.py.mako", "components/auth/global_role_permissions.yaml"]
 
 
 [tool.versioningit]

--- a/qcfractal/qcfractal/components/serverinfo/test_access_client.py
+++ b/qcfractal/qcfractal/components/serverinfo/test_access_client.py
@@ -61,11 +61,10 @@ def test_serverinfo_client_access_logged(secure_snowflake_allow_read: QCATesting
     assert accesses[3].request_bytes == 0
 
 
-def test_serverinfo_client_access_not_logged(postgres_server, pytestconfig):
+def test_serverinfo_client_access_not_logged(postgres_server, client_encoding):
     pg_harness = postgres_server.get_new_harness("serverinfo_client_access_not_logged")
-    encoding = pytestconfig.getoption("--client-encoding")
 
-    with QCATestingSnowflake(pg_harness, encoding, log_access=False) as server:
+    with QCATestingSnowflake(pg_harness, client_encoding, log_access=False) as server:
         client = server.client()
         client.query_access_log()
         client.query_molecules(molecular_formula=["C"])

--- a/qcfractal/qcfractal/components/serverinfo/test_access_client_query.py
+++ b/qcfractal/qcfractal/components/serverinfo/test_access_client_query.py
@@ -9,12 +9,13 @@ from qcportal.utils import now_at_utc
 
 
 @pytest.fixture(scope="module")
-def queryable_access_client(postgres_server, pytestconfig):
+def queryable_access_client(postgres_server, client_encoding):
     pg_harness = postgres_server.get_new_harness("serverinfo_test_access")
-    encoding = pytestconfig.getoption("--client-encoding")
 
     # Don't log accesses
-    with QCATestingSnowflake(pg_harness, encoding, enable_security=True, create_users=True, log_access=False) as server:
+    with QCATestingSnowflake(
+        pg_harness, client_encoding, enable_security=True, create_users=True, log_access=False
+    ) as server:
         # generate a bunch of test data
         storage_socket = server.get_storage_socket()
 

--- a/qcfractal/qcfractal/components/serverinfo/test_error_client_query.py
+++ b/qcfractal/qcfractal/components/serverinfo/test_error_client_query.py
@@ -7,11 +7,12 @@ from qcportal import PortalClient
 
 
 @pytest.fixture(scope="module")
-def queryable_error_client(postgres_server, pytestconfig):
+def queryable_error_client(postgres_server, client_encoding):
     pg_harness = postgres_server.get_new_harness("serverinfo_test_errors")
-    encoding = pytestconfig.getoption("--client-encoding")
 
-    with QCATestingSnowflake(pg_harness, encoding, create_users=True, enable_security=True, log_access=False) as server:
+    with QCATestingSnowflake(
+        pg_harness, client_encoding, create_users=True, enable_security=True, log_access=False
+    ) as server:
         # generate a bunch of test data
         storage_socket = server.get_storage_socket()
 

--- a/qcfractal/qcfractal/components/tasks/test_reset_logic.py
+++ b/qcfractal/qcfractal/components/tasks/test_reset_logic.py
@@ -12,10 +12,9 @@ from qcportal.qcschema_v1 import ComputeError, FailedOperation
 from qcportal.record_models import PriorityEnum, RecordStatusEnum
 
 
-def test_reset_logic_dict_comprehension_bug(postgres_server, pytestconfig):
+def test_reset_logic_dict_comprehension_bug(postgres_server, client_encoding):
 
     pg_harness = postgres_server.get_new_harness("reset_logic_dict_bug")
-    encoding = pytestconfig.getoption("--client-encoding")
     
     # Configure auto_reset with a limit of 2 unknown_errors
     extra_config = {
@@ -25,7 +24,7 @@ def test_reset_logic_dict_comprehension_bug(postgres_server, pytestconfig):
         }
     }
     
-    with QCATestingSnowflake(pg_harness, encoding=encoding, extra_config=extra_config) as snowflake:
+    with QCATestingSnowflake(pg_harness, encoding=client_encoding, extra_config=extra_config) as snowflake:
         storage_socket = snowflake.get_storage_socket()
         activated_manager_name, _ = snowflake.activate_manager()
         activated_manager_programs = snowflake.activated_manager_programs()

--- a/qcfractal/qcfractal/components/tasks/test_socket_claim.py
+++ b/qcfractal/qcfractal/components/tasks/test_socket_claim.py
@@ -359,11 +359,12 @@ def test_task_socket_claim_tag_wildcard(storage_socket: SQLAlchemySocket, sessio
     assert tasks[2]["id"] == recs[4].task.id
 
 
-def test_task_socket_claim_tag_wildcard_strict(postgres_server, pytestconfig):
+def test_task_socket_claim_tag_wildcard_strict(postgres_server, client_encoding):
 
     pg_harness = postgres_server.get_new_harness("claim_tag_wildcard_strict")
-    encoding = pytestconfig.getoption("--client-encoding")
-    with QCATestingSnowflake(pg_harness, encoding=encoding, extra_config={"strict_compute_tags": True}) as snowflake:
+    with QCATestingSnowflake(
+        pg_harness, encoding=client_encoding, extra_config={"strict_compute_tags": True}
+    ) as snowflake:
         storage_socket = snowflake.get_storage_socket()
 
         mname1 = ManagerName(cluster="test_cluster", hostname="a_host1", uuid="1234-5678-1234-5678")

--- a/qcfractal/qcfractal/components/test_record_client_query.py
+++ b/qcfractal/qcfractal/components/test_record_client_query.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import time
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 
 from qcfractal.components.testing_helpers import populate_records_status
 from qcportal import PortalClient
@@ -142,7 +142,7 @@ def test_record_client_query(queryable_records_client: PortalClient):
 
 @pytest.mark.parametrize("timezone", [None, "UTC", "Asia/Singapore"])
 def test_record_client_query_timezones(queryable_records_client: PortalClient, timezone: Optional[str]):
-    tzinfo = pytz.timezone(timezone) if timezone is not None else None
+    tzinfo = ZoneInfo(timezone) if timezone is not None else None
     query_res = queryable_records_client.query_records(record_type="singlepoint")
     all_records = list(query_res)
     assert len(all_records) == 325

--- a/qcfractal/qcfractal/flask_app/auth_v1/test_auth_jwt.py
+++ b/qcfractal/qcfractal/flask_app/auth_v1/test_auth_jwt.py
@@ -54,15 +54,14 @@ def test_jwt_refresh_user_disabled(secure_snowflake):
 
 
 @pytest.mark.slow
-def test_jwt_disabled_before_refresh(postgres_server, pytestconfig):
+def test_jwt_disabled_before_refresh(postgres_server, client_encoding):
     # Disabling an account must take effect within the server-side re-verify cache lifetime (~5s),
     # not only after the access token expires and is refreshed. Use a long access-token lifetime
     # so the token is still valid (and no refresh happens) when we make the post-disable request.
     pg_harness = postgres_server.get_new_harness("jwt_disabled_before_refresh")
-    encoding = pytestconfig.getoption("--client-encoding")
     with QCATestingSnowflake(
         pg_harness,
-        encoding=encoding,
+        encoding=client_encoding,
         create_users=True,
         enable_security=True,
         allow_unauthenticated_read=False,
@@ -88,14 +87,13 @@ def test_jwt_disabled_before_refresh(postgres_server, pytestconfig):
 
 
 @pytest.mark.slow
-def test_jwt_role_downgrade_before_refresh(postgres_server, pytestconfig):
+def test_jwt_role_downgrade_before_refresh(postgres_server, client_encoding):
     # Downgrading a user's role must take effect within the re-verify cache lifetime, even though
     # the still-valid access token carries the old (higher) role in its claims.
     pg_harness = postgres_server.get_new_harness("jwt_role_downgrade_before_refresh")
-    encoding = pytestconfig.getoption("--client-encoding")
     with QCATestingSnowflake(
         pg_harness,
-        encoding=encoding,
+        encoding=client_encoding,
         create_users=True,
         enable_security=True,
         allow_unauthenticated_read=False,
@@ -125,15 +123,14 @@ def test_jwt_role_downgrade_before_refresh(postgres_server, pytestconfig):
 
 
 @pytest.mark.slow
-def test_jwt_refresh_user_deleted(postgres_server, pytestconfig):
+def test_jwt_refresh_user_deleted(postgres_server, client_encoding):
     # Need its own snowflake because we need logging disabled
     # Otherwise, the user cannot be deleted because it is referenced in the access log table
 
     pg_harness = postgres_server.get_new_harness("jwt_user_deleted")
-    encoding = pytestconfig.getoption("--client-encoding")
     with QCATestingSnowflake(
         pg_harness,
-        encoding=encoding,
+        encoding=client_encoding,
         create_users=True,
         enable_security=True,
         allow_unauthenticated_read=False,

--- a/qcfractal/qcfractal/flask_app/test_homepage.py
+++ b/qcfractal/qcfractal/flask_app/test_homepage.py
@@ -3,12 +3,11 @@ import requests
 from qcarchivetesting.testing_classes import QCATestingSnowflake
 
 
-def test_homepage_redirect(postgres_server, pytestconfig):
+def test_homepage_redirect(postgres_server, client_encoding):
     pg_harness = postgres_server.get_new_harness("test_homepage_redirect")
-    encoding = pytestconfig.getoption("--client-encoding")
 
     extra_config = {"homepage_redirect_url": "https://example.com"}
-    snowflake = QCATestingSnowflake(pg_harness, encoding, extra_config=extra_config)
+    snowflake = QCATestingSnowflake(pg_harness, client_encoding, extra_config=extra_config)
 
     # The URI doesn't contain any path or anything
     r = requests.get(snowflake.get_uri(), allow_redirects=False)
@@ -16,8 +15,7 @@ def test_homepage_redirect(postgres_server, pytestconfig):
     assert r.headers["Location"] == "https://example.com"
 
 
-def test_homepage_serve_dir(postgres_server, tmp_path, pytestconfig):
-    encoding = pytestconfig.getoption("--client-encoding")
+def test_homepage_serve_dir(postgres_server, tmp_path, client_encoding):
 
     homepage_dir = tmp_path / "homepage"
     homepage_dir.mkdir()
@@ -32,7 +30,7 @@ def test_homepage_serve_dir(postgres_server, tmp_path, pytestconfig):
 
     pg_harness = postgres_server.get_new_harness("test_homepage_serve_dir")
     extra_config = {"homepage_directory": str(homepage_dir)}
-    snowflake = QCATestingSnowflake(pg_harness, encoding, extra_config=extra_config)
+    snowflake = QCATestingSnowflake(pg_harness, client_encoding, extra_config=extra_config)
 
     # The URI doesn't contain any path or anything
     r = requests.get(snowflake.get_uri(), headers={"Accept": "text/html"})

--- a/qcportal/pyproject.toml
+++ b/qcportal/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "pyjwt>=2.10",
     "packaging",
     "python-dateutil",
-    "pytz",
 ]
 
 


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

This hopefully fixes downstream packages that use qcarchive testing fixtures running into an error related to the client-encoding command line option. This option was set in my top level conftest.py, but that is not packaged anywhere. This moves that option handling to the qcarchivetesting package.

This also removes the unneeded pytz package (not needed with newer pythons) and updates the package-data needed for installation.

## Status
- [X] Code base linted
- [X] Ready to go
