### PR TITLE
Default to verifying SSL certificates for compute managers

### DIFF
--- a/qcfractalcompute/qcfractalcompute/config.py
+++ b/qcfractalcompute/qcfractalcompute/config.py
@@ -165,8 +165,8 @@ class FractalServerSettings(QCFComputeConfigBase):
     password: str | None = None
     """Password to authenticate to the Fractal Server with (alongside the `username`)"""
 
-    verify: bool | None = None
-    """Use Server-side generated SSL certification or not"""
+    verify: bool = True
+    """If True, verify SSL certificate of the server"""
 
 
 class FractalComputeConfig(BaseSettings):


### PR DESCRIPTION
## Description
<!-- Thank you for your contribution! -->
<!-- Provide a brief description of the PR's purpose here. -->

In compute manager configuration, the default for verifying SSL certificates of servers was "None". This changes it to be always bool, and to default to be True.

Should have very little effect on current users, but is a safer default (now that getting certificates is very easy).

## Status
- [X] Code base linted
- [X] Ready to go
